### PR TITLE
feat(harness): update Phase A — 센티널 + 3-way merge + 마이그레이션 (v2.2.0)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,5 +1,6 @@
 # Claude Code 워크플로우 템플릿
 
+<!-- harness:managed:critical-directives:start -->
 ## 🚫 CRITICAL DIRECTIVES (NEVER BYPASS)
 
 **아래 규칙은 세션 초기화/신규 프로젝트 셋업/모호한 지시 상황에서도 예외 없이 적용된다.**
@@ -13,6 +14,7 @@
 6. **스프린트 계약** — 구현 착수 전 검증 가능한 완료 기준 목록을 사용자와 합의한다.
 
 > **세션 시작 시 자기 점검**: 새 대화에서 첫 작업을 시작하기 전, 본 블록을 인지했는지 확인하고 위반 가능성이 있는 경우 사용자에게 명시한다. 프레임워크 구성 이상이 의심되면 `harness doctor`를 실행한다.
+<!-- harness:managed:critical-directives:end -->
 
 ---
 
@@ -74,6 +76,7 @@ UI가 포함된 작업에서 4축으로 품질을 평가한다:
 
 ---
 
+<!-- harness:managed:real-lessons:start -->
 ## 실전 교훈 (portfolio-26, simple-shop 등에서 추출)
 
 ### 빌드 성공 ≠ 동작하는 앱
@@ -100,6 +103,7 @@ AI가 생성하는 코드에서 반복되는 실패 패턴:
 ### 프로젝트 재구축 시 주의
 `rm -rf`로 재구축 시 사용자 터미널의 cwd가 삭제된 디렉토리를 가리킬 수 있다.
 반드시 사전 경고한다.
+<!-- harness:managed:real-lessons:end -->
 
 ---
 

--- a/bin/harness.js
+++ b/bin/harness.js
@@ -23,6 +23,7 @@ Commands:
                            --apply-frozen    : frozen 카테고리만
                            --apply-pristine  : 사용자 미수정 파일만
                            --apply-added     : 신규 파일만
+                           --apply-merge     : divergent atomic을 3-way merge로 자동 시도
                            --interactive,-i  : divergent/removed 파일별 결정
                            --dry-run         : 적용 없이 시뮬레이션
   doctor                   셋업 규칙 자체 점검 (CRITICAL DIRECTIVES, hook, 브랜치 등)
@@ -56,6 +57,7 @@ switch (command) {
           applyPristine: sub.includes('--apply-pristine'),
           applyAdded: sub.includes('--apply-added'),
           applyAllSafe: sub.includes('--apply-all-safe'),
+          applyMerge: sub.includes('--apply-merge'),
           interactive: sub.includes('--interactive') || sub.includes('-i'),
           dryRun: sub.includes('--dry-run'),
         });

--- a/lib/manifest.js
+++ b/lib/manifest.js
@@ -5,6 +5,7 @@ const path = require('node:path');
 const crypto = require('node:crypto');
 
 const { categorize } = require('./categorize');
+const { managedSha256 } = require('./sentinels');
 
 const MANIFEST_REL = '.harness/manifest.json';
 const TRACKED_DIRS = ['.claude', '.github', 'scripts', 'docs'];
