### PR TITLE
feat(examples): 예제 프로젝트별 OG 이미지 및 파비콘 추가

### DIFF
--- a/examples/chat-app/src/app/icon.tsx
+++ b/examples/chat-app/src/app/icon.tsx
@@ -1,0 +1,40 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 32, height: 32 };
+export const contentType = 'image/png';
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #1a1a2e, #16213e)',
+          borderRadius: '8px',
+        }}
+      >
+        {/* 채팅 말풍선 아이콘 */}
+        <svg
+          width="22"
+          height="22"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M21 11.5C21 16.19 16.97 20 12 20C10.82 20 9.69 19.82 8.65 19.47L3 21L4.76 16.47C3.67 15.07 3 13.36 3 11.5C3 6.81 7.03 3 12 3C16.97 3 21 6.81 21 11.5Z"
+            fill="rgba(99, 179, 237, 0.9)"
+          />
+          <circle cx="8.5" cy="11.5" r="1.2" fill="white" />
+          <circle cx="12" cy="11.5" r="1.2" fill="white" />
+          <circle cx="15.5" cy="11.5" r="1.2" fill="white" />
+        </svg>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/examples/chat-app/src/app/layout.tsx
+++ b/examples/chat-app/src/app/layout.tsx
@@ -13,8 +13,14 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL('http://localhost:3000'),
   title: 'ChatApp - 메신저',
   description: '다크 글래스모피즘 채팅 애플리케이션',
