### PR TITLE
[feat] playwright-test 스킬 + agent-browser 폴백 전략

### DIFF
--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -65,7 +65,8 @@ SSR 프로젝트에서는 반드시 hydration mismatch를 검증한다:
 
 ## 사용 스킬
 - `run-tests`: 테스트 실행
-- `browser-test`: E2E 브라우저 테스트 (UI 프로젝트)
+- `browser-test`: E2E 브라우저 테스트 — 탐색, 스크린샷, 접근성 확인 (UI 프로젝트)
+- `playwright-test`: 정밀 브라우저 테스트 — form 제출, 동적 컴포넌트, 트레이스 (browser-test 폴백)
 - `sync-status`: 상태 동기화
 
 ## 규칙

--- a/.claude/skills/browser-test/SKILL.md
+++ b/.claude/skills/browser-test/SKILL.md
@@ -257,11 +257,17 @@ agent-browser auth save staging --url https://staging.app.com/login
 agent-browser auth login staging
 ```
 
-## 알려진 제한
+## 알려진 제한 및 Playwright 폴백
 
-- **동적 마운트 컴포넌트**: React state 변경으로 새로 마운트된 컴포넌트 내부의 이벤트 핸들러가 `click` 명령으로 트리거되지 않을 수 있다. 조건부 렌더링(`{show && <Component />}`)으로 나타난 요소의 버튼 클릭이 실패하면, `snapshot -i`로 요소 존재를 확인한 뒤 ref 기반 클릭(`click @eN`)을 시도한다.
-- **React controlled input**: `fill` 명령이 React의 `onChange`를 트리거하지 못해 `useState`로 관리되는 값이 갱신되지 않을 수 있다. uncontrolled input(`useRef` + `FormData`)을 사용하면 `fill`로 설정한 DOM value가 제출 시 정상적으로 읽힌다.
-- **form submit**: `type="submit"` 버튼을 `click`해도 `<form onSubmit>`이 호출되지 않을 수 있다. `press Enter`나 ref 기반 클릭으로 대체를 시도한다.
+아래 상황에서는 `playwright-test` 스킬로 전환한다:
+
+| 상황 | agent-browser 증상 | Playwright 해결 |
+|------|-------------------|----------------|
+| 동적 마운트 컴포넌트 | `click` 후 상태 변화 없음 | auto-waiting으로 마운트 대기 후 클릭 |
+| React controlled input | `fill` 후 state 미갱신 | input/change 이벤트 순차 발생 |
+| form submit | `click` 후 서버에 요청 미도달 | 정상적 form submission 이벤트 체인 |
+
+**폴백 판단 기준**: agent-browser로 액션 수행 후 `snapshot`으로 결과를 확인했을 때 상태 변화가 없으면 동일 목표를 `playwright-test`로 재시도한다.
 
 ## 규칙
 

--- a/.claude/skills/playwright-test/SKILL.md
+++ b/.claude/skills/playwright-test/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: playwright-test
+description: |
+  Playwright 기반 정밀 브라우저 테스트 스킬. form 제출, 동적 컴포넌트, controlled input 등
+  agent-browser로 처리 불가능한 복잡한 브라우저 인터랙션을 안정적으로 수행한다.
+  TRIGGER when: agent-browser에서 form submit 실패, 동적 컴포넌트 이벤트 미동작,
+  controlled input fill 실패, "playwright", "정밀 테스트", "form 제출 테스트",
+  크로스 브라우저 테스트, 네트워크 인터셉트, 트레이스 디버깅이 필요할 때.
+  DO NOT TRIGGER when: 단순 페이지 확인/스크린샷(browser-test 담당),
+  접근성 트리 스냅샷, 단위 테스트, API 테스트.
+---
+
+# Playwright 정밀 브라우저 테스트
+
+agent-browser의 한계를 보완하는 정밀 브라우저 인터랙션 도구.
+form 제출, React 동적 컴포넌트, controlled input 등에서 신뢰성 높은 테스트를 수행한다.
+
+## agent-browser vs Playwright 역할 분담
+
+| 상황 | 도구 | 이유 |
+|------|------|------|
+| 페이지 구조 파악, 요소 탐색 | **agent-browser** | 접근성 트리 스냅샷이 AI에 최적화 |
+| 단순 클릭, 네비게이션 | **agent-browser** | 빠르고 간편 |
+| 스크린샷, 반응형 검증 | **agent-browser** | 뷰포트 변경 + 스크린샷 한 줄 |
+| **form 입력 + 제출** | **Playwright** | fill이 onChange 트리거, submit 정상 동작 |
+| **동적 마운트 컴포넌트 클릭** | **Playwright** | auto-waiting으로 마운트 대기 후 클릭 |
+| **React controlled input** | **Playwright** | input/change 이벤트 순차 시뮬레이션 |
+| 네트워크 요청 검증 | **Playwright** | route intercept, waitForResponse |
+| 크로스 브라우저 테스트 | **Playwright** | Chromium, Firefox, WebKit |
+| 디버깅 (트레이스) | **Playwright** | trace.zip으로 시각적 디버깅 |
+
+## 사전 조건
+
+```bash
+# Playwright 설치 확인
+npx playwright --version || echo "미설치"
+
+# 브라우저 설치 (처음 한 번만)
+npx playwright install chromium
+```
+
+## 핵심 사용법
+
+### 1. 인라인 스크립트 실행
+
+간단한 테스트는 `node -e`로 직접 실행한다.
+
+```bash
+node -e "
+const { chromium } = require('playwright');
+(async () => {
+  const browser = await chromium.launch();
+  const page = await browser.newPage();
+  await page.goto('http://localhost:3000');
+
+  // form 입력 + 제출
+  await page.click('.add-btn');
+  await page.fill('input[name=\"title\"]', '할 일 제목');
+  await page.click('button:has-text(\"추가하기\")');
+
+  // 결과 검증
+  await page.waitForSelector('.todo-item');
+  const count = await page.locator('.todo-item').count();
+  console.log('할 일 개수:', count);
+
+  await browser.close();
+})();
+"
+```
+
+### 2. 실행 스크립트 사용
+
+복잡한 시나리오는 `scripts/run_playwright.js`를 사용한다.
+
+```bash
+# form 제출 테스트
+node .claude/skills/playwright-test/scripts/run_playwright.js \
+  --url http://localhost:3000 \
+  --steps '[
+    {"action":"click","selector":".add-btn"},
+    {"action":"fill","selector":"input[name=title]","value":"Playwright 테스트"},
+    {"action":"click","selector":"button:has-text(추가하기)"},
+    {"action":"waitForSelector","selector":".todo-item"},
+    {"action":"expect","selector":".todo-item","assertion":"toBeVisible"}
+  ]'
+
+# 트레이스 포함 실행
+node .claude/skills/playwright-test/scripts/run_playwright.js \
+  --url http://localhost:3000 \
+  --steps '[...]' \
+  --trace
+```
+
+### 3. Codegen으로 테스트 생성
+
+사용자 조작을 녹화하여 테스트 코드를 자동 생성한다.
+
+```bash
+npx playwright codegen http://localhost:3000
+```
+
+## 폴백 전략: agent-browser → Playwright
+
+`browser-test` 스킬에서 다음 상황이 발생하면 자동으로 `playwright-test`로 전환한다:
+
+```
+1. agent-browser fill + click 후 상태 변화 없음
+   → Playwright fill + click으로 재시도
+
+2. agent-browser에서 동적 컴포넌트 버튼 클릭 실패
+   → Playwright의 auto-waiting click으로 재시도
+
+3. form submit이 서버에 도달하지 않음
+   → Playwright로 form 제출 수행
+```
+
+### 폴백 워크플로우
+
+```
+[browser-test로 시작]
+       |
+  agent-browser snapshot → 요소 식별
+  agent-browser fill/click → 액션 수행
+  agent-browser snapshot → 결과 검증
+       |
+  ┌─ 성공 → 완료
+  └─ 실패 → [playwright-test로 전환]
+                |
+           Playwright fill/click → 동일 액션
+           결과 검증
+                |
+           ┌─ 성공 → agent-browser 한계로 기록
+           └─ 실패 → 앱 버그로 보고 (트레이스 첨부)
+```
+
+## Playwright가 해결하는 agent-browser 한계
+
+### 1. 동적 마운트 컴포넌트 이벤트
+
+```javascript
+// agent-browser: 조건부 렌더링 컴포넌트의 onClick 미동작
+// Playwright: auto-waiting으로 마운트 대기 후 클릭
+await page.click('.add-btn'); // 폼 열기
+await page.click('button:has-text("추가하기")'); // auto-wait 후 클릭
+```
+
+### 2. React controlled input
+
+```javascript
+// agent-browser fill: onChange 미트리거 → state 미갱신
+// Playwright fill: input/change 이벤트 순차 발생 → state 정상 갱신
+await page.fill('input[name="title"]', '새 할 일');
+// React의 useState가 정상적으로 "새 할 일"로 업데이트됨
+```
+
+### 3. form submit
+
+```javascript
+// agent-browser: type="submit" 클릭 시 onSubmit 미호출
+// Playwright: 정상적인 form submission 이벤트 체인 발생
+await page.click('button[type="submit"]');
+// 또는 Enter 키
+await page.press('input[name="title"]', 'Enter');
+```
+
+### 4. 네트워크 요청 검증
+
+```javascript
+// API 호출이 실제로 발생했는지 검증
+const [response] = await Promise.all([
+  page.waitForResponse(resp => resp.url().includes('/api/todos') && resp.request().method() === 'POST'),
+  page.click('button:has-text("추가하기")'),
+]);
+console.log('POST 응답:', response.status()); // 201
+```
+
+### 5. 트레이스 디버깅
+
+```javascript
+// 트레이스 녹화 → 실패 시 시각적 디버깅
+const context = await browser.newContext();
+await context.tracing.start({ screenshots: true, snapshots: true });
+
+// ... 테스트 수행 ...
+
+await context.tracing.stop({ path: '.harness/logs/trace.zip' });
+// npx playwright show-trace .harness/logs/trace.zip 로 분석
+```
+
+## 보안 규칙
+
+- `browser-test` 스킬과 동일한 보안 규칙을 따른다
+- **프로덕션 URL 직접 접근 금지**
+- **인증 정보 하드코딩 금지** — 환경변수 또는 시크릿 관리 도구 사용
+- 트레이스 파일에 민감 정보가 포함될 수 있으므로 `.harness/logs/`에만 저장
+
+## 규칙
+
+- agent-browser로 먼저 시도하고, 실패 시에만 Playwright를 사용한다 (불필요한 복잡성 방지)
+- Playwright 스크립트는 가능한 짧고 단일 목적으로 작성한다
+- 테스트 실패 시 반드시 트레이스를 첨부하여 디버깅을 돕는다
+- 결과는 PR 코멘트 또는 이슈에 보고한다

--- a/.claude/skills/playwright-test/scripts/run_playwright.js
+++ b/.claude/skills/playwright-test/scripts/run_playwright.js
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Playwright 기반 브라우저 테스트 실행기
+ *
+ * 사용법:
+ *   node run_playwright.js --url <URL> --steps '<JSON>' [--trace] [--browser chromium|firefox|webkit]
+ *
+ * steps JSON 형식:
+ *   [
+ *     { "action": "click", "selector": ".btn" },
+ *     { "action": "fill", "selector": "input[name=title]", "value": "텍스트" },
+ *     { "action": "waitForSelector", "selector": ".result" },
+ *     { "action": "expect", "selector": "h1", "assertion": "toBeVisible" },
+ *     { "action": "expect", "selector": ".count", "assertion": "toHaveText", "expected": "3" },
+ *     { "action": "screenshot", "path": "result.png" },
+ *     { "action": "waitForResponse", "urlPattern": "/api/todos", "method": "POST" },
+ *     { "action": "console" }
+ *   ]
+ */
+
+const { parseArgs } = require('node:util');
+const path = require('node:path');
+
+const { values } = parseArgs({
+  options: {
+    url: { type: 'string' },
+    steps: { type: 'string' },
+    trace: { type: 'boolean', default: false },
+    browser: { type: 'string', default: 'chromium' },
+  },
+});
+
+if (!values.url || !values.steps) {
+  console.error('사용법: node run_playwright.js --url <URL> --steps \'<JSON>\' [--trace] [--browser chromium|firefox|webkit]');
+  process.exit(1);
+}
+
+let steps;
+try {
+  steps = JSON.parse(values.steps);
+} catch (e) {
+  console.error('에러: steps JSON 파싱 실패:', e.message);
+  process.exit(1);
+}
+
+async function run() {
+  // playwright는 프로젝트 의존성이 아니므로 동적 import
+  let playwright;
+  try {
+    playwright = require('playwright');
+  } catch {
+    console.error('에러: playwright가 설치되어 있지 않습니다.');
+    console.error('설치: npm install -D playwright && npx playwright install chromium');
+    process.exit(1);
+  }
+
+  const browserType = playwright[values.browser] || playwright.chromium;
+  const browser = await browserType.launch({ headless: true });
+  const context = await browser.newContext();
+
+  // 트레이스 녹화
+  if (values.trace) {
+    await context.tracing.start({ screenshots: true, snapshots: true, sources: true });
+  }
+
+  const page = await context.newPage();
+  const consoleMessages = [];
+  const errors = [];
+
+  // 콘솔/에러 수집
+  page.on('console', (msg) => consoleMessages.push({ type: msg.type(), text: msg.text() }));
+  page.on('pageerror', (err) => errors.push(err.message));
+
+  console.log(`[Playwright] ${values.browser} → ${values.url}`);
+  await page.goto(values.url, { waitUntil: 'networkidle' });
+
+  let passed = 0;
+  let failed = 0;
+
+  for (let i = 0; i < steps.length; i++) {
+    const step = steps[i];
+    const stepLabel = `[${i + 1}/${steps.length}] ${step.action}${step.selector ? ` "${step.selector}"` : ''}`;
+
+    try {
+      switch (step.action) {
+        case 'click':
+          await page.click(step.selector, { timeout: step.timeout || 10000 });
+          break;
+
+        case 'fill':
+          await page.fill(step.selector, step.value || '', { timeout: step.timeout || 10000 });
+          break;
+
+        case 'press':
+          await page.press(step.selector || 'body', step.key || 'Enter');
+          break;
+
+        case 'select':
+          await page.selectOption(step.selector, step.value);
+          break;
+
+        case 'check':
+          await page.check(step.selector);
+          break;
+
+        case 'waitForSelector':
+          await page.waitForSelector(step.selector, { timeout: step.timeout || 10000 });
+          break;
+
+        case 'waitForResponse': {
+          const pattern = step.urlPattern;
+          const method = step.method || 'GET';
+          await page.waitForResponse(
+            (resp) => resp.url().includes(pattern) && resp.request().method() === method,
+            { timeout: step.timeout || 10000 },
+          );
+          break;
+        }
+
+        case 'waitForNavigation':
+          await page.waitForLoadState('networkidle');
+          break;
+
+        case 'wait':
+          await page.waitForTimeout(step.ms || 1000);
+          break;
+
+        case 'expect': {
+          const locator = page.locator(step.selector);
+          switch (step.assertion) {
+            case 'toBeVisible':
+              await locator.waitFor({ state: 'visible', timeout: step.timeout || 10000 });
+              break;
+            case 'toHaveText':
+              const text = await locator.textContent({ timeout: step.timeout || 10000 });
+              if (!text?.includes(step.expected)) {
+                throw new Error(`텍스트 불일치: "${text}" (기대: "${step.expected}")`);
+              }
+              break;
+            case 'toHaveCount':
+              const count = await locator.count();
+              if (count !== step.expected) {
+                throw new Error(`개수 불일치: ${count} (기대: ${step.expected})`);
+              }
+              break;
+            default:
+              throw new Error(`알 수 없는 assertion: ${step.assertion}`);
+          }
+          break;
+        }
+
+        case 'screenshot':
+          await page.screenshot({
+            path: step.path || `.harness/logs/playwright-screenshot-${Date.now()}.png`,
+            fullPage: step.fullPage || false,
+          });
+          break;
+
+        case 'console':
+          console.log('  콘솔 메시지:');
+          consoleMessages.forEach((m) => console.log(`    [${m.type}] ${m.text}`));
+          break;
+
+        case 'errors':
+          console.log('  페이지 에러:');
+          errors.forEach((e) => console.log(`    ${e}`));
+          break;
+
+        default:
+          throw new Error(`알 수 없는 액션: ${step.action}`);
+      }
+
+      console.log(`  ✓ ${stepLabel}`);
+      passed++;
+    } catch (err) {
+      console.error(`  ✗ ${stepLabel} — ${err.message}`);
+      failed++;
+
+      // 실패 시 스크린샷 자동 저장
+      const failPath = `.harness/logs/playwright-fail-step${i + 1}-${Date.now()}.png`;
+      await page.screenshot({ path: failPath }).catch(() => {});
+      console.error(`    실패 스크린샷: ${failPath}`);
+      break;
+    }
+  }
+
+  // 트레이스 저장
+  if (values.trace) {
+    const tracePath = `.harness/logs/playwright-trace-${Date.now()}.zip`;
+    await context.tracing.stop({ path: tracePath });
+    console.log(`\n트레이스: ${tracePath}`);
+    console.log(`분석: npx playwright show-trace ${tracePath}`);
+  }
+
+  // hydration 에러 감지
+  const hydrationErrors = consoleMessages.filter(
+    (m) => m.type === 'error' && /hydration|text content|did not expect/i.test(m.text),
+  );
+  if (hydrationErrors.length > 0) {
+    console.log('\n⚠️  Hydration 에러 감지:');
+    hydrationErrors.forEach((m) => console.log(`  ${m.text.slice(0, 200)}`));
+  }
+
+  await browser.close();
+
+  console.log(`\n=== 결과: ${passed} 통과, ${failed} 실패 ===`);
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+run().catch((err) => {
+  console.error('실행 에러:', err.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Playwright 기반 정밀 브라우저 테스트 스킬 추가
- Gemini 교차검증으로 설계한 agent-browser / Playwright 역할 분담 체계

## 역할 분담 (Gemini 합의)

| 상황 | 도구 |
|------|------|
| 페이지 구조 파악, 스크린샷 | agent-browser |
| form 제출, 동적 컴포넌트, controlled input | **Playwright** |
| 네트워크 인터셉트, 크로스 브라우저 | **Playwright** |
| 디버깅 (트레이스) | **Playwright** |

## 폴백 전략
```
agent-browser 시도 → 실패 → Playwright 재시도 → 실패 → 앱 버그 보고
```

## 변경 파일
- `playwright-test/SKILL.md` — 새 스킬 정의 (역할 분담, 사용법, 폴백)
- `playwright-test/scripts/run_playwright.js` — JSON 액션 시퀀스 실행기
- `browser-test/SKILL.md` — 알려진 제한 → Playwright 폴백 테이블
- `agents/qa.md` — playwright-test 스킬 참조 추가

## Test plan
- [x] 정합성 검증: 에러 0, 스킬 15개

🤖 Generated with [Claude Code](https://claude.com/claude-code)