### PR TITLE
feat(harness): update Phase C — 인터랙티브 + 자동 적용 + dry-run

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,17 +49,27 @@ claude --plugin-dir ./.harness-plugin
 # 1. 변경 요약만 보기 (비파괴)
 npx @seo/harness-setting@latest update --check
 
-# 2. 파일별 diff 표시 + 적용 가이드 (자동 쓰기 안 함)
-npx @seo/harness-setting@latest update
+# 2. 충돌 없는 모든 변경 자동 적용 (frozen + pristine + added)
+npx @seo/harness-setting@latest update --apply-all-safe
 
-# 3. CI/스크립트 등 frozen 카테고리만 자동 덮어쓰기
-npx @seo/harness-setting@latest update --apply-frozen
+# 3. 카테고리별 세분화 적용
+npx @seo/harness-setting@latest update --apply-frozen     # CI/스크립트만
+npx @seo/harness-setting@latest update --apply-pristine   # 사용자 미수정 파일만
+npx @seo/harness-setting@latest update --apply-added      # 신규 파일만
 
-# 4. 매니페스트 부재 시 — 현재 상태를 baseline으로 박제
+# 4. divergent/removed 파일별 결정 (TTY 필수)
+npx @seo/harness-setting@latest update --interactive
+
+# 5. 적용 없이 시뮬레이션
+npx @seo/harness-setting@latest update --apply-all-safe --dry-run
+
+# 6. 매니페스트 부재 시 — 현재 상태를 baseline으로 박제
 npx @seo/harness-setting@latest update --bootstrap
 ```
 
-**Phase B 한계**: 사용자 수정과 패키지 변경이 동시에 발생한 파일(`divergent`)은 **자동 머지하지 않습니다**. 표시된 `diff -u` 명령으로 직접 비교하고 Edit 도구로 머지한 뒤, `harness update --bootstrap` 으로 매니페스트를 갱신하세요.
+적용 후 매니페스트는 **자동 갱신**됩니다 (별도 `--bootstrap` 불필요).
+
+**Phase C 한계**: `divergent` 파일의 자동 3-way merge는 지원하지 않습니다. `--interactive` 모드에서 [k]eep/[n]ew/[d]iff/[s]kip 중 선택하거나, 표시된 `diff -u` 로 직접 비교 후 Edit 도구로 머지하세요. (Phase A에서 CLAUDE.md 센티널 + 자동 머지 도입 예정.)
 
 파일 카테고리:
 - **frozen** (`scripts/`, `.github/workflows/`) — 자동 덮어쓰기 안전

--- a/bin/harness.js
+++ b/bin/harness.js
@@ -16,7 +16,15 @@ function printUsage() {
 
 Commands:
   init [경로]              새 프로젝트에 harness 프레임워크 초기화
-  update [--check|--bootstrap|--apply-frozen]  업데이트 확인/적용
+  update [옵션]            업데이트 확인/적용
+                           --check           : 변경 요약만 (비파괴)
+                           --bootstrap       : 현재 상태를 baseline으로 박제
+                           --apply-all-safe  : frozen + pristine + added 자동 적용
+                           --apply-frozen    : frozen 카테고리만
+                           --apply-pristine  : 사용자 미수정 파일만
+                           --apply-added     : 신규 파일만
+                           --interactive,-i  : divergent/removed 파일별 결정
+                           --dry-run         : 적용 없이 시뮬레이션
   doctor                   셋업 규칙 자체 점검 (CRITICAL DIRECTIVES, hook, 브랜치 등)
   validate                 프로젝트 설정 검증
   integrity                문서/설정 정합성 검증
@@ -36,17 +44,27 @@ switch (command) {
 
   case 'update': {
     const sub = args.slice(1);
-    let result;
-    if (sub.includes('--bootstrap')) {
-      result = updater.bootstrap();
-    } else if (sub.includes('--check')) {
-      result = updater.check();
-    } else {
-      result = updater.update(process.cwd(), { applyFrozen: sub.includes('--apply-frozen') });
-    }
-    if (result.output) console.log(result.output);
-    if (result.message) console.log(result.message);
-    process.exit(result.ok ? 0 : 1);
+    (async () => {
+      let result;
+      if (sub.includes('--bootstrap')) {
+        result = updater.bootstrap();
+      } else if (sub.includes('--check')) {
+        result = updater.check();
+      } else {
+        result = await updater.update(process.cwd(), {
+          applyFrozen: sub.includes('--apply-frozen'),
+          applyPristine: sub.includes('--apply-pristine'),
+          applyAdded: sub.includes('--apply-added'),
+          applyAllSafe: sub.includes('--apply-all-safe'),
+          interactive: sub.includes('--interactive') || sub.includes('-i'),
+          dryRun: sub.includes('--dry-run'),
+        });
+      }
+      if (result.output) console.log(result.output);
+      if (result.message) console.log(result.message);
+      process.exit(result.ok ? 0 : 1);
+    })();
+    break;
   }
 
   case 'doctor': {

--- a/lib/update.js
+++ b/lib/update.js
@@ -2,6 +2,7 @@
 
 const fs = require('node:fs');
 const path = require('node:path');
+const readline = require('node:readline');
 
 const {
   walkTracked,
@@ -28,17 +29,9 @@ const COLORS = {
 const c = (color, text) => `${COLORS[color]}${text}${COLORS.reset}`;
 
 /**
- * 로컬 설치본과 패키지 본을 비교하여 파일별 액션을 결정한다.
- *
- * 액션 종류:
- *   - identical            : 동일, 변경 없음
- *   - added                : 패키지에만 있음 (신규 도입)
- *   - removed-upstream     : 매니페스트에 있으나 패키지에서 사라짐
- *   - missing-locally      : 매니페스트에 있으나 사용자 디렉토리에서 사라짐 (사용자 삭제)
- *   - modified-pristine    : 사용자가 안 건드림 + 패키지가 바뀜 (안전 덮어쓰기)
- *   - converged            : 사용자가 수정했지만 패키지와 우연히 일치
- *   - divergent            : 사용자도 수정 + 패키지도 변경 (3-way merge 필요, B에선 수동)
- *   - user-modified-stable : 사용자가 수정 + 패키지는 그대로 (사용자 변경 보존)
+ * 파일 단위 액션 종류:
+ *   identical / added / removed-upstream / missing-locally /
+ *   modified-pristine / converged / divergent / user-modified-stable
  */
 function diffAgainstPackage(cwd, manifest) {
   const userFiles = walkTracked(cwd);
@@ -85,7 +78,7 @@ function summarize(actions) {
 }
 
 /**
- * `harness update --check` — 비파괴 요약
+ * harness update --check — 비파괴 요약
  */
 function check(cwd = process.cwd()) {
   const manifest = readManifest(cwd);
@@ -103,7 +96,13 @@ function check(cwd = process.cwd()) {
   lines.push(`  설치 시점 : ${c('gray', manifest.installedAt)}`);
   lines.push('');
 
-  if (manifest.harnessVersion === PKG_VERSION && (counts.divergent || 0) === 0 && (counts['modified-pristine'] || 0) === 0 && (counts.added || 0) === 0 && (counts['removed-upstream'] || 0) === 0) {
+  const noChange =
+    manifest.harnessVersion === PKG_VERSION &&
+    !counts.divergent &&
+    !counts['modified-pristine'] &&
+    !counts.added &&
+    !counts['removed-upstream'];
+  if (noChange) {
     lines.push(c('green', '  ✅ 최신입니다. 적용할 변경 없음.'));
     return { ok: true, manifest, actions, counts, output: lines.join('\n') };
   }
@@ -130,78 +129,168 @@ function check(cwd = process.cwd()) {
   }
 
   lines.push('');
-  lines.push(c('cyan', '  다음 단계:'));
-  lines.push('    harness update              # 파일별 diff 표시 (자동 적용 안 함)');
-  lines.push('    harness update --apply-frozen   # frozen 카테고리만 자동 덮어쓰기');
+  lines.push(c('cyan', '  적용 옵션:'));
+  lines.push('    harness update --apply-all-safe   # frozen + pristine + added 자동 적용 (충돌 없는 모든 변경)');
+  lines.push('    harness update --apply-frozen     # frozen 카테고리만');
+  lines.push('    harness update --apply-pristine   # 사용자 미수정 파일만');
+  lines.push('    harness update --apply-added      # 신규 파일만');
+  lines.push('    harness update --interactive      # divergent/removed-upstream 파일별 결정');
+  lines.push('    harness update --dry-run [옵션]   # 적용 없이 시뮬레이션');
   lines.push('');
   if (counts.divergent) {
-    lines.push(c('yellow', '  ⚠  Phase B는 자동 머지를 지원하지 않습니다. divergent 파일은 수동으로 검토/적용하세요.'));
+    lines.push(c('yellow', '  ⚠  divergent 파일은 --interactive 또는 수동 머지 필요. Phase C는 자동 3-way merge를 지원하지 않음.'));
   }
 
   return { ok: true, manifest, actions, counts, output: lines.join('\n') };
 }
 
-/**
- * `harness update` — diff 표시 + 옵션에 따라 frozen 자동 적용
- */
-function update(cwd = process.cwd(), opts = {}) {
-  const result = check(cwd);
-  if (!result.ok) return result;
-  const { actions } = result;
-  const lines = [result.output, ''];
+function copyFromPkg(rel, cwd) {
+  const src = path.join(PKG_ROOT, rel);
+  const dest = path.join(cwd, rel);
+  fs.mkdirSync(path.dirname(dest), { recursive: true });
+  fs.copyFileSync(src, dest);
+}
 
-  let appliedCount = 0;
+function deleteLocal(rel, cwd) {
+  const dest = path.join(cwd, rel);
+  if (fs.existsSync(dest)) fs.unlinkSync(dest);
+}
 
-  for (const a of actions) {
-    if (a.action === 'identical' || a.action === 'converged' || a.action === 'user-modified-stable') continue;
+function ask(rl, prompt) {
+  return new Promise((resolve) => rl.question(prompt, (a) => resolve(a.trim().toLowerCase())));
+}
 
-    lines.push(c('bold', `\n── ${a.rel} `) + c('gray', `[${a.category}/${a.action}]`));
-
-    if (a.action === 'modified-pristine' && opts.applyFrozen && a.category === 'frozen') {
-      const src = path.join(PKG_ROOT, a.rel);
-      const dest = path.join(cwd, a.rel);
-      fs.mkdirSync(path.dirname(dest), { recursive: true });
-      fs.copyFileSync(src, dest);
-      lines.push(c('green', `  ✓ frozen 자동 적용 완료`));
-      appliedCount++;
-      continue;
-    }
-
-    if (a.action === 'added') {
-      lines.push(c('green', `  + 신규 파일 — 적용 권장:`));
-      lines.push(c('gray', `    cp ${path.join(PKG_ROOT, a.rel)} ${a.rel}`));
-    } else if (a.action === 'removed-upstream') {
-      lines.push(c('yellow', `  - 상위에서 제거됨 — 삭제 여부 직접 결정:`));
-      lines.push(c('gray', `    rm ${a.rel}`));
-    } else if (a.action === 'missing-locally') {
-      lines.push(c('yellow', `  ! 로컬에서 누락 — 의도적이 아니면 복원:`));
-      lines.push(c('gray', `    cp ${path.join(PKG_ROOT, a.rel)} ${a.rel}`));
-    } else if (a.action === 'modified-pristine') {
-      lines.push(c('green', `  ↑ 안전 업데이트 가능 (사용자 미수정):`));
-      lines.push(c('gray', `    cp ${path.join(PKG_ROOT, a.rel)} ${a.rel}`));
-    } else if (a.action === 'divergent') {
-      lines.push(c('red', `  ✗ 충돌 — 사용자 수정과 패키지 변경 모두 존재. 수동 머지 필요:`));
-      lines.push(c('gray', `    diff -u ${a.rel} ${path.join(PKG_ROOT, a.rel)}`));
-    }
+function showDiff(rel, cwd) {
+  const { execSync } = require('node:child_process');
+  const src = path.join(PKG_ROOT, rel);
+  const dest = path.join(cwd, rel);
+  try {
+    return execSync(`diff -u "${dest}" "${src}"`, { encoding: 'utf8' });
+  } catch (err) {
+    return err.stdout || err.message;
   }
-
-  if (appliedCount > 0) {
-    lines.push('');
-    lines.push(c('cyan', `  매니페스트를 갱신하려면:`));
-    lines.push('    harness update --bootstrap   # 현재 상태를 새 baseline으로 기록');
-  }
-
-  lines.push('');
-  lines.push(c('gray', '  ℹ  Phase B는 안전을 위해 atomic/managed-block 파일을 자동 적용하지 않습니다.'));
-  lines.push(c('gray', '     사용자가 cp 명령을 직접 실행하거나 Edit 도구로 머지하세요.'));
-  lines.push(c('gray', '     적용 완료 후 `harness update --bootstrap` 으로 매니페스트를 갱신하세요.'));
-
-  return { ok: true, output: lines.join('\n'), appliedCount };
 }
 
 /**
- * `harness update --bootstrap` — 현재 상태를 새 baseline으로 박제
- * 매니페스트가 없거나, 수동 머지 후 baseline을 갱신할 때 사용.
+ * harness update [--apply-* | --interactive | --dry-run]
+ * 적용 후 매니페스트 자동 갱신.
+ */
+async function update(cwd = process.cwd(), opts = {}) {
+  const result = check(cwd);
+  if (!result.ok) return result;
+  const { manifest, actions } = result;
+
+  const dryRun = !!opts.dryRun;
+  const lines = [result.output, ''];
+
+  // 적용할 액션 결정
+  const applied = []; // { rel, action, type: 'copy'|'delete' }
+  const interactive = !!opts.interactive;
+  const applyFrozen = !!opts.applyFrozen || !!opts.applyAllSafe;
+  const applyPristine = !!opts.applyPristine || !!opts.applyAllSafe;
+  const applyAdded = !!opts.applyAdded || !!opts.applyAllSafe;
+
+  // 1단계: 자동 적용 가능 항목
+  for (const a of actions) {
+    if (a.action === 'modified-pristine' && (applyPristine || (applyFrozen && a.category === 'frozen'))) {
+      applied.push({ ...a, type: 'copy' });
+    } else if (a.action === 'added' && applyAdded) {
+      applied.push({ ...a, type: 'copy' });
+    }
+  }
+
+  // 2단계: 인터랙티브 (TTY 필수)
+  if (interactive) {
+    if (!process.stdin.isTTY) {
+      lines.push(c('red', '\n  ✗ --interactive 는 TTY가 필요합니다 (CI/파이프 환경에서는 사용 불가).'));
+      return { ok: false, output: lines.join('\n') };
+    }
+    const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+    const interactiveTargets = actions.filter((a) =>
+      a.action === 'divergent' || a.action === 'removed-upstream' || a.action === 'missing-locally'
+    );
+    for (const a of interactiveTargets) {
+      console.log(c('bold', `\n── ${a.rel}`) + c('gray', ` [${a.category}/${a.action}]`));
+      let choice;
+      if (a.action === 'divergent') {
+        console.log('  옵션: [k]eep 사용자 보존 / [n]ew 신규로 덮어쓰기 / [d]iff 표시 / [s]kip');
+        while (true) {
+          choice = await ask(rl, '  선택 (k/n/d/s): ');
+          if (choice === 'd') {
+            console.log(showDiff(a.rel, cwd));
+            continue;
+          }
+          if (['k', 'n', 's'].includes(choice)) break;
+          console.log(c('yellow', '  알 수 없는 선택. k/n/d/s 중 하나.'));
+        }
+        if (choice === 'n') applied.push({ ...a, type: 'copy' });
+        // k/s는 변경 없음
+      } else if (a.action === 'removed-upstream') {
+        console.log('  옵션: [k]eep 보존 / [d]elete 삭제 / [s]kip');
+        while (true) {
+          choice = await ask(rl, '  선택 (k/d/s): ');
+          if (['k', 'd', 's'].includes(choice)) break;
+        }
+        if (choice === 'd') applied.push({ ...a, type: 'delete' });
+      } else if (a.action === 'missing-locally') {
+        console.log('  옵션: [r]estore 복원 / [s]kip');
+        while (true) {
+          choice = await ask(rl, '  선택 (r/s): ');
+          if (['r', 's'].includes(choice)) break;
+        }
+        if (choice === 'r') applied.push({ ...a, type: 'copy' });
+      }
+    }
+    rl.close();
+  }
+
+  // 3단계: 적용 (또는 dry-run 표시)
+  if (applied.length === 0) {
+    lines.push(c('gray', '  적용할 변경 없음. (옵션 확인: --apply-all-safe, --interactive 등)'));
+    return { ok: true, output: lines.join('\n') };
+  }
+
+  lines.push(c('bold', `\n  ${dryRun ? '[DRY-RUN] ' : ''}적용 대상 ${applied.length}건:`));
+  for (const a of applied) {
+    const verb = a.type === 'delete' ? '삭제' : (a.action === 'added' ? '추가' : '덮어쓰기');
+    lines.push(`    ${c('cyan', verb)} ${c('gray', `[${a.category}/${a.action}]`)} ${a.rel}`);
+    if (!dryRun) {
+      if (a.type === 'copy') copyFromPkg(a.rel, cwd);
+      else if (a.type === 'delete') deleteLocal(a.rel, cwd);
+    }
+  }
+
+  // 4단계: 매니페스트 자동 갱신
+  if (!dryRun) {
+    const newManifest = buildManifest(cwd, PKG_VERSION);
+    // 기존 installedAt 보존, 적용 시점은 별도 필드로
+    newManifest.installedAt = manifest.installedAt;
+    newManifest.lastUpdatedAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+    writeManifest(cwd, newManifest);
+    lines.push('');
+    lines.push(c('green', `  ✅ 적용 완료. 매니페스트 갱신 (v${PKG_VERSION}, ${Object.keys(newManifest.files).length}개 파일).`));
+  } else {
+    lines.push('');
+    lines.push(c('yellow', '  ℹ  [DRY-RUN] 실제 변경되지 않았습니다. 옵션에서 --dry-run 제거 시 적용됩니다.'));
+  }
+
+  // divergent 잔존 안내
+  const remainingDivergent = actions
+    .filter((a) => a.action === 'divergent')
+    .filter((a) => !applied.some((ap) => ap.rel === a.rel));
+  if (remainingDivergent.length > 0) {
+    lines.push('');
+    lines.push(c('yellow', `  ⚠  미해결 divergent ${remainingDivergent.length}건 — --interactive 또는 수동 머지 필요:`));
+    for (const a of remainingDivergent) {
+      lines.push(`      diff -u ${a.rel} ${path.join(PKG_ROOT, a.rel)}`);
+    }
+  }
+
+  return { ok: true, output: lines.join('\n'), appliedCount: applied.length };
+}
+
+/**
+ * harness update --bootstrap — 현재 상태를 새 baseline으로 박제
  */
 function bootstrap(cwd = process.cwd()) {
   const manifest = buildManifest(cwd, PKG_VERSION);


### PR DESCRIPTION
## Summary

Phase B(diff 표시만) 다음 단계. 실제 적용 흐름과 인터랙티브 충돌 해결 추가.

## 새 옵션

| 옵션 | 동작 |
|---|---|
| `--apply-all-safe` | frozen + pristine + added 일괄 자동 적용 (충돌 없는 모든 변경) |
| `--apply-pristine` | 사용자 미수정 atomic만 |
| `--apply-added` | 신규 파일만 |
| `--interactive`, `-i` | divergent/removed-upstream 파일별 [k]eep/[n]ew/[d]iff/[s]kip (TTY 필수) |
| `--dry-run` | 모든 적용 옵션과 조합, 시뮬레이션만 |

적용 후 매니페스트 **자동 갱신** (별도 `--bootstrap` 불필요, `lastUpdatedAt` 필드 추가).

## 검증 (smoke test)

- added 시나리오: 식별 → `--dry-run` 시뮬레이션 → 실제 적용 → 매니페스트 갱신 → 재 `--check` 시 "최신" ✓
- `--interactive` 비-TTY 환경 명확히 거부 ✓
- 미해결 divergent 잔존 시 안내 메시지 ✓

## Phase A 후속

- divergent 자동 3-way merge (`git merge-file`)
- `CLAUDE.md` 센티널 블록(`<!-- harness:managed:... -->`) + 마이그레이션 스크립트
- 슬래시 커맨드 `/harness-update`

## Test plan

- [ ] `harness update --apply-all-safe --dry-run` 출력 확인
- [ ] divergent 파일이 있을 때 `--interactive` 모드 동작
- [ ] 적용 후 `--check` 가 "최신" 보고

🤖 Generated with [Claude Code](https://claude.com/claude-code)