+  openGraph: {
+    title: 'ChatApp - 메신저',
+    description: '다크 글래스모피즘 채팅 애플리케이션',
+    type: 'website',
+  },
 };
 
 export default function RootLayout({

--- a/examples/chat-app/src/app/opengraph-image.tsx
+++ b/examples/chat-app/src/app/opengraph-image.tsx
@@ -1,0 +1,80 @@
+import { ImageResponse } from 'next/og';
+
+export const alt = 'ChatApp - 메신저';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #0f0f1a 0%, #1a1a2e 40%, #16213e 100%)',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        {/* 글래스모피즘 카드 */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            justifyContent: 'center',
+            padding: '60px 80px',
+            borderRadius: '32px',
+            background: 'rgba(255, 255, 255, 0.05)',
+            border: '1px solid rgba(255, 255, 255, 0.1)',
+          }}
+        >
+          {/* 채팅 아이콘 */}
+          <svg
+            width="80"
+            height="80"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M21 11.5C21 16.19 16.97 20 12 20C10.82 20 9.69 19.82 8.65 19.47L3 21L4.76 16.47C3.67 15.07 3 13.36 3 11.5C3 6.81 7.03 3 12 3C16.97 3 21 6.81 21 11.5Z"
+              fill="rgba(99, 179, 237, 0.85)"
+            />
+            <circle cx="8.5" cy="11.5" r="1.2" fill="white" />
+            <circle cx="12" cy="11.5" r="1.2" fill="white" />
+            <circle cx="15.5" cy="11.5" r="1.2" fill="white" />
+          </svg>
+
+          {/* 타이틀 */}
+          <div
+            style={{
+              fontSize: 64,
+              fontWeight: 700,
+              color: 'white',
+              marginTop: 32,
+              letterSpacing: '-0.02em',
+            }}
+          >
+            ChatApp
+          </div>
+
+          {/* 설명 */}
+          <div
+            style={{
+              fontSize: 28,
+              color: 'rgba(255, 255, 255, 0.6)',
+              marginTop: 16,
+            }}
+          >
+            다크 글래스모피즘 채팅 애플리케이션
+          </div>
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/examples/recipe-hub/src/app/icon.tsx
+++ b/examples/recipe-hub/src/app/icon.tsx
@@ -1,0 +1,33 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 32, height: 32 };
+export const contentType = 'image/png';
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #3D2B1F, #8B6914)',
+          borderRadius: '8px',
+        }}
+      >
+        {/* 냄비/요리 아이콘 */}
+        <div
+          style={{
+            fontSize: 20,
+            display: 'flex',
+          }}
+        >
+          🍲
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/examples/recipe-hub/src/app/layout.tsx
+++ b/examples/recipe-hub/src/app/layout.tsx
@@ -9,8 +9,14 @@ const geistSans = Geist({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL('http://localhost:3000'),
   title: 'RecipeHub - 한식의 맛을 전합니다',
   description: '정성을 담은 한식 레시피로 매일의 식탁을 특별하게',
+  openGraph: {
+    title: 'RecipeHub - 한식의 맛을 전합니다',
+    description: '정성을 담은 한식 레시피로 매일의 식탁을 특별하게',
+    type: 'website',
+  },
 };
 
 export default function RootLayout({

--- a/examples/recipe-hub/src/app/opengraph-image.tsx
+++ b/examples/recipe-hub/src/app/opengraph-image.tsx
@@ -1,0 +1,77 @@
+import { ImageResponse } from 'next/og';
+
+export const alt = 'RecipeHub - 한식의 맛을 전합니다';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #FFFBF0 0%, #F5F0E8 50%, #E8DFD0 100%)',
+          fontFamily: 'serif',
+        }}
+      >
+        {/* 장식 상단 라인 */}
+        <div
+          style={{
+            width: 80,
+            height: 3,
+            background: '#8B6914',
+            borderRadius: 2,
+            marginBottom: 40,
+            display: 'flex',
+          }}
+        />
+
+        {/* 아이콘 */}
+        <div style={{ fontSize: 72, display: 'flex', marginBottom: 24 }}>
+          🍲
+        </div>
+
+        {/* 타이틀 */}
+        <div
+          style={{
+            fontSize: 64,
+            fontWeight: 700,
+            color: '#3D2B1F',
+            letterSpacing: '-0.01em',
+          }}
+        >
+          RecipeHub
+        </div>
+
+        {/* 설명 */}
+        <div
+          style={{
+            fontSize: 28,
+            color: '#9B8E7E',
+            marginTop: 16,
+          }}
+        >
+          한식의 맛을 전합니다
+        </div>
+
+        {/* 장식 하단 라인 */}
+        <div
+          style={{
+            width: 80,
+            height: 3,
+            background: '#8B6914',
+            borderRadius: 2,
+            marginTop: 40,
+            display: 'flex',
+          }}
+        />
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/examples/simple-shop/src/app/icon.tsx
+++ b/examples/simple-shop/src/app/icon.tsx
@@ -1,0 +1,53 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 32, height: 32 };
+export const contentType = 'image/png';
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#2D2D2D',
+          borderRadius: '8px',
+        }}
+      >
+        {/* 쇼핑백 아이콘 */}
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6 2L3 6V20C3 20.5304 3.21071 21.0391 3.58579 21.4142C3.96086 21.7893 4.46957 22 5 22H19C19.5304 22 20.0391 21.7893 20.4142 21.4142C20.7893 21.0391 21 20.5304 21 20V6L18 2H6Z"
+            stroke="#C4983B"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M3 6H21"
+            stroke="#C4983B"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+          <path
+            d="M16 10C16 11.0609 15.5786 12.0783 14.8284 12.8284C14.0783 13.5786 13.0609 14 12 14C10.9391 14 9.92172 13.5786 9.17157 12.8284C8.42143 12.0783 8 11.0609 8 10"
+            stroke="#C4983B"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/examples/simple-shop/src/app/layout.tsx
+++ b/examples/simple-shop/src/app/layout.tsx
@@ -16,8 +16,14 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("http://localhost:3000"),
   title: "SimpleShop",
   description: "일상을 디자인하다",
