### PR TITLE
[fix] state.json 스키마 통일 + lock-file 자동 호출

### DIFF
--- a/lib/copy-template.js
+++ b/lib/copy-template.js
@@ -105,6 +105,7 @@ function copyTemplate(targetDir) {
       developers: [],
       reviewer: { status: 'idle', current_task: null },
       qa: { status: 'idle', current_task: null },
+      auditor: { status: 'idle', current_task: null },
       integrator: { status: 'idle', current_task: null },
     },
     issues: [],

--- a/scripts/dispatch-agent.sh
+++ b/scripts/dispatch-agent.sh
@@ -253,11 +253,25 @@ ALLOWED_TOOLS=$(get_allowed_tools "${AGENT}")
 # 타임아웃 설정 (기본 30분)
 AGENT_TIMEOUT="${HARNESS_AGENT_TIMEOUT:-1800}"
 
+# 병렬 에이전트용 파일 잠금 — 개발자 에이전트만 적용
+LOCK_ACQUIRED=""
+if [[ "${AGENT}" =~ ^(frontend-developer|backend-developer|developer)$ ]] && [ -n "${TASK_NUMBER}" ]; then
+  if [ -f "${SCRIPT_DIR}/lock-file.sh" ]; then
+    HARNESS_AGENT="${AGENT}" "${SCRIPT_DIR}/lock-file.sh" acquire "issue-${TASK_NUMBER}" 2>/dev/null && \
+      LOCK_ACQUIRED="issue-${TASK_NUMBER}" || true
+  fi
+fi
+
 # Claude Code 실행
 cd "${PROJECT_DIR}"
 
 EXIT_CODE=0
 timeout "${AGENT_TIMEOUT}" claude -p "${FULL_PROMPT}" --allowedTools "${ALLOWED_TOOLS}" 2>&1 | tee -a "${LOG_FILE}" || EXIT_CODE=$?
+
+# 파일 잠금 해제
+if [ -n "${LOCK_ACQUIRED}" ] && [ -f "${SCRIPT_DIR}/lock-file.sh" ]; then
+  "${SCRIPT_DIR}/lock-file.sh" release "${LOCK_ACQUIRED}" 2>/dev/null || true
+fi
 
 # 타임아웃 감지 (exit code 124)
 if [ "${EXIT_CODE}" -eq 124 ]; then

--- a/scripts/init-project.sh
+++ b/scripts/init-project.sh
@@ -102,11 +102,16 @@ cat > .harness/state.json << EOF
   "current_phase": "planning",
   "agents": {
     "orchestrator": { "status": "idle", "current_task": null },
+    "planner": { "status": "idle", "current_task": null },
     "pm": { "status": "idle", "current_task": null },
     "architect": { "status": "idle", "current_task": null },
+    "frontend-developers": [],
+    "backend-developers": [],
     "developers": [],
     "reviewer": { "status": "idle", "current_task": null },
-    "qa": { "status": "idle", "current_task": null }
+    "qa": { "status": "idle", "current_task": null },
+    "auditor": { "status": "idle", "current_task": null },
+    "integrator": { "status": "idle", "current_task": null }
   },
   "issues": [],
   "pull_requests": [],

--- a/scripts/orchestrator.sh
+++ b/scripts/orchestrator.sh
@@ -429,6 +429,10 @@ start_loop() {
   log "중지: Ctrl+C"
 
   while true; do
+    # 만료된 파일 잠금 정리
+    if [ -f "${SCRIPT_DIR}/lock-file.sh" ]; then
+      "${SCRIPT_DIR}/lock-file.sh" cleanup 2>/dev/null || true
+    fi
     sync_github
     auto_dispatch
     sleep "${POLL_INTERVAL}"

--- a/scripts/validate-integrity.sh
+++ b/scripts/validate-integrity.sh
@@ -107,31 +107,38 @@ done
 
 echo ""
 
-# ─── 6. copy-template.js state.json 구조 검사 ───
-echo "6. copy-template.js 상태 구조 검사..."
+# ─── 6. state.json 스키마 정합성 검사 (init-project.sh + copy-template.js) ───
+echo "6. state.json 스키마 정합성 검사..."
 
+STATE_REQUIRED_KEYS=("planner" "frontend-developers" "backend-developers" "auditor" "integrator")
+
+# 6-1. copy-template.js 검사
 COPY_TEMPLATE="${PROJECT_DIR}/lib/copy-template.js"
 if [ -f "${COPY_TEMPLATE}" ]; then
-  # planner가 state.json에 포함되어 있는지 등 기본 검사
-  if grep -q "planner" "${COPY_TEMPLATE}" 2>/dev/null; then
-    ok "copy-template.js에 planner 포함"
-  else
-    warn "copy-template.js state.json에 planner 누락"
-  fi
-
-  if grep -q "frontend-developers" "${COPY_TEMPLATE}" 2>/dev/null; then
-    ok "copy-template.js에 frontend-developers 포함"
-  else
-    warn "copy-template.js state.json에 frontend-developers 누락"
-  fi
-
-  if grep -q "backend-developers" "${COPY_TEMPLATE}" 2>/dev/null; then
-    ok "copy-template.js에 backend-developers 포함"
-  else
-    warn "copy-template.js state.json에 backend-developers 누락"
-  fi
+  for key in "${STATE_REQUIRED_KEYS[@]}"; do
+    # JS 객체 키는 따옴표 있거나 없을 수 있음 (planner: 또는 'planner': 또는 "planner":)
+    if grep -qE "(\"${key}\"|'${key}'|${key})\s*:" "${COPY_TEMPLATE}" 2>/dev/null; then
+      ok "copy-template.js에 ${key} 포함"
+    else
+      warn "copy-template.js state.json에 ${key} 누락"
+    fi
+  done
 else
   warn "copy-template.js 파일 없음 (npm 패키지 미구성 환경)"
+fi
+
+# 6-2. init-project.sh 검사
+INIT_SCRIPT="${PROJECT_DIR}/scripts/init-project.sh"
+if [ -f "${INIT_SCRIPT}" ]; then
+  for key in "${STATE_REQUIRED_KEYS[@]}"; do
+    if grep -q "\"${key}\"" "${INIT_SCRIPT}" 2>/dev/null; then
+      ok "init-project.sh에 ${key} 포함"
+    else
+      warn "init-project.sh state.json에 ${key} 누락"
+    fi
+  done
+else
+  warn "init-project.sh 파일 없음"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary
- 교차검증 문제 #2 (state.json 스키마 불일치) 수정
- 교차검증 문제 #8 (lock-file 미사용) 수정
- validate-integrity.sh 검증 범위 확장

## 변경 사항

### state.json 스키마 통일
- `init-project.sh`: `planner`, `frontend-developers`, `backend-developers`, `auditor`, `integrator` 추가
- `copy-template.js`: `auditor` 추가
- 두 파일의 agents 스키마가 완전히 동일

### lock-file 자동 호출
- `dispatch-agent.sh`: 개발자 에이전트 실행 시 `lock-file.sh acquire/release` 자동 호출
- `orchestrator.sh`: 이벤트 루프에서 매 사이클 만료 잠금 cleanup

### validate-integrity.sh 개선
- `init-project.sh`도 state.json 스키마 검증 대상 추가
- JS 객체 키 grep 패턴 개선 (따옴표 유무 대응)

## Test plan
- [x] `validate-integrity.sh` — 에러 0개, 경고 4개 (의도적 제외)
- [x] state.json 스키마: init-project.sh와 copy-template.js 10/10 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)