### PR TITLE
[fix] pr-review 워크플로우 권한 + Draft PR 필터

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -2,12 +2,18 @@ name: PR 자동 리뷰 트리거
 
 on:
   pull_request:
-    types: [opened, synchronize]
+    types: [opened, synchronize, ready_for_review]
     branches: [develop, main]
+
+permissions:
+  pull-requests: write
+  issues: write
 
 jobs:
   label-pr:
     runs-on: ubuntu-latest
+    # Draft PR은 라벨 부착 스킵
+    if: github.event.pull_request.draft == false
     steps:
       - name: PR에 리뷰 대기 라벨 추가
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- `label-pr` job 403 에러 해결: `permissions` 블록 추가
- Draft PR에서 불필요한 `status:review` 라벨 부착 방지
- `ready_for_review` 이벤트로 Draft → Ready 전환 시 정상 트리거

## Test plan
- [ ] PR 생성 시 `label-pr` job 성공 확인
- [ ] Draft PR 생성 시 `label-pr` job 스킵 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)