### PR TITLE
feat(harness): update 명령 Phase B — manifest 기반 변경 추적 + diff 표시

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,32 @@ git clone https://github.com/coseo12/harness-setting.git .harness-plugin
 claude --plugin-dir ./.harness-plugin
 ```
 
+### 업데이트 확인/적용
+
+설치된 harness의 업데이트를 확인하고 적용:
+
+```bash
+# 1. 변경 요약만 보기 (비파괴)
+npx @seo/harness-setting@latest update --check
+
+# 2. 파일별 diff 표시 + 적용 가이드 (자동 쓰기 안 함)
+npx @seo/harness-setting@latest update
+
+# 3. CI/스크립트 등 frozen 카테고리만 자동 덮어쓰기
+npx @seo/harness-setting@latest update --apply-frozen
+
+# 4. 매니페스트 부재 시 — 현재 상태를 baseline으로 박제
+npx @seo/harness-setting@latest update --bootstrap
+```
+
+**Phase B 한계**: 사용자 수정과 패키지 변경이 동시에 발생한 파일(`divergent`)은 **자동 머지하지 않습니다**. 표시된 `diff -u` 명령으로 직접 비교하고 Edit 도구로 머지한 뒤, `harness update --bootstrap` 으로 매니페스트를 갱신하세요.
+
+파일 카테고리:
+- **frozen** (`scripts/`, `.github/workflows/`) — 자동 덮어쓰기 안전
+- **atomic** (스킬/에이전트/커맨드/템플릿) — 사용자 수정 시 충돌
+- **managed-block** (`CLAUDE.md`) — Phase A에서 센티널 블록 도입 예정
+- **user-only** (`.harness/`, `docs/decisions/`, `docs/retrospectives/` 사용자 추가분) — harness가 손대지 않음
+
 ### 셋업 자체 점검
 
 초기화 후 프레임워크 규칙과 구성이 올바른지 확인:

--- a/bin/harness.js
+++ b/bin/harness.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const { copyTemplate } = require('../lib/copy-template');
 const { runScript } = require('../lib/run-script');
 const { runDoctor, formatReport } = require('../lib/doctor');
+const updater = require('../lib/update');
 
 const args = process.argv.slice(2);
 const command = args[0];
@@ -15,6 +16,7 @@ function printUsage() {
 
 Commands:
   init [경로]              새 프로젝트에 harness 프레임워크 초기화
+  update [--check|--bootstrap|--apply-frozen]  업데이트 확인/적용
   doctor                   셋업 규칙 자체 점검 (CRITICAL DIRECTIVES, hook, 브랜치 등)
   validate                 프로젝트 설정 검증
   integrity                문서/설정 정합성 검증
@@ -30,6 +32,21 @@ switch (command) {
     const targetDir = args[1] || '.';
     copyTemplate(targetDir);
     break;
+  }
+
+  case 'update': {
+    const sub = args.slice(1);
+    let result;
+    if (sub.includes('--bootstrap')) {
+      result = updater.bootstrap();
+    } else if (sub.includes('--check')) {
+      result = updater.check();
+    } else {
+      result = updater.update(process.cwd(), { applyFrozen: sub.includes('--apply-frozen') });
+    }
+    if (result.output) console.log(result.output);
+    if (result.message) console.log(result.message);
+    process.exit(result.ok ? 0 : 1);
   }
 
   case 'doctor': {

--- a/lib/categorize.js
+++ b/lib/categorize.js
@@ -1,0 +1,28 @@
+'use strict';
+
+/**
+ * 파일 경로를 4종 카테고리 중 하나로 분류한다.
+ *   - frozen        : 사용자 수정 의도 없음 (CI/스크립트 보일러플레이트). 자동 덮어쓰기 안전.
+ *   - managed-block : 일부만 harness 소유 (Phase A에서 센티널 블록으로 분리). Phase B는 atomic처럼 취급.
+ *   - atomic        : 단일 단위 교체 (스킬/에이전트/커맨드/PR 템플릿). 사용자 수정 시 충돌.
+ *   - user-only     : init 후엔 harness가 손대지 않음 (state, logs, 사용자 추가 파일).
+ */
+function categorize(relPath) {
+  // 정규화: 윈도우 경로 대비
+  const p = relPath.replace(/\\/g, '/');
+
+  if (p.startsWith('.harness/')) return 'user-only';
+  if (p === '.gitignore') return 'user-only';
+  if (p.startsWith('scripts/')) return 'frozen';
+  if (p.startsWith('.github/workflows/')) return 'frozen';
+  if (p === 'CLAUDE.md') return 'managed-block';
+
+  // 사용자가 자유롭게 추가하는 디렉토리의 README만 atomic, 나머지는 user-only
+  if (p.startsWith('docs/decisions/') && p !== 'docs/decisions/README.md') return 'user-only';
+  if (p.startsWith('docs/retrospectives/') && p !== 'docs/retrospectives/README.md') return 'user-only';
+
+  // 기본: atomic (스킬/에이전트/커맨드/템플릿/문서)
+  return 'atomic';
+}
+
+module.exports = { categorize };

--- a/lib/copy-template.js
+++ b/lib/copy-template.js
@@ -4,7 +4,10 @@ const fs = require('node:fs');
 const path = require('node:path');
 const { execFileSync, execSync } = require('node:child_process');
 
+const { buildManifest, writeManifest } = require('./manifest');
+
 const PKG_ROOT = path.resolve(__dirname, '..');
+const PKG_VERSION = require(path.join(PKG_ROOT, 'package.json')).version;
 
 // 복사할 디렉토리/파일 목록
 const COPY_DIRS = ['.claude', '.github', 'scripts', 'docs'];
@@ -117,6 +120,15 @@ function copyTemplate(targetDir) {
     JSON.stringify(stateJson, null, 2) + '\n'
   );
   console.log('  - .harness/state.json 생성 완료');
+
+  // .harness/manifest.json — update 추적용 baseline (방금 복사한 파일들을 박제)
+  try {
+    const manifest = buildManifest(dest, PKG_VERSION);
+    writeManifest(dest, manifest);
+    console.log(`  - .harness/manifest.json 생성 완료 (v${PKG_VERSION}, ${Object.keys(manifest.files).length}개 파일 추적)`);
+  } catch (err) {
+    console.log(`  [WARN] manifest 생성 실패: ${err.message}`);
+  }
 
   // .gitignore 업데이트
   const gitignorePath = path.join(dest, '.gitignore');

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -109,7 +109,21 @@ function runDoctor(cwd = process.cwd()) {
     report.add(exists ? 'pass' : 'warn', dir, exists ? '존재' : '디렉토리 없음');
   }
 
-  // 5. 현재 브랜치가 main/master가 아닌지
+  // 5. .harness/manifest.json 존재 여부 (update 추적 활성화 확인)
+  const manifestPath = path.join(cwd, '.harness', 'manifest.json');
+  if (fs.existsSync(manifestPath)) {
+    try {
+      const m = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+      const fileCount = m.files ? Object.keys(m.files).length : 0;
+      report.add('pass', '.harness/manifest.json', `update 추적 활성 (v${m.harnessVersion}, ${fileCount}개 파일)`);
+    } catch (err) {
+      report.add('fail', '.harness/manifest.json', `JSON 파싱 실패: ${err.message}`);
+    }
+  } else {
+    report.add('warn', '.harness/manifest.json', 'update 추적 미활성 — `harness update --bootstrap` 권장');
+  }
+
+  // 6. 현재 브랜치가 main/master가 아닌지
   const branch = tryExec('git rev-parse --abbrev-ref HEAD');
   if (branch) {
     const protectedBranch = branch === 'main' || branch === 'master';

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -1,0 +1,97 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+const crypto = require('node:crypto');
+
+const { categorize } = require('./categorize');
+
+const MANIFEST_REL = '.harness/manifest.json';
+const TRACKED_DIRS = ['.claude', '.github', 'scripts', 'docs'];
+const TRACKED_FILES = ['CLAUDE.md'];
+
+function sha256(buf) {
+  return crypto.createHash('sha256').update(buf).digest('hex');
+}
+
+function sha256File(absPath) {
+  return sha256(fs.readFileSync(absPath));
+}
+
+/**
+ * 추적 대상 파일을 재귀적으로 수집한다.
+ * 결과: { '<rel/path>': '<absPath>' }
+ * user-only 카테고리는 매니페스트에 기록하지 않으므로 수집 단계에서 제외.
+ */
+function walkTracked(rootDir) {
+  const result = {};
+
+  function walk(rel, abs) {
+    if (!fs.existsSync(abs)) return;
+    const stat = fs.statSync(abs);
+    if (stat.isDirectory()) {
+      for (const entry of fs.readdirSync(abs)) {
+        walk(path.posix.join(rel, entry), path.join(abs, entry));
+      }
+    } else if (stat.isFile()) {
+      if (categorize(rel) === 'user-only') return;
+      result[rel] = abs;
+    }
+  }
+
+  for (const file of TRACKED_FILES) {
+    walk(file, path.join(rootDir, file));
+  }
+  for (const dir of TRACKED_DIRS) {
+    walk(dir, path.join(rootDir, dir));
+  }
+
+  return result;
+}
+
+function buildManifest(rootDir, harnessVersion) {
+  const tracked = walkTracked(rootDir);
+  const files = {};
+  for (const [rel, abs] of Object.entries(tracked)) {
+    files[rel] = { sha256: sha256File(abs), category: categorize(rel) };
+  }
+  return {
+    harnessVersion,
+    installedAt: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    files,
+  };
+}
+
+function manifestPath(cwd) {
+  return path.join(cwd, MANIFEST_REL);
+}
+
+function readManifest(cwd) {
+  const p = manifestPath(cwd);
+  if (!fs.existsSync(p)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(p, 'utf8'));
+  } catch (err) {
+    throw new Error(`manifest 파싱 실패 (${p}): ${err.message}`);
+  }
+}
+
+function writeManifest(cwd, manifest) {
+  const p = manifestPath(cwd);
+  fs.mkdirSync(path.dirname(p), { recursive: true });
+  fs.writeFileSync(p, JSON.stringify(manifest, null, 2) + '\n');
+  return p;
+}
+
+module.exports = {
+  MANIFEST_REL,
+  TRACKED_DIRS,
+  TRACKED_FILES,
+  walkTracked,
+  buildManifest,
+  readManifest,
+  writeManifest,
+  manifestPath,
+  sha256,
+  sha256File,
+};

--- a/lib/update.js
+++ b/lib/update.js
@@ -1,0 +1,233 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  walkTracked,
+  buildManifest,
+  readManifest,
+  writeManifest,
+  manifestPath,
+  sha256File,
+} = require('./manifest');
+const { categorize } = require('./categorize');
+
+const PKG_ROOT = path.resolve(__dirname, '..');
+const PKG_VERSION = require(path.join(PKG_ROOT, 'package.json')).version;
+
+const COLORS = {
+  reset: '\x1b[0m',
+  red: '\x1b[31m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  cyan: '\x1b[36m',
+  gray: '\x1b[90m',
+  bold: '\x1b[1m',
+};
+const c = (color, text) => `${COLORS[color]}${text}${COLORS.reset}`;
+
+/**
+ * 로컬 설치본과 패키지 본을 비교하여 파일별 액션을 결정한다.
+ *
+ * 액션 종류:
+ *   - identical            : 동일, 변경 없음
+ *   - added                : 패키지에만 있음 (신규 도입)
+ *   - removed-upstream     : 매니페스트에 있으나 패키지에서 사라짐
+ *   - missing-locally      : 매니페스트에 있으나 사용자 디렉토리에서 사라짐 (사용자 삭제)
+ *   - modified-pristine    : 사용자가 안 건드림 + 패키지가 바뀜 (안전 덮어쓰기)
+ *   - converged            : 사용자가 수정했지만 패키지와 우연히 일치
+ *   - divergent            : 사용자도 수정 + 패키지도 변경 (3-way merge 필요, B에선 수동)
+ *   - user-modified-stable : 사용자가 수정 + 패키지는 그대로 (사용자 변경 보존)
+ */
+function diffAgainstPackage(cwd, manifest) {
+  const userFiles = walkTracked(cwd);
+  const pkgFiles = walkTracked(PKG_ROOT);
+  const actions = [];
+
+  const allRels = new Set([
+    ...Object.keys(manifest.files),
+    ...Object.keys(userFiles),
+    ...Object.keys(pkgFiles),
+  ]);
+
+  for (const rel of allRels) {
+    const inManifest = manifest.files[rel];
+    const inUser = userFiles[rel];
+    const inPkg = pkgFiles[rel];
+    const category = categorize(rel);
+
+    const userSha = inUser ? sha256File(inUser) : null;
+    const pkgSha = inPkg ? sha256File(inPkg) : null;
+    const baseSha = inManifest ? inManifest.sha256 : null;
+
+    let action;
+    if (!inManifest && inPkg && !inUser) action = 'added';
+    else if (!inManifest && inPkg && inUser) {
+      action = userSha === pkgSha ? 'converged' : 'divergent';
+    } else if (inManifest && !inPkg) action = 'removed-upstream';
+    else if (inManifest && !inUser) action = 'missing-locally';
+    else if (userSha === pkgSha) action = 'identical';
+    else if (userSha === baseSha) action = 'modified-pristine';
+    else if (pkgSha === baseSha) action = 'user-modified-stable';
+    else action = 'divergent';
+
+    actions.push({ rel, category, action, userSha, pkgSha, baseSha });
+  }
+
+  return actions;
+}
+
+function summarize(actions) {
+  const counts = {};
+  for (const a of actions) counts[a.action] = (counts[a.action] || 0) + 1;
+  return counts;
+}
+
+/**
+ * `harness update --check` — 비파괴 요약
+ */
+function check(cwd = process.cwd()) {
+  const manifest = readManifest(cwd);
+  if (!manifest) {
+    return { ok: false, reason: 'no-manifest', message: noManifestMessage(cwd) };
+  }
+
+  const actions = diffAgainstPackage(cwd, manifest);
+  const counts = summarize(actions);
+  const lines = [];
+
+  lines.push(c('bold', '\n📦 Harness Update — 변경 요약\n'));
+  lines.push(`  설치 버전 : ${c('cyan', manifest.harnessVersion)}`);
+  lines.push(`  최신 버전 : ${c('cyan', PKG_VERSION)}`);
+  lines.push(`  설치 시점 : ${c('gray', manifest.installedAt)}`);
+  lines.push('');
+
+  if (manifest.harnessVersion === PKG_VERSION && (counts.divergent || 0) === 0 && (counts['modified-pristine'] || 0) === 0 && (counts.added || 0) === 0 && (counts['removed-upstream'] || 0) === 0) {
+    lines.push(c('green', '  ✅ 최신입니다. 적용할 변경 없음.'));
+    return { ok: true, manifest, actions, counts, output: lines.join('\n') };
+  }
+
+  const buckets = [
+    ['added', '신규 추가', 'green'],
+    ['modified-pristine', '안전 업데이트 (사용자 미수정)', 'green'],
+    ['divergent', '충돌 (사용자도 수정 + 패키지도 변경)', 'red'],
+    ['user-modified-stable', '사용자 변경 보존 (패키지 미변경)', 'gray'],
+    ['removed-upstream', '상위에서 삭제됨', 'yellow'],
+    ['missing-locally', '로컬에서 누락', 'yellow'],
+    ['converged', '우연히 일치', 'gray'],
+    ['identical', '동일', 'gray'],
+  ];
+
+  for (const [key, label, color] of buckets) {
+    if (!counts[key]) continue;
+    lines.push(`  ${c(color, '●')} ${label}: ${c('bold', counts[key])}`);
+    if (key !== 'identical' && key !== 'converged' && key !== 'user-modified-stable') {
+      for (const a of actions.filter((x) => x.action === key)) {
+        lines.push(`      ${c('gray', `[${a.category}]`)} ${a.rel}`);
+      }
+    }
+  }
+
+  lines.push('');
+  lines.push(c('cyan', '  다음 단계:'));
+  lines.push('    harness update              # 파일별 diff 표시 (자동 적용 안 함)');
+  lines.push('    harness update --apply-frozen   # frozen 카테고리만 자동 덮어쓰기');
+  lines.push('');
+  if (counts.divergent) {
+    lines.push(c('yellow', '  ⚠  Phase B는 자동 머지를 지원하지 않습니다. divergent 파일은 수동으로 검토/적용하세요.'));
+  }
+
+  return { ok: true, manifest, actions, counts, output: lines.join('\n') };
+}
+
+/**
+ * `harness update` — diff 표시 + 옵션에 따라 frozen 자동 적용
+ */
+function update(cwd = process.cwd(), opts = {}) {
+  const result = check(cwd);
+  if (!result.ok) return result;
+  const { actions } = result;
+  const lines = [result.output, ''];
+
+  let appliedCount = 0;
+
+  for (const a of actions) {
+    if (a.action === 'identical' || a.action === 'converged' || a.action === 'user-modified-stable') continue;
+
+    lines.push(c('bold', `\n── ${a.rel} `) + c('gray', `[${a.category}/${a.action}]`));
+
+    if (a.action === 'modified-pristine' && opts.applyFrozen && a.category === 'frozen') {
+      const src = path.join(PKG_ROOT, a.rel);
+      const dest = path.join(cwd, a.rel);
+      fs.mkdirSync(path.dirname(dest), { recursive: true });
+      fs.copyFileSync(src, dest);
+      lines.push(c('green', `  ✓ frozen 자동 적용 완료`));
+      appliedCount++;
+      continue;
+    }
+
+    if (a.action === 'added') {
+      lines.push(c('green', `  + 신규 파일 — 적용 권장:`));
+      lines.push(c('gray', `    cp ${path.join(PKG_ROOT, a.rel)} ${a.rel}`));
+    } else if (a.action === 'removed-upstream') {
+      lines.push(c('yellow', `  - 상위에서 제거됨 — 삭제 여부 직접 결정:`));
+      lines.push(c('gray', `    rm ${a.rel}`));
+    } else if (a.action === 'missing-locally') {
+      lines.push(c('yellow', `  ! 로컬에서 누락 — 의도적이 아니면 복원:`));
+      lines.push(c('gray', `    cp ${path.join(PKG_ROOT, a.rel)} ${a.rel}`));
+    } else if (a.action === 'modified-pristine') {
+      lines.push(c('green', `  ↑ 안전 업데이트 가능 (사용자 미수정):`));
+      lines.push(c('gray', `    cp ${path.join(PKG_ROOT, a.rel)} ${a.rel}`));
+    } else if (a.action === 'divergent') {
+      lines.push(c('red', `  ✗ 충돌 — 사용자 수정과 패키지 변경 모두 존재. 수동 머지 필요:`));
+      lines.push(c('gray', `    diff -u ${a.rel} ${path.join(PKG_ROOT, a.rel)}`));
+    }
+  }
+
+  if (appliedCount > 0) {
+    lines.push('');
+    lines.push(c('cyan', `  매니페스트를 갱신하려면:`));
+    lines.push('    harness update --bootstrap   # 현재 상태를 새 baseline으로 기록');
+  }
+
+  lines.push('');
+  lines.push(c('gray', '  ℹ  Phase B는 안전을 위해 atomic/managed-block 파일을 자동 적용하지 않습니다.'));
+  lines.push(c('gray', '     사용자가 cp 명령을 직접 실행하거나 Edit 도구로 머지하세요.'));
+  lines.push(c('gray', '     적용 완료 후 `harness update --bootstrap` 으로 매니페스트를 갱신하세요.'));
+
+  return { ok: true, output: lines.join('\n'), appliedCount };
+}
+
+/**
+ * `harness update --bootstrap` — 현재 상태를 새 baseline으로 박제
+ * 매니페스트가 없거나, 수동 머지 후 baseline을 갱신할 때 사용.
+ */
+function bootstrap(cwd = process.cwd()) {
+  const manifest = buildManifest(cwd, PKG_VERSION);
+  const written = writeManifest(cwd, manifest);
+  const lines = [];
+  lines.push(c('bold', '\n📦 Harness Update — Bootstrap\n'));
+  lines.push(`  매니페스트 생성: ${c('cyan', written)}`);
+  lines.push(`  버전 기록     : ${c('cyan', PKG_VERSION)}`);
+  lines.push(`  추적 파일 수  : ${c('cyan', Object.keys(manifest.files).length)}`);
+  lines.push('');
+  lines.push(c('green', '  ✅ 이후 `harness update --check` 로 변경을 추적할 수 있습니다.'));
+  return { ok: true, output: lines.join('\n'), manifest };
+}
+
+function noManifestMessage(cwd) {
+  const lines = [];
+  lines.push(c('bold', '\n📦 Harness Update\n'));
+  lines.push(c('yellow', `  ⚠  매니페스트가 없습니다 (${manifestPath(cwd)}).`));
+  lines.push('');
+  lines.push('  이 프로젝트는 update 추적이 활성화되지 않았습니다.');
+  lines.push('  현재 상태를 baseline으로 기록하려면:');
+  lines.push('');
+  lines.push(c('cyan', '    harness update --bootstrap'));
+  lines.push('');
+  lines.push(c('gray', '  주의: bootstrap은 "지금 상태가 정상"임을 가정합니다. 손상된 설치라면 먼저 init을 다시 실행하세요.'));
+  return lines.join('\n');
+}
+
+module.exports = { check, update, bootstrap, PKG_VERSION };


### PR DESCRIPTION
## Summary

`harness update` 명령 도입 (Phase B 미니멀). 설치된 harness의 변경을 감지하고 안전하게 표시한다. 자동 머지는 Phase A에서 추가 예정.

## 스프린트 계약 충족 항목

- [x] `.harness/manifest.json` 자동 생성 (init 시, 38개 파일 추적)
- [x] 4종 카테고리: `frozen` / `atomic` / `managed-block` / `user-only`
- [x] `harness update --check` — 비파괴 변경 요약 (현재 vs 최신 vs 충돌)
- [x] `harness update` — 파일별 diff 표시, 자동 쓰기 없음 (안전 우선)
- [x] `harness update --apply-frozen` — frozen 카테고리만 자동 덮어쓰기
- [x] `harness update --bootstrap` — baseline 박제 (매니페스트 부재/수동 머지 후 갱신)
- [x] `harness doctor` — manifest 존재 여부 점검 추가
- [x] README update 절차 + Phase B 한계 문서화
- [x] 한글 인코딩 검증 (U+FFFD 없음)

## 검증 (smoke test)

```
init → manifest 38개 파일 박제 ✓
update --check (변경 없음) → "최신입니다" ✓
divergent 시뮬레이션 → 충돌 1건 정확히 식별 + diff 명령 표시 ✓
bootstrap → 새 baseline 박제 ✓
doctor → manifest 점검 통과 ✓
```

## Phase B 한계 (의도적)

- divergent 파일 자동 머지 안 함 — 사용자가 `diff -u` 로 직접 비교 후 Edit 도구로 머지
- 머지 완료 후 `harness update --bootstrap` 으로 baseline 갱신
- CLAUDE.md는 현재 atomic처럼 동작 — Phase A에서 센티널 블록(`<!-- harness:managed:start -->`) 도입 예정

## 후속 (Phase A/C/D 후보)

- Phase C: frozen 외에도 modified-pristine 자동 적용 + 인터랙티브 atomic 승인
- Phase A: CLAUDE.md 센티널 블록 + 3-way merge (`git merge-file`)
- 슬래시 커맨드 `/harness-update` (Claude가 release notes 요약 + 인터랙티브 머지 도움)
- 마이그레이션 스크립트 인프라 (`lib/migrations/<version>.js`)
- npm registry 에서 latest 버전 fetch (현재는 패키지 자체 버전 = "최신")

## Test plan

- [ ] `npx @seo/harness-setting init <new-dir>` 후 manifest 생성 확인
- [ ] `harness update --check` 출력 확인
- [ ] divergent 시 `diff -u` 명령으로 수동 비교 후 `--bootstrap` 갱신 흐름

🤖 Generated with [Claude Code](https://claude.com/claude-code)