### PR TITLE
feat(update): post-apply 검증 게이트 + doctor 해시 정합성 (#89)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [2.8.0] — 2026-04-18
+
+harness [#89](https://github.com/coseo12/harness-setting/issues/89) 반영 — `harness update --apply-all-safe` post-apply 검증 게이트 + `harness doctor` 매니페스트 해시 정합성 검증. v2.7.2 에서 박제한 "매니페스트 최신 ≠ 파일 적용 완료" 교착 상태를 코드 레벨에서 방어.
+
+### Added
+
+- **`lib/update.js` post-apply 검증 게이트** — 파일 적용 직후 upstream 패키지 해시와 디스크 실측 해시를 비교하여 외부 프로세스(lint-staged 등) 에 의한 롤백을 감지. 불일치 파일의 매니페스트 해시는 이전 값으로 유지되어 재-apply 시 `modified-pristine` 으로 재감지됨. merge/delete type 은 검증 제외.
+- **`lib/doctor.js` "매니페스트 해시 정합성" 항목** — 매니페스트 기록 해시 vs 파일 실측 해시를 비교하여 해시 위조 또는 파일 누락을 warn 으로 리포트. managed-block 파일은 센티널 내부만 해시하므로 외부 편집 오탐 없음.
+- **`test/` 디렉토리 신설** — Node 내장 `node --test` 기반 6케이스 (update 검증 3 + doctor 정합성 3). `package.json scripts.test` 추가.
+
+### Behavior Changes
+
+- `harness update --apply-all-safe` 가 적용 직후 upstream/디스크 해시 비교를 수행한다
+- 불일치 파일은 매니페스트 해시를 갱신하지 않고 이전 값 유지 (재-apply 시 pristine 재감지)
+- 부분 실패 감지 시 exit code 1 + stderr `harness update: post-apply 검증 실패 N건 — <파일 목록>` 출력
+- `harness doctor` 가 "매니페스트 해시 정합성" 항목을 pass/warn 으로 리포트 (매니페스트 없으면 항목 스킵)
+- 정상 경로(검증 성공) 에서는 기존 동작과 완전 동일 (backward-compatible)
+
+### Notes
+
+- 한계: post-apply 검증은 `harness update` 종료 직전까지만 유효. 사용자 `git commit` 시점에 동작하는 lint-staged pre-commit 훅 롤백은 `harness doctor` 실행 시점에만 감지됨. 커밋 시점 롤백의 자가 복구는 후속 이슈 [#92](https://github.com/coseo12/harness-setting/issues/92) 에서 `previousSha256` 필드 도입으로 다룸.
+- Gemini 교차검증 수행 — 설계 방향 / edge case / 한계 인식 모두 합의. Gemini 고유 발견(previousSha256 제안, merge/managed-block 스킵 경로 테스트 보강)은 이슈 #92 에 박제.
+- 근거: harness [#89](https://github.com/coseo12/harness-setting/issues/89), volt [#27](https://github.com/coseo12/volt/issues/27)
+
 ## [2.7.2] — 2026-04-18
 
 volt [#27](https://github.com/coseo12/volt/issues/27) 반영 — 매니페스트 기반 패키지 관리자 부분 실패 교착 복구 교훈 박제.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,7 +142,8 @@ AI가 생성하는 코드에서 반복되는 실패 패턴:
   ```
 - 예방 루틴: 패키지 업데이트 커밋 시 매니페스트와 파일을 **동일 커밋**에 묶고, 부분 실패 감지 시 전체 revert + 재시도를 부분 보수보다 우선한다
 - 선행 원인 lint-staged silent partial commit (volt [#13](https://github.com/coseo12/volt/issues/13)) 과 연쇄될 때 가장 자주 관찰됨
-- 근거: volt [#27](https://github.com/coseo12/volt/issues/27). harness 코드 레벨 원자성 개선은 [#89](https://github.com/coseo12/harness-setting/issues/89) 로 분리
+- v2.8.0 (harness [#89](https://github.com/coseo12/harness-setting/issues/89)) 부터 **post-apply 검증 게이트** 도입: 파일 적용 직후 upstream 패키지 해시와 디스크 실측 해시를 비교하여 불일치 파일의 매니페스트 해시는 이전 값으로 유지(재-apply 시 pristine 재감지). 부분 실패 시 exit code 1 + stderr 경고. `harness doctor` 는 "매니페스트 해시 정합성" 항목으로 해시 위조를 감지한다.
+- 근거: volt [#27](https://github.com/coseo12/volt/issues/27). harness 코드 레벨 원자성 개선은 [#89](https://github.com/coseo12/harness-setting/issues/89) 에서 반영
 
 ### sub-agent 검증 완료 ≠ GitHub 박제 완료
 sub-agent(dev/qa 페르소나 등)는 빌드·테스트·브라우저 검증은 수행하면서도 **커밋/푸시/PR 생성/`gh pr comment` 박제** 같은 외부 가시성 단계에서 이탈하는 패턴이 반복된다(4회 관찰). sub-agent 관점 "작업 완료"와 harness 관점 "외부 가시성 있음"이 어긋나 메인 오케스트레이터가 매번 수동 보완해야 했다.

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -3,6 +3,7 @@
 const fs = require('node:fs');
 const path = require('node:path');
 const { execSync } = require('node:child_process');
+const { categoricalSha256 } = require('./manifest');
 
 const COLORS = {
   reset: '\x1b[0m',
@@ -111,16 +112,54 @@ function runDoctor(cwd = process.cwd()) {
 
   // 5. .harness/manifest.json 존재 여부 (update 추적 활성화 확인)
   const manifestPath = path.join(cwd, '.harness', 'manifest.json');
+  let parsedManifest = null;
   if (fs.existsSync(manifestPath)) {
     try {
-      const m = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
-      const fileCount = m.files ? Object.keys(m.files).length : 0;
-      report.add('pass', '.harness/manifest.json', `update 추적 활성 (v${m.harnessVersion}, ${fileCount}개 파일)`);
+      parsedManifest = JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+      const fileCount = parsedManifest.files ? Object.keys(parsedManifest.files).length : 0;
+      report.add('pass', '.harness/manifest.json', `update 추적 활성 (v${parsedManifest.harnessVersion}, ${fileCount}개 파일)`);
     } catch (err) {
       report.add('fail', '.harness/manifest.json', `JSON 파싱 실패: ${err.message}`);
     }
   } else {
     report.add('warn', '.harness/manifest.json', 'update 추적 미활성 — `harness update --bootstrap` 권장');
+  }
+
+  // 5b. 매니페스트 기록 해시 vs 파일 실측 해시 일치 검증 (해시 위조 탐지)
+  // 불일치 원인:
+  //   (a) 사용자가 파일을 의도적으로 수정 — divergent/user-modified. 정상.
+  //   (b) 외부 프로세스(lint-staged 등)가 apply 후 revert. 매니페스트가 파일보다 "앞서감"(해시 위조).
+  //   (c) 파일 누락. baseline 파손.
+  // doctor 는 정상/비정상을 구분하지 못하므로 불일치 "건수"만 warn 으로 리포트하고,
+  // 상세는 `harness update --check` 로 확인하도록 안내한다.
+  if (parsedManifest && parsedManifest.files) {
+    const mismatched = [];
+    const missing = [];
+    for (const [rel, entry] of Object.entries(parsedManifest.files)) {
+      const abs = path.join(cwd, rel);
+      if (!fs.existsSync(abs)) {
+        missing.push(rel);
+        continue;
+      }
+      try {
+        const actual = categoricalSha256(rel, abs);
+        if (actual !== entry.sha256) mismatched.push(rel);
+      } catch {
+        // 파일 읽기 실패는 무시 (권한 등)
+      }
+    }
+    if (missing.length === 0 && mismatched.length === 0) {
+      report.add('pass', '매니페스트 해시 정합성', '기록된 모든 파일의 실측 해시 일치');
+    } else {
+      const parts = [];
+      if (mismatched.length > 0) parts.push(`해시 불일치 ${mismatched.length}건`);
+      if (missing.length > 0) parts.push(`파일 누락 ${missing.length}건`);
+      report.add(
+        'warn',
+        '매니페스트 해시 정합성',
+        `${parts.join(', ')} — 사용자 수정이면 정상, 아니면 외부 롤백 의심. \`harness update --check\` 로 상세 확인`
+      );
+    }
   }
 
   // 6a. .harnessignore — manifest 추적 제외 패턴 (사용자 오버라이드)

--- a/lib/update.js
+++ b/lib/update.js
@@ -355,18 +355,69 @@ async function update(cwd = process.cwd(), opts = {}) {
     lines.push(`    ${c('cyan', verb)} ${c('gray', `[${a.category}/${a.action}]`)} ${a.rel}${suffix}`);
   }
 
+  // 3.5단계: post-apply 검증 — 외부 요인(lint-staged 등)에 의한 rollback 감지
+  // 적용한 파일의 디스크 실측 해시와 upstream 패키지 해시를 비교한다.
+  // 불일치하면 "적용했으나 되돌려진" 상태이므로 매니페스트 갱신에서 해당 파일을 제외한다.
+  const rolledBack = [];
+  if (!dryRun) {
+    for (const a of applied) {
+      if (a.type === 'delete') continue; // 삭제는 검증 불필요
+      const pkgAbs = path.join(PKG_ROOT, a.rel);
+      const localAbs = path.join(cwd, a.rel);
+      if (!fs.existsSync(pkgAbs)) continue; // upstream 없으면 비교 불가
+      if (!fs.existsSync(localAbs)) {
+        rolledBack.push({ rel: a.rel, reason: '적용 직후 파일 누락' });
+        continue;
+      }
+      const expected = categoricalSha256(a.rel, pkgAbs);
+      const actual = categoricalSha256(a.rel, localAbs);
+      if (expected !== actual) {
+        // merge 성공/충돌은 의도적으로 upstream 과 다를 수 있으므로 제외
+        if (a.type === 'merge') continue;
+        rolledBack.push({ rel: a.rel, reason: '해시 불일치 (외부 롤백 의심)' });
+      }
+    }
+  }
+
   // 4단계: 매니페스트 자동 갱신
   if (!dryRun) {
     const newManifest = buildManifest(cwd, PKG_VERSION);
     // 기존 installedAt 보존, 적용 시점은 별도 필드로
     newManifest.installedAt = manifest.installedAt;
     newManifest.lastUpdatedAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+    // rolled-back 파일은 이전 매니페스트 해시로 복원 — 재-apply 시 pristine 으로 재감지되도록.
+    // 이전 매니페스트에도 없던 신규 파일이 롤백된 경우 엔트리 자체를 제거한다.
+    for (const rb of rolledBack) {
+      if (manifest.files && manifest.files[rb.rel]) {
+        newManifest.files[rb.rel] = manifest.files[rb.rel];
+      } else {
+        delete newManifest.files[rb.rel];
+      }
+    }
+
     writeManifest(cwd, newManifest);
     lines.push('');
-    lines.push(c('green', `  ✅ 적용 완료. 매니페스트 갱신 (v${PKG_VERSION}, ${Object.keys(newManifest.files).length}개 파일).`));
+    if (rolledBack.length > 0) {
+      lines.push(c('yellow', `  ⚠  적용 완료 (${applied.length - rolledBack.length}/${applied.length}건). 매니페스트 갱신 (v${PKG_VERSION}, ${Object.keys(newManifest.files).length}개 파일).`));
+    } else {
+      lines.push(c('green', `  ✅ 적용 완료. 매니페스트 갱신 (v${PKG_VERSION}, ${Object.keys(newManifest.files).length}개 파일).`));
+    }
   } else {
     lines.push('');
     lines.push(c('yellow', '  ℹ  [DRY-RUN] 실제 변경되지 않았습니다. 옵션에서 --dry-run 제거 시 적용됩니다.'));
+  }
+
+  // post-apply 검증 실패 메시지는 stderr 로도 출력 (CI 로그에서 눈에 띄도록)
+  if (rolledBack.length > 0) {
+    lines.push('');
+    lines.push(c('red', `  ✗ post-apply 검증 실패: ${rolledBack.length}건 — 외부 요인으로 롤백된 것으로 의심`));
+    for (const rb of rolledBack) {
+      lines.push(`      ${c('gray', `[${rb.reason}]`)} ${rb.rel}`);
+    }
+    lines.push(c('yellow', '    해당 파일의 매니페스트 해시는 갱신되지 않았습니다. 재-apply 시 pristine 으로 재감지됩니다.'));
+    lines.push(c('yellow', '    의심 원인: lint-staged 부분 실패, pre-commit hook revert, 병렬 편집 등'));
+    process.stderr.write(`\nharness update: post-apply 검증 실패 ${rolledBack.length}건 — ${rolledBack.map((r) => r.rel).join(', ')}\n`);
   }
 
   if (mergeConflicts > 0) {
@@ -386,7 +437,12 @@ async function update(cwd = process.cwd(), opts = {}) {
     }
   }
 
-  return { ok: true, output: lines.join('\n'), appliedCount: applied.length };
+  return {
+    ok: rolledBack.length === 0,
+    output: lines.join('\n'),
+    appliedCount: applied.length,
+    rolledBack,
+  };
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.7.2",
+  "version": "2.8.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"
+  },
+  "scripts": {
+    "test": "node --test \"test/**/*.test.js\""
   },
   "files": [
     "bin/",

--- a/test/doctor-hash-integrity.test.js
+++ b/test/doctor-hash-integrity.test.js
@@ -1,0 +1,116 @@
+'use strict';
+
+/**
+ * harness doctor — 매니페스트 해시 정합성 검증.
+ * 완료 기준: "해시 불일치" 또는 "파일 누락" 감지 시 warn 리포트.
+ *
+ * 이슈 #89
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { runDoctor } = require('../lib/doctor');
+const { writeManifest } = require('../lib/manifest');
+
+function makeTmpCwd(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `harness-doctor-${prefix}-`));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function shaOf(text) {
+  return require('node:crypto').createHash('sha256').update(text).digest('hex');
+}
+
+function seedMinimalProject(cwd) {
+  // doctor 가 요구하는 최소 파일들
+  fs.mkdirSync(path.join(cwd, '.claude'), { recursive: true });
+  fs.mkdirSync(path.join(cwd, '.claude', 'agents'), { recursive: true });
+  fs.mkdirSync(path.join(cwd, '.claude', 'skills'), { recursive: true });
+  fs.writeFileSync(path.join(cwd, '.claude', 'settings.json'), JSON.stringify({ hooks: { SessionStart: [] } }));
+  fs.writeFileSync(
+    path.join(cwd, 'CLAUDE.md'),
+    '# CRITICAL DIRECTIVES\n\n(test fixture)\n'
+  );
+}
+
+test('doctor: 매니페스트 해시 = 파일 실측 해시 일치 시 pass', () => {
+  const cwd = makeTmpCwd('hash-ok');
+  try {
+    seedMinimalProject(cwd);
+    const targetRel = 'docs/fixture.md';
+    const content = '# fixture\n';
+    fs.mkdirSync(path.join(cwd, 'docs'), { recursive: true });
+    fs.writeFileSync(path.join(cwd, targetRel), content);
+
+    writeManifest(cwd, {
+      harnessVersion: '0.0.1',
+      installedAt: '2020-01-01T00:00:00Z',
+      files: {
+        [targetRel]: { sha256: shaOf(content), category: 'pristine' },
+      },
+    });
+
+    const report = runDoctor(cwd);
+    const integrity = report.items.find((i) => i.name === '매니페스트 해시 정합성');
+    assert.ok(integrity, '해시 정합성 항목이 리포트에 포함돼야 함');
+    assert.strictEqual(integrity.status, 'pass', `해시 일치 시 pass. 실제: ${integrity.status} / ${integrity.detail}`);
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('doctor: 매니페스트 해시 ≠ 파일 실측 해시 (해시 위조) 감지 시 warn', () => {
+  const cwd = makeTmpCwd('hash-mismatch');
+  try {
+    seedMinimalProject(cwd);
+    const targetRel = 'docs/fixture.md';
+    fs.mkdirSync(path.join(cwd, 'docs'), { recursive: true });
+    // 실제 파일은 "rolled back content"
+    fs.writeFileSync(path.join(cwd, targetRel), '# rolled back\n');
+    // 매니페스트는 "upstream content" 해시를 가짐 — 해시 위조 상태
+    writeManifest(cwd, {
+      harnessVersion: '0.0.1',
+      installedAt: '2020-01-01T00:00:00Z',
+      files: {
+        [targetRel]: { sha256: shaOf('# upstream fresh\n'), category: 'pristine' },
+      },
+    });
+
+    const report = runDoctor(cwd);
+    const integrity = report.items.find((i) => i.name === '매니페스트 해시 정합성');
+    assert.ok(integrity, '해시 정합성 항목이 리포트에 포함돼야 함');
+    assert.strictEqual(integrity.status, 'warn', `해시 불일치 시 warn. 실제: ${integrity.status}`);
+    assert.match(integrity.detail, /해시 불일치 1건/, '불일치 건수가 detail 에 표시돼야 함');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('doctor: 매니페스트에 기록된 파일이 디스크에 없으면 warn', () => {
+  const cwd = makeTmpCwd('missing');
+  try {
+    seedMinimalProject(cwd);
+    writeManifest(cwd, {
+      harnessVersion: '0.0.1',
+      installedAt: '2020-01-01T00:00:00Z',
+      files: {
+        'docs/ghost.md': { sha256: shaOf('ghost'), category: 'pristine' },
+      },
+    });
+
+    const report = runDoctor(cwd);
+    const integrity = report.items.find((i) => i.name === '매니페스트 해시 정합성');
+    assert.ok(integrity);
+    assert.strictEqual(integrity.status, 'warn');
+    assert.match(integrity.detail, /파일 누락 1건/);
+  } finally {
+    cleanup(cwd);
+  }
+});

--- a/test/update-verification.test.js
+++ b/test/update-verification.test.js
@@ -1,0 +1,185 @@
+'use strict';
+
+/**
+ * post-apply 검증 게이트 — lint-staged partial revert 시뮬레이션.
+ *
+ * 시나리오:
+ *   1. 사용자 프로젝트에 harness 파일 A, B 가 오래된 버전으로 존재 (modified-pristine).
+ *   2. `harness update --apply-all-safe` 실행 → 둘 다 upstream 내용으로 덮어써짐.
+ *   3. 외부 프로세스(lint-staged 모사)가 B 를 이전 내용으로 즉시 되돌린다.
+ *   4. 매니페스트 갱신 단계에서 B 의 해시 불일치 감지 → B 해시는 이전 매니페스트 값 유지.
+ *   5. 재-apply 시 B 가 modified-pristine 으로 재감지되어 다시 적용 가능.
+ *
+ * 이슈 #89 — CLAUDE.md "매니페스트 최신 ≠ 파일 적용 완료" 대응.
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { update, check } = require('../lib/update');
+const { readManifest, writeManifest, buildManifest, categoricalSha256 } = require('../lib/manifest');
+
+const PKG_ROOT = path.resolve(__dirname, '..');
+
+function makeTmpCwd(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `harness-test-${prefix}-`));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/**
+ * 테스트 픽스처: 사용자 프로젝트에 tracked 디렉토리를 만들고,
+ * 지정 파일들을 "이전 내용" 으로 시드 + 매니페스트를 "이전 내용 해시" 로 기록한다.
+ * 이 상태는 modified-pristine (사용자 미수정, 업스트림 업데이트 대기) 을 시뮬레이션한다.
+ */
+function seedStaleProject(cwd, targets) {
+  for (const [rel, oldContent] of Object.entries(targets)) {
+    const abs = path.join(cwd, rel);
+    fs.mkdirSync(path.dirname(abs), { recursive: true });
+    fs.writeFileSync(abs, oldContent);
+  }
+  const manifest = {
+    harnessVersion: '0.0.1',
+    installedAt: '2020-01-01T00:00:00Z',
+    files: {},
+  };
+  for (const [rel, oldContent] of Object.entries(targets)) {
+    manifest.files[rel] = { sha256: shaOf(oldContent), category: guessCategory(rel) };
+  }
+  writeManifest(cwd, manifest);
+}
+
+function shaOf(text) {
+  return require('node:crypto').createHash('sha256').update(text).digest('hex');
+}
+
+function guessCategory(rel) {
+  // 테스트용 단순화 — 실제 categorize 를 사용해도 무방
+  const { categorize } = require('../lib/categorize');
+  return categorize(rel);
+}
+
+test('post-apply 검증: 외부 rollback 감지 시 매니페스트 해시는 이전 값 유지', async () => {
+  const cwd = makeTmpCwd('rollback');
+  try {
+    // 실제 upstream 파일 중 하나를 타겟으로 선정 — scripts/setup-labels.sh 같은 frozen 후보
+    // 테스트 안정성을 위해 docs/ 아래 파일 중 하나로 고정.
+    const targetRel = 'docs/agents-guide.md';
+    const upstreamAbs = path.join(PKG_ROOT, targetRel);
+    if (!fs.existsSync(upstreamAbs)) {
+      // 업스트림에 파일이 없으면 테스트 스킵 (환경 독립적 보장)
+      return;
+    }
+    const upstreamContent = fs.readFileSync(upstreamAbs, 'utf8');
+    const oldContent = '# stale baseline\n';
+
+    seedStaleProject(cwd, { [targetRel]: oldContent });
+    const oldSha = shaOf(oldContent);
+
+    // update 실행 전 스텁: 적용 직후 외부 프로세스가 파일을 revert 하도록 흉내내기 위해,
+    // fs.copyFileSync 를 감싼 뒤 원래 동작 + 즉시 revert 를 한다.
+    const origCopy = fs.copyFileSync;
+    fs.copyFileSync = (src, dest) => {
+      origCopy(src, dest);
+      if (path.resolve(dest) === path.resolve(path.join(cwd, targetRel))) {
+        // lint-staged 가 파일을 revert 한 것으로 모사
+        fs.writeFileSync(dest, oldContent);
+      }
+    };
+
+    let result;
+    try {
+      result = await update(cwd, { applyAllSafe: true });
+    } finally {
+      fs.copyFileSync = origCopy;
+    }
+
+    // 검증 1: update 가 실패(ok:false) 를 반환 — 부분 실패 감지
+    assert.strictEqual(result.ok, false, 'rollback 감지 시 ok=false 반환');
+    assert.ok(Array.isArray(result.rolledBack), 'rolledBack 배열 포함');
+    assert.ok(result.rolledBack.some((rb) => rb.rel === targetRel), `대상 파일이 rolledBack 에 포함돼야 함: ${JSON.stringify(result.rolledBack)}`);
+
+    // 검증 2: 매니페스트에 기록된 해시는 "이전 해시"(oldSha) 로 유지되어야 함.
+    // 새 업스트림 해시로 갱신되면 안 됨 (해시 위조 방지).
+    const after = readManifest(cwd);
+    assert.ok(after.files[targetRel], '대상 파일 엔트리 존재');
+    assert.strictEqual(
+      after.files[targetRel].sha256,
+      oldSha,
+      `매니페스트 해시가 이전 값으로 유지되어야 함. 실제: ${after.files[targetRel].sha256}, 기대: ${oldSha}`
+    );
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('post-apply 검증: 재-apply 시 롤백된 파일이 modified-pristine 으로 재감지', async () => {
+  const cwd = makeTmpCwd('reapply');
+  try {
+    const targetRel = 'docs/agents-guide.md';
+    const upstreamAbs = path.join(PKG_ROOT, targetRel);
+    if (!fs.existsSync(upstreamAbs)) return;
+
+    const oldContent = '# stale baseline 2\n';
+    seedStaleProject(cwd, { [targetRel]: oldContent });
+
+    // 1차 apply + rollback 모사
+    const origCopy = fs.copyFileSync;
+    fs.copyFileSync = (src, dest) => {
+      origCopy(src, dest);
+      if (path.resolve(dest) === path.resolve(path.join(cwd, targetRel))) {
+        fs.writeFileSync(dest, oldContent);
+      }
+    };
+    try {
+      await update(cwd, { applyAllSafe: true });
+    } finally {
+      fs.copyFileSync = origCopy;
+    }
+
+    // 2차 check — 해당 파일은 여전히 modified-pristine 으로 감지되어야 함
+    const result2 = check(cwd);
+    assert.ok(result2.ok, 'check 성공');
+    const entry = result2.actions.find((a) => a.rel === targetRel);
+    assert.ok(entry, `${targetRel} 이 actions 에 포함돼야 함`);
+    assert.strictEqual(
+      entry.action,
+      'modified-pristine',
+      `재-apply 시 modified-pristine 으로 감지돼야 함. 실제: ${entry.action}`
+    );
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('post-apply 검증: 정상 apply 시 ok=true 반환 + 매니페스트 최신 해시 기록', async () => {
+  const cwd = makeTmpCwd('happy');
+  try {
+    const targetRel = 'docs/agents-guide.md';
+    const upstreamAbs = path.join(PKG_ROOT, targetRel);
+    if (!fs.existsSync(upstreamAbs)) return;
+
+    const oldContent = '# stale baseline 3\n';
+    seedStaleProject(cwd, { [targetRel]: oldContent });
+
+    // rollback 없이 정상 apply
+    const result = await update(cwd, { applyAllSafe: true });
+    assert.strictEqual(result.ok, true, '정상 apply 시 ok=true');
+    assert.strictEqual(result.rolledBack.length, 0, 'rolledBack 이 비어있어야 함');
+
+    const after = readManifest(cwd);
+    const upstreamSha = categoricalSha256(targetRel, upstreamAbs);
+    assert.strictEqual(
+      after.files[targetRel].sha256,
+      upstreamSha,
+      '정상 apply 후 매니페스트 해시가 upstream 과 일치해야 함'
+    );
+  } finally {
+    cleanup(cwd);
+  }
+});


### PR DESCRIPTION
Closes #89
Follow-up: #92

## Summary

- `harness update --apply-all-safe` 에 **post-apply 검증 게이트** 도입 — 파일 적용 직후 upstream 해시와 디스크 실측 해시를 비교하여 외부 프로세스(lint-staged 등)에 의한 롤백을 감지
- 불일치 파일은 매니페스트 해시를 **이전 값으로 유지** → 재-apply 시 `modified-pristine` 으로 재감지되어 교착 해소
- `harness doctor` 에 **"매니페스트 해시 정합성"** 항목 추가 — 해시 위조(매니페스트 최신 ≠ 파일 실측) 감지 시 warn

## Behavior Changes

- `harness update` 가 적용 직후 upstream/디스크 해시 비교를 수행
- 불일치 파일은 매니페스트 해시 갱신을 스킵 (이전 값 유지)
- 부분 실패 시 `ok:false` 반환 → exit code 1 + stderr `harness update: post-apply 검증 실패 N건 — <파일 목록>`
- `harness doctor` 가 "매니페스트 해시 정합성" 항목을 리포트 (pass/warn)
- 정상 경로(검증 성공) 에서는 기존 동작과 완전 동일

## 완료 기준 (이슈 #89)

- [x] apply 대상 파일을 외부에서 revert 시, 해당 파일의 매니페스트 해시가 갱신되지 않는다 — `test/update-verification.test.js:66`
- [x] 재-apply 시 롤백된 파일이 `pristine` 카테고리로 재감지되어 적용된다 — `test/update-verification.test.js:114`
- [x] `harness doctor` 가 "매니페스트-파일 해시 불일치" 항목을 warn 으로 리포트한다 — `test/doctor-hash-integrity.test.js:62`
- [x] `harness update --apply-all-safe` 가 부분 실패 감지 시 exit code 1 + stderr 메시지 출력 — `lib/update.js` `ok: rolledBack.length === 0` 반환 → `bin/harness.js:68` 이 exit code 변환

## Changes

| 파일 | 변경 |
|------|------|
| `lib/update.js` | post-apply 검증 루프 +60줄. merge/delete type 제외. 불일치 시 매니페스트 이전 해시 유지, stderr 경고 |
| `lib/doctor.js` | 매니페스트 해시 정합성 검증 +45줄. categoricalSha256 기반 (managed-block 센티널 외부 편집 오탐 방지) |
| `test/update-verification.test.js` | 신규 — 3케이스 |
| `test/doctor-hash-integrity.test.js` | 신규 — 3케이스 |
| `package.json` | v2.7.2 → **v2.8.0** (MINOR). `scripts.test` 추가 (`node --test`) |
| `CLAUDE.md` | 기존 "매니페스트 최신 ≠ 파일 적용 완료" 섹션에 v2.8.0 개선 내역 1줄 |

## Test Plan

- [x] `npm test` — 6/6 통과 (1.5초)
- [x] `node bin/harness.js doctor` — 하네스 레포 자체에서 정상 실행 (매니페스트 없으면 5b 섹션 skip)
- [x] 한글 U+FFFD 검증 — 의도된 문서 참조만, 깨짐 없음
- [x] Gemini 교차검증 수행 — 합의: 설계 방향/edge case/한계 인식 모두 타당. Gemini 고유 발견 2건은 후속 이슈 #92 로 분리

## 한계 및 후속 (#92)

**post-apply 검증은 `harness update` 종료 직전까지만 유효**. 사용자가 `git commit` 할 때 동작하는 lint-staged pre-commit 훅은 harness update 프로세스 종료 후에 실행되므로 이 시점의 롤백은 업데이트 시점에 못 잡고 **`harness doctor` 로만 감지** 됨. 커밋 시점 롤백의 자가 복구는 후속 이슈 #92 에서 `previousSha256` 필드 도입으로 다룸.

Gemini 가 제안한 merge/managed-block 테스트 보강 2건도 #92 와 함께 처리 예정 (현재 6케이스로 완료 기준 4개는 모두 충족).

🤖 Generated with [Claude Code](https://claude.com/claude-code)