### PR TITLE
[#feat] npx 설치 지원을 위한 CLI 래퍼 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ Thumbs.db
 .env
 .env.local
 .claude/.harness/logs/
+
+# Node.js
+node_modules/

--- a/README.md
+++ b/README.md
@@ -44,6 +44,18 @@ scripts/           # 실행 스크립트
 
 ### 1. 새 프로젝트에 적용
 
+**npx로 즉시 설치 (권장):**
+
+```bash
+# GitHub에서 직접 실행 (npm publish 불필요)
+npx github:seo/harness_setting init ./my-project
+
+# npm publish 후
+npx @seo/harness-setting init ./my-project
+```
+
+**또는 수동 설치:**
+
 ```bash
 # 이 저장소를 클론
 git clone <this-repo> /tmp/harness
@@ -55,13 +67,14 @@ git clone <this-repo> /tmp/harness
 ### 2. GitHub 라벨 설정
 
 ```bash
-./scripts/setup-labels.sh
+harness labels          # npx로 설치한 경우
+./scripts/setup-labels.sh  # 수동 설치한 경우
 ```
 
 ### 3. 에이전트 실행
 
 ```bash
-# 개별 에이전트 실행
+# 개별 에이전트 실행 (npx 설치: harness dispatch <agent> [n])
 ./scripts/dispatch-agent.sh pm              # PM: 요구사항 분석
 ./scripts/dispatch-agent.sh architect 5     # Architect: 이슈 #5 설계
 ./scripts/dispatch-agent.sh developer 5     # Developer: 이슈 #5 구현
@@ -83,6 +96,7 @@ git clone <this-repo> /tmp/harness
 
 ## 사전 요구사항
 
+- [Node.js](https://nodejs.org/) >= 16.7.0 (npx 설치 시)
 - [Claude Code CLI](https://docs.anthropic.com/en/docs/claude-code)
 - [GitHub CLI (gh)](https://cli.github.com/)
 - [Gemini CLI](https://github.com/google-gemini/gemini-cli) (교차검증용)

--- a/bin/harness.js
+++ b/bin/harness.js
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+'use strict';
+
+const path = require('node:path');
+const { copyTemplate } = require('../lib/copy-template');
+const { runScript } = require('../lib/run-script');
+
+const args = process.argv.slice(2);
+const command = args[0];
+
+function printUsage() {
+  console.log(`
+사용법: harness <command> [options]
+
+Commands:
+  init [경로]              새 프로젝트에 harness 프레임워크 초기화
+  validate                 프로젝트 설정 검증
+  orchestrator <cmd>       오케스트레이터 실행 (start|pipeline|parallel)
+  dispatch <agent> [n]     에이전트 디스패치
+  labels                   GitHub 라벨 설정
+  version                  버전 출력
+`);
+}
+
+switch (command) {
+  case 'init': {
+    const targetDir = args[1] || '.';
+    copyTemplate(targetDir);
+    break;
+  }
+
+  case 'validate':
+    runScript('validate-setup.sh', args.slice(1));
+    break;
+
+  case 'orchestrator':
+    runScript('orchestrator.sh', args.slice(1));
+    break;
+
+  case 'dispatch':
+    runScript('dispatch-agent.sh', args.slice(1));
+    break;
+
+  case 'labels':
+    runScript('setup-labels.sh', args.slice(1));
+    break;
+
+  case 'version':
+  case '--version':
+  case '-v': {
+    const pkg = require('../package.json');
+    console.log(pkg.version);
+    break;
+  }
+
+  case '--help':
+  case '-h':
+  case undefined:
+    printUsage();
+    break;
+
+  default:
+    console.error(`알 수 없는 명령: ${command}`);
+    printUsage();
+    process.exit(1);
+}

--- a/lib/copy-template.js
+++ b/lib/copy-template.js
@@ -1,0 +1,174 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const { execFileSync, execSync } = require('node:child_process');
+
+const PKG_ROOT = path.resolve(__dirname, '..');
+
+// 복사할 디렉토리/파일 목록
+const COPY_DIRS = ['.claude', '.github', 'scripts', 'docs'];
+const COPY_FILES = ['CLAUDE.md'];
+
+/**
+ * 필수 도구 존재 여부 검사
+ */
+function checkTool(cmd, url) {
+  try {
+    const ver = execSync(`${cmd} --version 2>&1`, { encoding: 'utf8' }).split('\n')[0];
+    console.log(`  [OK] ${cmd}: ${ver}`);
+    return true;
+  } catch {
+    console.log(`  [MISSING] ${cmd}: 설치 필요 → ${url}`);
+    return false;
+  }
+}
+
+/**
+ * init-project.sh의 Node.js 재구현
+ * 패키지 루트에서 대상 디렉토리로 템플릿 파일을 복사
+ */
+function copyTemplate(targetDir) {
+  const dest = path.resolve(process.cwd(), targetDir);
+
+  console.log('=== Harness Engineering Framework 초기화 ===\n');
+  console.log('환경 검사 중...');
+
+  // 필수 도구 검사
+  let missing = false;
+  if (!checkTool('git', 'https://git-scm.com/')) missing = true;
+  if (!checkTool('gh', 'https://cli.github.com/')) missing = true;
+  if (!checkTool('claude', 'https://docs.anthropic.com/en/docs/claude-code')) missing = true;
+
+  // jq는 권장
+  try {
+    const jqVer = execSync('jq --version 2>&1', { encoding: 'utf8' }).trim();
+    console.log(`  [OK] jq: ${jqVer}`);
+  } catch {
+    console.log('  [WARN] jq: 미설치 (권장). 오케스트레이터 기능 일부 제한됨');
+  }
+
+  // gh 인증 확인
+  try {
+    execSync('gh auth status 2>&1', { encoding: 'utf8' });
+    console.log('  [OK] gh 인증 확인됨');
+  } catch {
+    console.log('  [WARN] gh 미인증. 나중에 \'gh auth login\' 필요');
+  }
+
+  if (missing) {
+    console.log('\n필수 도구가 누락되었습니다. 설치 후 다시 실행하세요.');
+    process.exit(1);
+  }
+
+  console.log(`\n대상 디렉토리: ${dest}`);
+
+  // 대상 디렉토리 생성
+  fs.mkdirSync(dest, { recursive: true });
+
+  // 디렉토리 복사
+  console.log('Harness 설정 파일 복사 중...');
+  for (const dir of COPY_DIRS) {
+    const src = path.join(PKG_ROOT, dir);
+    if (fs.existsSync(src)) {
+      fs.cpSync(src, path.join(dest, dir), { recursive: true });
+      console.log(`  - ${dir}/ 복사 완료`);
+    }
+  }
+
+  // 파일 복사
+  for (const file of COPY_FILES) {
+    const src = path.join(PKG_ROOT, file);
+    if (fs.existsSync(src)) {
+      fs.cpSync(src, path.join(dest, file));
+      console.log(`  - ${file} 복사 완료`);
+    }
+  }
+
+  // .harness/state.json 생성
+  const harnessDir = path.join(dest, '.harness');
+  const logsDir = path.join(harnessDir, 'logs');
+  fs.mkdirSync(logsDir, { recursive: true });
+
+  const projectName = path.basename(dest);
+  const stateJson = {
+    project: projectName,
+    created_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    current_phase: 'planning',
+    agents: {
+      orchestrator: { status: 'idle', current_task: null },
+      pm: { status: 'idle', current_task: null },
+      architect: { status: 'idle', current_task: null },
+      developers: [],
+      reviewer: { status: 'idle', current_task: null },
+      qa: { status: 'idle', current_task: null },
+    },
+    issues: [],
+    pull_requests: [],
+    blocked: [],
+  };
+  fs.writeFileSync(
+    path.join(harnessDir, 'state.json'),
+    JSON.stringify(stateJson, null, 2) + '\n'
+  );
+  console.log('  - .harness/state.json 생성 완료');
+
+  // .gitignore 업데이트
+  const gitignorePath = path.join(dest, '.gitignore');
+  let gitignore = '';
+  if (fs.existsSync(gitignorePath)) {
+    gitignore = fs.readFileSync(gitignorePath, 'utf8');
+  }
+  if (!gitignore.includes('.harness/logs')) {
+    gitignore += '\n# Harness 로그 (상태 파일은 추적)\n.harness/logs/\n';
+  }
+  if (!gitignore.includes('node_modules')) {
+    gitignore += '\n# Node.js\nnode_modules/\n';
+  }
+  fs.writeFileSync(gitignorePath, gitignore);
+
+  // scripts/*.sh 실행 권한 부여
+  const scriptsDir = path.join(dest, 'scripts');
+  if (fs.existsSync(scriptsDir)) {
+    const shFiles = fs.readdirSync(scriptsDir).filter(f => f.endsWith('.sh'));
+    for (const sh of shFiles) {
+      fs.chmodSync(path.join(scriptsDir, sh), 0o755);
+    }
+    console.log('  - scripts/*.sh 실행 권한 설정 완료');
+  }
+
+  // git init (없으면)
+  const gitDir = path.join(dest, '.git');
+  if (!fs.existsSync(gitDir)) {
+    try {
+      execFileSync('git', ['init'], { cwd: dest, stdio: 'pipe' });
+      console.log('  - Git 저장소 초기화 완료');
+    } catch (err) {
+      console.log('  [WARN] Git 초기화 실패:', err.message);
+    }
+  }
+
+  // develop 브랜치 생성
+  try {
+    execFileSync('git', ['checkout', '-b', 'develop'], {
+      cwd: dest,
+      stdio: 'pipe',
+    });
+    console.log('  - develop 브랜치 생성 완료');
+  } catch {
+    // 이미 존재하면 무시
+  }
+
+  console.log('\n=== 초기화 완료 ===\n');
+  console.log('다음 단계:');
+  console.log('  1. GitHub 저장소 생성 후 리모트 연결');
+  console.log('     git remote add origin <URL>');
+  console.log('  2. 라벨 생성 (아직 안 했다면)');
+  console.log('     harness labels');
+  console.log('  3. 오케스트레이터 시작');
+  console.log('     harness orchestrator start');
+  console.log('  4. 또는 개별 에이전트 실행');
+  console.log('     harness dispatch <pm|architect|developer|reviewer|qa> <이슈번호>');
+}
+
+module.exports = { copyTemplate };

--- a/lib/run-script.js
+++ b/lib/run-script.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const { execFileSync } = require('node:child_process');
+const path = require('node:path');
+const fs = require('node:fs');
+
+const PKG_SCRIPTS_DIR = path.resolve(__dirname, '..', 'scripts');
+
+/**
+ * Bash 스크립트 실행 헬퍼
+ * 로컬 프로젝트의 scripts/에 해당 스크립트가 있으면 로컬 사용, 없으면 패키지 내부 폴백
+ */
+function runScript(scriptName, args = []) {
+  const localPath = path.resolve(process.cwd(), 'scripts', scriptName);
+  const pkgPath = path.join(PKG_SCRIPTS_DIR, scriptName);
+
+  let scriptPath;
+  if (fs.existsSync(localPath)) {
+    scriptPath = localPath;
+  } else if (fs.existsSync(pkgPath)) {
+    scriptPath = pkgPath;
+  } else {
+    console.error(`스크립트를 찾을 수 없습니다: ${scriptName}`);
+    console.error(`  로컬: ${localPath}`);
+    console.error(`  패키지: ${pkgPath}`);
+    process.exit(1);
+  }
+
+  try {
+    execFileSync('bash', [scriptPath, ...args], {
+      stdio: 'inherit',
+      cwd: process.cwd(),
+    });
+  } catch (err) {
+    // execFileSync는 프로세스 종료 코드가 0이 아니면 에러를 던짐
+    // stdio: inherit로 이미 출력이 표시되었으므로 종료 코드만 전달
+    process.exit(err.status || 1);
+  }
+}
+
+module.exports = { runScript };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@seo/harness-setting",
+  "version": "1.0.0",
+  "description": "AI 에이전트 기반 자동화 개발 프레임워크",
+  "bin": {
+    "harness": "./bin/harness.js"
+  },
+  "files": [
+    "bin/",
+    "lib/",
+    ".claude/",
+    ".github/",
+    "scripts/",
+    "docs/",
+    "CLAUDE.md"
+  ],
+  "keywords": ["ai-agent", "claude", "automation", "harness"],
+  "license": "MIT",
+  "engines": {
+    "node": ">=16.7.0"
+  }
+}


### PR DESCRIPTION
## Summary
- 의존성 0개의 Node.js CLI 래퍼를 추가하여 `npx @seo/harness-setting init` 으로 즉시 스캐폴딩 가능
- `init` 명령은 `fs.cpSync`로 재구현, 나머지 명령(validate, orchestrator, dispatch, labels)은 기존 Bash 스크립트에 위임
- README에 npx 설치 방법 및 Node.js 사전 요구사항 추가

## 변경 파일
- **신규**: `package.json`, `bin/harness.js`, `lib/copy-template.js`, `lib/run-script.js`
- **수정**: `.gitignore` (node_modules 추가), `README.md` (npx 사용법 추가)

## Test plan
- [x] `node bin/harness.js --help` — 도움말 정상 출력
- [x] `node bin/harness.js version` — 버전 정상 출력
- [x] `node bin/harness.js init /tmp/test-harness` — 전체 초기화 플로우 정상 동작
- [x] 복사된 파일 구조, 실행 권한, state.json 내용 검증 완료
- [ ] `npx github:seo/harness_setting init` GitHub 직접 실행 테스트
- [ ] `npm link` 후 `harness` 명령어 글로벌 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)