### PR TITLE
chore(harness): 좀비 인프라 제거 — orchestrator/dispatch + state.json (v2.3.0)

### DIFF
--- a/bin/harness.js
+++ b/bin/harness.js
@@ -16,7 +16,7 @@ function printUsage() {
 
 Commands:
   init [경로]              새 프로젝트에 harness 프레임워크 초기화
-  update [옵션]            업데이트 확인/적용
+  update [옵션]            harness 프레임워크 업데이트 확인/적용
                            --check           : 변경 요약만 (비파괴)
                            --bootstrap       : 현재 상태를 baseline으로 박제
                            --apply-all-safe  : frozen + pristine + added 자동 적용
@@ -29,10 +29,11 @@ Commands:
   doctor                   셋업 규칙 자체 점검 (CRITICAL DIRECTIVES, hook, 브랜치 등)
   validate                 프로젝트 설정 검증
   integrity                문서/설정 정합성 검증
-  orchestrator <cmd>       오케스트레이터 실행 (start|pipeline|parallel)
-  dispatch <agent> [n]     에이전트 디스패치
-  labels                   GitHub 라벨 설정
+  labels                   GitHub 기본 라벨 설정 (stage:* 는 scripts/setup-stage-labels.sh)
   version                  버전 출력
+
+페르소나 호출은 Claude Code 세션 내 슬래시 커맨드 사용:
+  /pm  /architect  /dev  /review  /qa  /next        (docs/agents-guide.md 참조)
 `);
 }
 
@@ -85,12 +86,12 @@ switch (command) {
     break;
 
   case 'orchestrator':
-    runScript('orchestrator.sh', args.slice(1));
-    break;
-
   case 'dispatch':
-    runScript('dispatch-agent.sh', args.slice(1));
-    break;
+    console.error(`'${command}' 명령은 v2.3.0에서 제거됐습니다.`);
+    console.error('페르소나 호출은 Claude Code 세션 내 슬래시 커맨드를 사용하세요:');
+    console.error('  /pm  /architect  /dev  /review  /qa  /next');
+    console.error('상세: docs/agents-guide.md');
+    process.exit(1);
 
   case 'labels':
     runScript('setup-labels.sh', args.slice(1));

--- a/lib/copy-template.js
+++ b/lib/copy-template.js
@@ -89,38 +89,10 @@ function copyTemplate(targetDir) {
     }
   }
 
-  // .harness/state.json 생성
+  // .harness/ 디렉토리 (logs용) — 상태는 GitHub 이슈/PR 라벨이 SSoT
   const harnessDir = path.join(dest, '.harness');
   const logsDir = path.join(harnessDir, 'logs');
   fs.mkdirSync(logsDir, { recursive: true });
-
-  const projectName = path.basename(dest);
-  const stateJson = {
-    project: projectName,
-    created_at: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
-    current_phase: 'planning',
-    agents: {
-      orchestrator: { status: 'idle', current_task: null },
-      planner: { status: 'idle', current_task: null },
-      pm: { status: 'idle', current_task: null },
-      architect: { status: 'idle', current_task: null },
-      'frontend-developers': [],
-      'backend-developers': [],
-      developers: [],
-      reviewer: { status: 'idle', current_task: null },
-      qa: { status: 'idle', current_task: null },
-      auditor: { status: 'idle', current_task: null },
-      integrator: { status: 'idle', current_task: null },
-    },
-    issues: [],
-    pull_requests: [],
-    blocked: [],
-  };
-  fs.writeFileSync(
-    path.join(harnessDir, 'state.json'),
-    JSON.stringify(stateJson, null, 2) + '\n'
-  );
-  console.log('  - .harness/state.json 생성 완료');
 
   // .harness/policy.json — 페르소나 호출 정책 (auto/manual)
   try {
@@ -189,12 +161,13 @@ function copyTemplate(targetDir) {
   console.log('다음 단계:');
   console.log('  1. GitHub 저장소 생성 후 리모트 연결');
   console.log('     git remote add origin <URL>');
-  console.log('  2. 라벨 생성 (아직 안 했다면)');
-  console.log('     harness labels');
-  console.log('  3. 오케스트레이터 시작');
-  console.log('     harness orchestrator start');
-  console.log('  4. 또는 개별 에이전트 실행');
-  console.log('     harness dispatch <pm|architect|developer|reviewer|qa> <이슈번호>');
+  console.log('  2. 기본 라벨 + stage:* 라벨 생성');
+  console.log('     harness labels                          # 작업 분류 라벨');
+  console.log('     bash scripts/setup-stage-labels.sh      # 페르소나 핸드오프 라벨');
+  console.log('  3. Claude Code 세션에서 페르소나 호출');
+  console.log('     /pm <요구>           # 스프린트 계약 + 이슈 생성');
+  console.log('     /next <이슈번호>     # 다음 페르소나 자동 추천');
+  console.log('     상세는 docs/agents-guide.md');
 }
 
 module.exports = { copyTemplate };

--- a/lib/migrations/2.2.0-to-2.3.0.js
+++ b/lib/migrations/2.2.0-to-2.3.0.js
@@ -1,0 +1,36 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * 2.3.0 — 좀비 인프라 정리.
+ * - .harness/state.json 제거 (이슈/PR 라벨이 SSoT)
+ * - orchestrator/dispatch 명령 제거 (페르소나는 슬래시 커맨드로 호출)
+ *
+ * state.json은 사용자 데이터가 들어있을 수 있으므로, 삭제 대신 .deprecated 로 rename.
+ */
+module.exports = {
+  from: '2.2.0',
+  to: '2.3.0',
+  name: '좀비 인프라 제거 (state.json deprecate, orchestrator/dispatch 명령 제거)',
+  run(cwd) {
+    const notes = [];
+    const changed = [];
+    const stateP = path.join(cwd, '.harness', 'state.json');
+    if (fs.existsSync(stateP)) {
+      const target = `${stateP}.deprecated`;
+      try {
+        fs.renameSync(stateP, target);
+        notes.push(`.harness/state.json → state.json.deprecated 로 이동 (참조하는 코드 없음, 안전 시 삭제)`);
+        changed.push('.harness/state.json');
+      } catch (err) {
+        notes.push(`state.json rename 실패: ${err.message}`);
+      }
+    } else {
+      notes.push('.harness/state.json 없음 — 스킵');
+    }
+    notes.push('orchestrator/dispatch 명령은 v2.3.0에서 제거됐습니다. /pm /architect /dev /review /qa /next 슬래시 커맨드 사용.');
+    return { changed, notes };
+  },
+};

--- a/lib/migrations/index.js
+++ b/lib/migrations/index.js
@@ -12,6 +12,7 @@ const path = require('node:path');
  */
 const MIGRATIONS = [
   require('./2.1.0-to-2.2.0'),
+  require('./2.2.0-to-2.3.0'),
 ];
 
 function cmpSemver(a, b) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Summary

5 페르소나 + thin orchestrator 정착 후 잔재 정리. 이슈/PR 라벨이 SSoT이므로 별도 state 불필요.

## 변경

- **제거**: `harness orchestrator`, `harness dispatch` 명령 → 호출 시 안내 메시지 + exit 1
- **제거**: `init` 시 `.harness/state.json` 생성 (11에이전트 슬롯)
- **마이그레이션 (2.2→2.3)**: 기존 사용자의 state.json → state.json.deprecated rename (데이터 보존)
- **사용법 텍스트**: 페르소나 호출은 슬래시 커맨드(`/pm /architect /dev /review /qa /next`) 로 안내

## Smoke

- init → state.json 미생성 ✓
- orchestrator 호출 → 안내 + exit 1 ✓

## Test plan

- [ ] 기존 v2.2 설치본에서 `harness update` → 마이그레이션 자동 실행 → state.json deprecate

🤖 Generated with [Claude Code](https://claude.com/claude-code)