### PR TITLE
fix(skills/cross-validate): U+FFFD → 시도 복구 (#87)

### DIFF
--- a/.claude/skills/cross-validate/scripts/cross_validate.sh
+++ b/.claude/skills/cross-validate/scripts/cross_validate.sh
@@ -62,7 +62,7 @@ run_gemini() {
     }
 
     if echo "${output}" | grep -qE "RESOURCE_EXHAUSTED|429|503|500"; then
-      log "경고: ${GEMINI_MODEL} 용량 부족 (시��� ${attempt}/${MAX_GEMINI_RETRIES})"
+      log "경고: ${GEMINI_MODEL} 용량 부족 (시도 ${attempt}/${MAX_GEMINI_RETRIES})"
       attempt=$((attempt + 1))
       sleep $((attempt * 5))
     else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [2.7.1] — 2026-04-18
+
+`cross_validate.sh` 한국어 로그 메시지 U+FFFD 복구 ([#87](https://github.com/coseo12/harness-setting/issues/87)).
+
+### Fixed
+
+- **`.claude/skills/cross-validate/scripts/cross_validate.sh:65`** — `시` + `U+FFFD × 3` → `시도` 복구. RESOURCE_EXHAUSTED 재시도 로그 메시지의 의미 깨짐을 해소.
+
+### Behavior Changes
+
+- None — 문구/인코딩만. 로그 출력 문자열만 교체되며 에이전트/스킬 동작 로직 변화 없음. `atomic` 카테고리 파일이라 다음 `harness update` 때 다운스트림에 자동 반영된다.
+
 ## [2.7.0] — 2026-04-18
 
 volt #23 #24 #26 반영 — cross-validate 박제 후 루틴 + sub-agent 마무리 체크리스트 + ADR 변형 박제.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.7.0",
+  "version": "2.7.1",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Summary

- `.claude/skills/cross-validate/scripts/cross_validate.sh:65` RESOURCE_EXHAUSTED 재시도 로그의 U+FFFD 3자 → `시도` 복구
- CRITICAL #4 (한글 인코딩 검증) 위반 해소
- v2.7.1 PATCH 릴리스 준비 (package.json / CHANGELOG 포함)

## 영향 범위

- `atomic` 카테고리 파일 — 다음 `harness update` 실행 시 다운스트림 프로젝트에 자동 overwrite 되어 반영됨
- 에이전트/스킬 실행 로직 변화 없음 (로그 출력 문자열만 교체)

## Test plan

- [x] `grep -n '�' .claude/skills/cross-validate/scripts/cross_validate.sh` → 0건
- [x] `git diff` 로 의도한 3개 파일만 변경되었는지 확인 (`cross_validate.sh`, `CHANGELOG.md`, `package.json`)
- [ ] 머지 후 `git tag v2.7.1` + `gh release create`

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)