+  openGraph: {
+    title: "SimpleShop",
+    description: "일상을 디자인하다",
+    type: "website",
+  },
 };
 
 export default function RootLayout({

--- a/examples/simple-shop/src/app/opengraph-image.tsx
+++ b/examples/simple-shop/src/app/opengraph-image.tsx
@@ -1,0 +1,90 @@
+import { ImageResponse } from 'next/og';
+
+export const alt = 'SimpleShop - 일상을 디자인하다';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#F7F5F2',
+          fontFamily: 'serif',
+        }}
+      >
+        {/* 쇼핑백 아이콘 */}
+        <svg
+          width="72"
+          height="72"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M6 2L3 6V20C3 20.5304 3.21071 21.0391 3.58579 21.4142C3.96086 21.7893 4.46957 22 5 22H19C19.5304 22 20.0391 21.7893 20.4142 21.4142C20.7893 21.0391 21 20.5304 21 20V6L18 2H6Z"
+            stroke="#C4983B"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M3 6H21"
+            stroke="#C4983B"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+          <path
+            d="M16 10C16 11.0609 15.5786 12.0783 14.8284 12.8284C14.0783 13.5786 13.0609 14 12 14C10.9391 14 9.92172 13.5786 9.17157 12.8284C8.42143 12.0783 8 11.0609 8 10"
+            stroke="#C4983B"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+
+        {/* 타이틀 */}
+        <div
+          style={{
+            fontSize: 64,
+            fontWeight: 700,
+            color: '#2D2D2D',
+            marginTop: 32,
+            letterSpacing: '-0.01em',
+          }}
+        >
+          SimpleShop
+        </div>
+
+        {/* 구분선 */}
+        <div
+          style={{
+            width: 60,
+            height: 2,
+            background: '#C4983B',
+            marginTop: 24,
+            marginBottom: 24,
+            display: 'flex',
+          }}
+        />
+
+        {/* 설명 */}
+        <div
+          style={{
+            fontSize: 28,
+            color: '#A09890',
+          }}
+        >
+          일상을 디자인하다
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/examples/todo-app/src/app/icon.tsx
+++ b/examples/todo-app/src/app/icon.tsx
@@ -1,0 +1,40 @@
+import { ImageResponse } from 'next/og';
+
+export const size = { width: 32, height: 32 };
+export const contentType = 'image/png';
+
+export default function Icon() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: '#f5d547',
+          borderRadius: '8px',
+        }}
+      >
+        {/* 체크마크 아이콘 */}
+        <svg
+          width="20"
+          height="20"
+          viewBox="0 0 24 24"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            d="M20 6L9 17L4 12"
+            stroke="#1a1a1a"
+            strokeWidth="3"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/examples/todo-app/src/app/layout.tsx
+++ b/examples/todo-app/src/app/layout.tsx
@@ -13,8 +13,14 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("http://localhost:3000"),
   title: "Todo Dashboard",
   description: "타임라인 기반 할 일 관리 대시보드",
+  openGraph: {
+    title: "Todo Dashboard",
+    description: "타임라인 기반 할 일 관리 대시보드",
+    type: "website",
+  },
 };
 
 export default function RootLayout({

--- a/examples/todo-app/src/app/opengraph-image.tsx
+++ b/examples/todo-app/src/app/opengraph-image.tsx
@@ -1,0 +1,78 @@
+import { ImageResponse } from 'next/og';
+
+export const alt = 'Todo Dashboard - 할 일 관리';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: '100%',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          alignItems: 'center',
+          justifyContent: 'center',
+          background: 'linear-gradient(135deg, #f8f6f0 0%, #f0ede4 100%)',
+          fontFamily: 'sans-serif',
+        }}
+      >
+        {/* 노란 원 배경 + 체크 아이콘 */}
+        <div
+          style={{
+            width: 100,
+            height: 100,
+            borderRadius: '50%',
+            background: '#f5d547',
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <svg
+            width="48"
+            height="48"
+            viewBox="0 0 24 24"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M20 6L9 17L4 12"
+              stroke="#1a1a1a"
+              strokeWidth="2.5"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+            />
+          </svg>
+        </div>
+
+        {/* 타이틀 */}
+        <div
+          style={{
+            fontSize: 64,
+            fontWeight: 700,
+            color: '#1a1a1a',
+            marginTop: 32,
+            letterSpacing: '-0.02em',
+          }}
+        >
+          Todo Dashboard
+        </div>
+
+        {/* 설명 */}
+        <div
+          style={{
+            fontSize: 28,
+            color: '#888',
+            marginTop: 16,
+          }}
+        >
+          타임라인 기반 할 일 관리 대시보드
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}


### PR DESCRIPTION
## Summary
- chat-app, recipe-hub, simple-shop, todo-app 4개 예제에 동적 파비콘(`icon.tsx`)과 OG 이미지(`opengraph-image.tsx`) 추가
- 각 프로젝트 테마에 맞는 디자인 적용 (Next.js `ImageResponse` API 활용)
- `layout.tsx`에 `metadataBase` 및 `openGraph` 메타데이터 설정

## Test plan
- [x] 4개 프로젝트 모두 `next build` 성공 확인
- [x] 빌드 결과에 `/icon`, `/opengraph-image` 라우트 생성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)