@@ -16,6 +17,19 @@ function sha256(buf) {
 
 function sha256File(absPath) {
   return sha256(fs.readFileSync(absPath));
+}
+
+/**
+ * 카테고리 기반 SHA — managed-block은 센티널 내부만 해시.
+ * 그래야 사용자가 센티널 외부(자유 영역)를 편집해도 update 추적이 깨지지 않는다.
+ */
+function categoricalSha256(relPath, absPath) {
+  const cat = categorize(relPath);
+  if (cat === 'managed-block') {
+    const text = fs.readFileSync(absPath, 'utf8');
+    return managedSha256(text);
+  }
+  return sha256File(absPath);
 }
 
 /**
@@ -53,7 +67,7 @@ function buildManifest(rootDir, harnessVersion) {
   const tracked = walkTracked(rootDir);
   const files = {};
   for (const [rel, abs] of Object.entries(tracked)) {
-    files[rel] = { sha256: sha256File(abs), category: categorize(rel) };
+    files[rel] = { sha256: categoricalSha256(rel, abs), category: categorize(rel) };
   }
   return {
     harnessVersion,
@@ -94,4 +108,5 @@ module.exports = {
   manifestPath,
   sha256,
   sha256File,
+  categoricalSha256,
 };

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { execFileSync } = require('node:child_process');
+
+/**
+ * 3-way merge wrapper using `git merge-file`.
+ * 입력: base / current / other (모두 텍스트)
+ * 출력: { merged: string, conflicts: boolean }
+ *
+ * git merge-file 종료 코드: 0=깨끗, >0=충돌 갯수, <0=에러
+ * 충돌 시 결과에 <<<<<<< ======= >>>>>>> 마커가 삽입됨.
+ */
+function threeWayMerge({ base, current, other, label = { current: 'LOCAL', other: 'PACKAGE' } }) {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-merge-'));
+  const baseP = path.join(tmp, 'base');
+  const curP = path.join(tmp, 'current');
+  const othP = path.join(tmp, 'other');
+
+  fs.writeFileSync(baseP, base);
+  fs.writeFileSync(curP, current);
+  fs.writeFileSync(othP, other);
+
+  let conflicts = false;
+  try {
+    execFileSync(
+      'git',
+      ['merge-file', '-L', label.current, '-L', 'BASE', '-L', label.other, curP, baseP, othP],
+      { stdio: 'pipe' }
+    );
+  } catch (err) {
+    // status > 0 = 충돌. status < 0 또는 다른 에러는 throw.
+    if (err.status && err.status > 0) {
+      conflicts = true;
+    } else {
+      fs.rmSync(tmp, { recursive: true, force: true });
+      throw err;
+    }
+  }
+
+  const merged = fs.readFileSync(curP, 'utf8');
+  fs.rmSync(tmp, { recursive: true, force: true });
+  return { merged, conflicts };
+}
+
+module.exports = { threeWayMerge };

--- a/lib/migrations/2.1.0-to-2.2.0.js
+++ b/lib/migrations/2.1.0-to-2.2.0.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const { hasSentinels } = require('../sentinels');
+
+/**
+ * 2.2.0 — CLAUDE.md에 managed 센티널 도입.
+ * 기존 사용자의 CLAUDE.md를 분석하여 다음 두 섹션을 센티널로 감싼다:
+ *   - critical-directives: "## 🚫 CRITICAL DIRECTIVES" ~ 다음 "---" 구분선 직전
+ *   - real-lessons: "## 실전 교훈" ~ 다음 "---" 구분선 직전
+ *
+ * 실패 조건(섹션을 못 찾으면) 변경 없이 노트만 남김 — 사용자가 직접 마이그레이션해야 함.
+ */
+module.exports = {
+  from: '2.1.0',
+  to: '2.2.0',
+  name: 'CLAUDE.md sentinel 도입',
+  run(cwd) {
+    const claudePath = path.join(cwd, 'CLAUDE.md');
+    if (!fs.existsSync(claudePath)) {
+      return { changed: [], notes: ['CLAUDE.md 없음 — 마이그레이션 스킵'] };
+    }
+    let text = fs.readFileSync(claudePath, 'utf8');
+    if (hasSentinels(text)) {
+      return { changed: [], notes: ['CLAUDE.md 이미 센티널 적용됨 — 스킵'] };
+    }
+
+    const notes = [];
+    const wraps = [
+      { id: 'critical-directives', heading: /^##\s*🚫?\s*CRITICAL DIRECTIVES/m },
+      { id: 'real-lessons', heading: /^##\s*실전 교훈/m },
+    ];
+
+    for (const w of wraps) {
+      const headMatch = w.heading.exec(text);
+      if (!headMatch) {
+        notes.push(`${w.id}: 헤더 매칭 실패 — 수동 wrap 필요`);
+        continue;
+      }
+      const sectionStart = headMatch.index;
+      // 섹션 종료: 다음 '\n---\n' 까지 (없으면 파일 끝까지)
+      const after = text.slice(sectionStart);
+      const sepMatch = /\n---\n/.exec(after);
+      const sectionEnd = sectionStart + (sepMatch ? sepMatch.index : after.length);
+
+      const before = text.slice(0, sectionStart);
+      const section = text.slice(sectionStart, sectionEnd).replace(/\n+$/, '');
+      const tail = text.slice(sectionEnd);
+
+      text =
+        before +
+        `<!-- harness:managed:${w.id}:start -->\n` +
+        section +
+        `\n<!-- harness:managed:${w.id}:end -->\n` +
+        tail;
+      notes.push(`${w.id}: 센티널 적용 완료`);
+    }
+
+    fs.writeFileSync(claudePath, text);
+    return { changed: ['CLAUDE.md'], notes };
+  },
+};

--- a/lib/migrations/index.js
+++ b/lib/migrations/index.js
@@ -1,0 +1,47 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * 마이그레이션 등록.
+ * 각 마이그레이션은 { from, to, name, run(cwd, manifest) -> { changed: string[], notes: string[] } }.
+ * - from: 시작 버전 (semver). semver 비교는 단순 split — pre-release 비지원.
+ * - to: 도달 버전.
+ * - run: 사용자 디렉토리(cwd) 와 현재 manifest를 받아 변경 수행. 부수효과 발생 가능.
+ */
+const MIGRATIONS = [
+  require('./2.1.0-to-2.2.0'),
+];
+
+function cmpSemver(a, b) {
+  const pa = a.split('.').map((n) => parseInt(n, 10));
+  const pb = b.split('.').map((n) => parseInt(n, 10));
+  for (let i = 0; i < Math.max(pa.length, pb.length); i++) {
+    const x = pa[i] || 0;
+    const y = pb[i] || 0;
+    if (x !== y) return x < y ? -1 : 1;
+  }
+  return 0;
+}
+
+/**
+ * fromVersion → toVersion 사이에 적용해야 할 마이그레이션 체인을 반환.
+ */
+function planMigrations(fromVersion, toVersion) {
+  return MIGRATIONS.filter(
+    (m) => cmpSemver(fromVersion, m.from) <= 0 && cmpSemver(m.to, toVersion) <= 0
+  ).sort((a, b) => cmpSemver(a.from, b.from));
+}
+
+function runMigrations(cwd, manifest, toVersion) {
+  const plan = planMigrations(manifest.harnessVersion, toVersion);
+  const results = [];
+  for (const mig of plan) {
+    const result = mig.run(cwd, manifest);
+    results.push({ migration: `${mig.from}→${mig.to} ${mig.name}`, ...result });
+  }
+  return results;
+}
+
+module.exports = { planMigrations, runMigrations, cmpSemver };

--- a/lib/sentinels.js
+++ b/lib/sentinels.js
@@ -1,0 +1,100 @@
+'use strict';
+
+const crypto = require('node:crypto');
+const fs = require('node:fs');
+
+/**
+ * managed-block 파일에서 harness가 소유하는 영역을 표시하는 센티널.
+ * 형식: <!-- harness:managed:<id>:start --> ... <!-- harness:managed:<id>:end -->
+ *
+ * 센티널 내부는 update 시 패키지 버전으로 교체된다.
+ * 외부는 사용자가 자유롭게 수정 가능 — 절대 손대지 않는다.
+ */
+
+const START = /<!--\s*harness:managed:([\w-]+):start\s*-->/g;
+const END_FOR = (id) => new RegExp(`<!--\\s*harness:managed:${id}:end\\s*-->`);
+
+/**
+ * 텍스트에서 모든 managed 블록을 추출.
+ * 결과: [{ id, content, startIdx, endIdx, blockStart, blockEnd }]
+ *   - content: 센티널 내부 본문 (앞뒤 줄바꿈 한 줄 트림)
+ *   - blockStart/End: 센티널 마커 자체를 포함한 인덱스 범위
+ */
+function parseBlocks(text) {
+  const blocks = [];
+  let m;
+  START.lastIndex = 0;
+  while ((m = START.exec(text)) !== null) {
+    const id = m[1];
+    const blockStart = m.index;
+    const startMarkerEnd = m.index + m[0].length;
+    const endRe = END_FOR(id);
+    endRe.lastIndex = startMarkerEnd;
+    const tail = text.slice(startMarkerEnd);
+    const endM = endRe.exec(tail);
+    if (!endM) continue; // 닫는 센티널 없음 — 무시
+    const endMarkerStart = startMarkerEnd + endM.index;
+    const blockEnd = endMarkerStart + endM[0].length;
+    const inner = text.slice(startMarkerEnd, endMarkerStart);
+    // 앞뒤 한 줄의 줄바꿈만 트림 (들여쓰기 보존)
+    const content = inner.replace(/^\n/, '').replace(/\n$/, '');
+    blocks.push({ id, content, startIdx: startMarkerEnd, endIdx: endMarkerStart, blockStart, blockEnd });
+  }
+  return blocks;
+}
+
+/**
+ * managed-block 파일의 SHA — 센티널 내부 콘텐츠만 정규화하여 해시.
+ * 외부 사용자 편집은 SHA에 영향 없음 (그래야 update 추적이 의미 있음).
+ */
+function managedSha256(text) {
+  const blocks = parseBlocks(text);
+  if (blocks.length === 0) {
+    // 센티널이 없으면 전체 파일을 해시 (마이그레이션 전 상태)
+    return crypto.createHash('sha256').update(text).digest('hex');
+  }
+  const concat = blocks.map((b) => `${b.id}\n${b.content}`).join('\n---\n');
+  return crypto.createHash('sha256').update(concat).digest('hex');
+}
+
+/**
+ * userText의 센티널 내부를 pkgText의 동일 id 블록으로 교체한다.
+ * - userText에 있는 외부 콘텐츠는 보존
+ * - pkgText에 새로 추가된 블록은 파일 끝에 append (드물지만 발생 가능)
+ * - userText에 있는데 pkgText에 없는 블록은 보존 (사용자가 직접 추가한 블록일 수 있음)
+ */
+function syncManagedBlocks(userText, pkgText) {
+  const userBlocks = parseBlocks(userText);
+  const pkgBlocks = parseBlocks(pkgText);
+  const pkgById = new Map(pkgBlocks.map((b) => [b.id, b]));
+  const userIds = new Set(userBlocks.map((b) => b.id));
+
+  // 1. userText의 블록을 pkg 블록으로 in-place 교체 (뒤에서부터)
+  let out = userText;
+  for (const ub of [...userBlocks].reverse()) {
+    const pb = pkgById.get(ub.id);
+    if (!pb) continue;
+    out = out.slice(0, ub.startIdx) + '\n' + pb.content + '\n' + out.slice(ub.endIdx);
+  }
+
+  // 2. pkg에만 있는 신규 블록은 파일 끝에 append
+  const newBlocks = pkgBlocks.filter((pb) => !userIds.has(pb.id));
+  if (newBlocks.length > 0) {
+    const appended = newBlocks
+      .map((pb) => `\n<!-- harness:managed:${pb.id}:start -->\n${pb.content}\n<!-- harness:managed:${pb.id}:end -->\n`)
+      .join('');
+    if (!out.endsWith('\n')) out += '\n';
+    out += appended;
+  }
+
+  return out;
+}
+
+/**
+ * 현재 텍스트가 센티널을 가지고 있는가 — 마이그레이션 필요 판단용
+ */
+function hasSentinels(text) {
+  return parseBlocks(text).length > 0;
+}
+
+module.exports = { parseBlocks, managedSha256, syncManagedBlocks, hasSentinels };

--- a/lib/update.js
+++ b/lib/update.js
@@ -11,8 +11,12 @@ const {
   writeManifest,
   manifestPath,
   sha256File,
+  categoricalSha256,
 } = require('./manifest');
 const { categorize } = require('./categorize');
+const { syncManagedBlocks } = require('./sentinels');
+const { threeWayMerge } = require('./merge');
+const { runMigrations, cmpSemver } = require('./migrations');
 
 const PKG_ROOT = path.resolve(__dirname, '..');
 const PKG_VERSION = require(path.join(PKG_ROOT, 'package.json')).version;
@@ -50,8 +54,8 @@ function diffAgainstPackage(cwd, manifest) {
     const inPkg = pkgFiles[rel];
     const category = categorize(rel);
 
-    const userSha = inUser ? sha256File(inUser) : null;
-    const pkgSha = inPkg ? sha256File(inPkg) : null;
+    const userSha = inUser ? categoricalSha256(rel, inUser) : null;
+    const pkgSha = inPkg ? categoricalSha256(rel, inPkg) : null;
     const baseSha = inManifest ? inManifest.sha256 : null;
 
     let action;
@@ -134,6 +138,7 @@ function check(cwd = process.cwd()) {
   lines.push('    harness update --apply-frozen     # frozen 카테고리만');
   lines.push('    harness update --apply-pristine   # 사용자 미수정 파일만');
   lines.push('    harness update --apply-added      # 신규 파일만');
+    lines.push('    harness update --apply-merge      # divergent atomic을 git 3-way merge로 자동 시도');
   lines.push('    harness update --interactive      # divergent/removed-upstream 파일별 결정');
   lines.push('    harness update --dry-run [옵션]   # 적용 없이 시뮬레이션');
   lines.push('');
@@ -149,6 +154,53 @@ function copyFromPkg(rel, cwd) {
   const dest = path.join(cwd, rel);
   fs.mkdirSync(path.dirname(dest), { recursive: true });
   fs.copyFileSync(src, dest);
+}
+
+/**
+ * managed-block 파일 동기화: 사용자 외부 편집 보존, 센티널 내부만 패키지로 교체.
+ */
+function applyManagedBlock(rel, cwd) {
+  const src = path.join(PKG_ROOT, rel);
+  const dest = path.join(cwd, rel);
+  if (!fs.existsSync(dest)) {
+    // 사용자 디렉토리에 없으면 그대로 복사
+    fs.mkdirSync(path.dirname(dest), { recursive: true });
+    fs.copyFileSync(src, dest);
+    return { mode: 'copy' };
+  }
+  const userText = fs.readFileSync(dest, 'utf8');
+  const pkgText = fs.readFileSync(src, 'utf8');
+  const synced = syncManagedBlocks(userText, pkgText);
+  fs.writeFileSync(dest, synced);
+  return { mode: 'sync' };
+}
+
+/**
+ * atomic divergent 파일 자동 3-way merge.
+ * base = 매니페스트 기록 시점의 패키지 본 — 매니페스트엔 SHA만 있으므로 base 텍스트가 없다.
+ * 대안: base를 빈 문자열로 두지 않고, "사용자 파일 = base"로 가정 (사용자 변경분만 충돌 후보) —
+ *       이 가정은 거짓일 수 있으므로 위험. 더 안전: 패키지의 git 히스토리에서 이전 버전을 fetch.
+ *       Phase A 미니멀 구현: PKG_ROOT가 git 저장소면 `git show <prev>:<file>` 시도, 실패 시 머지 거부.
+ */
+function applyMerge(rel, cwd, baseVersion) {
+  const dest = path.join(cwd, rel);
+  const src = path.join(PKG_ROOT, rel);
+  const current = fs.readFileSync(dest, 'utf8');
+  const other = fs.readFileSync(src, 'utf8');
+  let base;
+  try {
+    const { execFileSync } = require('node:child_process');
+    base = execFileSync('git', ['show', `v${baseVersion}:${rel}`], {
+      cwd: PKG_ROOT,
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+  } catch {
+    return { ok: false, reason: `base 버전(v${baseVersion}) 텍스트를 패키지 git에서 찾을 수 없음 — 수동 머지 필요` };
+  }
+  const { merged, conflicts } = threeWayMerge({ base, current, other });
+  fs.writeFileSync(dest, merged);
+  return { ok: true, conflicts };
 }
 
 function deleteLocal(rel, cwd) {
@@ -176,12 +228,34 @@ function showDiff(rel, cwd) {
  * 적용 후 매니페스트 자동 갱신.
  */
 async function update(cwd = process.cwd(), opts = {}) {
-  const result = check(cwd);
+  let result = check(cwd);
   if (!result.ok) return result;
-  const { manifest, actions } = result;
+  let { manifest, actions } = result;
 
   const dryRun = !!opts.dryRun;
   const lines = [result.output, ''];
+  const applyMergeFlag = !!opts.applyMerge;
+
+  // 0단계: 마이그레이션 (버전이 올라간 경우)
+  if (cmpSemver(manifest.harnessVersion, PKG_VERSION) < 0) {
+    lines.push(c('bold', `\n  🛠  마이그레이션: v${manifest.harnessVersion} → v${PKG_VERSION}`));
+    if (dryRun) {
+      lines.push(c('yellow', '    [DRY-RUN] 마이그레이션 스킵 (실제 실행 시 적용됨)'));
+    } else {
+      const migResults = runMigrations(cwd, manifest, PKG_VERSION);
+      for (const r of migResults) {
+        lines.push(`    ${c('cyan', r.migration)}`);
+        for (const note of r.notes) lines.push(`      - ${note}`);
+        if (r.changed && r.changed.length) {
+          lines.push(`      변경 파일: ${r.changed.join(', ')}`);
+        }
+      }
+      // 마이그레이션 후 manifest/diff 재계산
+      result = check(cwd);
+      manifest = result.manifest;
+      actions = result.actions;
+    }
+  }
 
   // 적용할 액션 결정
   const applied = []; // { rel, action, type: 'copy'|'delete' }
@@ -193,9 +267,15 @@ async function update(cwd = process.cwd(), opts = {}) {
   // 1단계: 자동 적용 가능 항목
   for (const a of actions) {
     if (a.action === 'modified-pristine' && (applyPristine || (applyFrozen && a.category === 'frozen'))) {
-      applied.push({ ...a, type: 'copy' });
+      applied.push({ ...a, type: a.category === 'managed-block' ? 'sync' : 'copy' });
     } else if (a.action === 'added' && applyAdded) {
       applied.push({ ...a, type: 'copy' });
+    } else if (a.action === 'divergent' && applyMergeFlag) {
+      if (a.category === 'managed-block') {
+        applied.push({ ...a, type: 'sync' });
+      } else if (a.category === 'atomic') {
+        applied.push({ ...a, type: 'merge' });
+      }
     }
   }
 
@@ -251,13 +331,28 @@ async function update(cwd = process.cwd(), opts = {}) {
   }
 
   lines.push(c('bold', `\n  ${dryRun ? '[DRY-RUN] ' : ''}적용 대상 ${applied.length}건:`));
+  let mergeConflicts = 0;
   for (const a of applied) {
-    const verb = a.type === 'delete' ? '삭제' : (a.action === 'added' ? '추가' : '덮어쓰기');
-    lines.push(`    ${c('cyan', verb)} ${c('gray', `[${a.category}/${a.action}]`)} ${a.rel}`);
+    const verb =
+      a.type === 'delete' ? '삭제' :
+      a.type === 'merge' ? '3-way merge' :
+      a.type === 'sync' ? '센티널 동기화' :
+      (a.action === 'added' ? '추가' : '덮어쓰기');
+    let suffix = '';
     if (!dryRun) {
       if (a.type === 'copy') copyFromPkg(a.rel, cwd);
       else if (a.type === 'delete') deleteLocal(a.rel, cwd);
+      else if (a.type === 'sync') applyManagedBlock(a.rel, cwd);
+      else if (a.type === 'merge') {
+        const mr = applyMerge(a.rel, cwd, manifest.harnessVersion);
+        if (!mr.ok) suffix = c('red', `  ✗ ${mr.reason}`);
+        else if (mr.conflicts) {
+          mergeConflicts++;
+          suffix = c('yellow', '  ⚠  충돌 마커 삽입됨 — 수동 해결 필요');
+        } else suffix = c('green', '  ✓ 깨끗한 머지');
+      }
     }
+    lines.push(`    ${c('cyan', verb)} ${c('gray', `[${a.category}/${a.action}]`)} ${a.rel}${suffix}`);
   }
 
   // 4단계: 매니페스트 자동 갱신
@@ -272,6 +367,11 @@ async function update(cwd = process.cwd(), opts = {}) {
   } else {
     lines.push('');
     lines.push(c('yellow', '  ℹ  [DRY-RUN] 실제 변경되지 않았습니다. 옵션에서 --dry-run 제거 시 적용됩니다.'));
+  }
+
+  if (mergeConflicts > 0) {
+    lines.push('');
+    lines.push(c('yellow', `  ⚠  3-way merge 충돌 ${mergeConflicts}건 — 파일 내 <<<<<<< 마커를 직접 해결하세요.`));
   }
 
   // divergent 잔존 안내

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"
@@ -18,7 +18,12 @@
     "CLAUDE.md",
     "README.md"
   ],
-  "keywords": ["ai-agent", "claude", "automation", "workflow-template"],
+  "keywords": [
+    "ai-agent",
+    "claude",
+    "automation",
+    "workflow-template"
+  ],
   "license": "MIT",
   "engines": {
     "node": ">=16.7.0"


### PR DESCRIPTION
## Summary

Phase A 완료. update 명령의 마지막 큰 조각:
1. **CLAUDE.md 센티널 블록** — harness 소유 영역과 사용자 자유 영역 분리
2. **3-way merge** — divergent atomic 자동 머지 (`git merge-file`)
3. **마이그레이션 인프라** — 버전 간 자동 변환 스크립트

## 핵심 설계

### 센티널 (managed-block)

```markdown
<!-- harness:managed:critical-directives:start -->
... harness 소유 ...
<!-- harness:managed:critical-directives:end -->

## 사용자가 추가한 자유 영역 (절대 손대지 않음)
```

- managed-block 파일의 SHA = 센티널 **내부 콘텐츠만** 해싱 → 외부 사용자 편집은 추적에 영향 없음
- update 시 `syncManagedBlocks` 가 센티널 내부만 패키지 본으로 교체

### 3-way merge

- `--apply-merge` 플래그로 divergent atomic 자동 시도
- base = 패키지 git 저장소의 `v<설치버전>:<파일>` (없으면 머지 거부 + 안내)
- 충돌 시 `<<<<<<< / ======= / >>>>>>>` 마커 삽입 + 보고

### 마이그레이션

- `lib/migrations/<from>-to-<to>.js` 형식
- 버전 mismatch 시 update 호출 첫 단계로 자동 실행 (dry-run 제외)
- 첫 마이그레이션: **2.1.0 → 2.2.0** (CRITICAL DIRECTIVES + 실전 교훈을 센티널로 자동 wrap)
- 멱등 (이미 센티널이 있으면 스킵)

## 신규 옵션

| 옵션 | 동작 |
|---|---|
| `--apply-merge` | divergent atomic을 3-way merge로 자동 시도 |

## Smoke test

- 구버전 매니페스트(v2.1.0) + 센티널 없는 CLAUDE.md → `harness update` → 마이그레이션 자동 실행 → 4개 센티널 마커 삽입 ✓
- 한글 인코딩 변경 없음 (의도 참조만 유지) ✓
- 패키지 자체 CLAUDE.md에도 센티널 적용 (dogfood) ✓

## Breaking change 주의

- 기존 v2.1.0 사용자가 `harness update` 호출 시 CLAUDE.md가 자동 마이그레이션됨
- 마이그레이션은 멱등이지만, 사용자가 CRITICAL/실전 교훈 섹션을 헤더 형식으로 변경했다면 매칭 실패 → notes에 "수동 wrap 필요" 표시 + 변경 없음 (안전)
- 권장: 마이그레이션 후 `git diff CLAUDE.md` 로 결과 확인

## 후속 (선택)

- 마이그레이션 후 manifest version 자동 갱신 (현재는 apply 시점에만)
- npm registry에서 latest 버전 fetch (현재는 패키지 자체 버전 = "최신")
- 슬래시 커맨드 `/harness-update` 가 마이그레이션 결과를 사용자에게 강조 표시

## Test plan

- [ ] 구버전 설치본에서 `harness update` 호출 → 마이그레이션 실행 + 센티널 적용
- [ ] divergent 파일 + `--apply-merge` 동작
- [ ] 사용자가 CLAUDE.md 외부 영역에 추가한 내용이 update 후에도 보존됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)