### PR TITLE
feat(update): previousSha256 자가 복구 (#92 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [2.9.0] — 2026-04-18
+
+harness [#92](https://github.com/coseo12/harness-setting/issues/92) Phase 1 — 매니페스트 `previousSha256` 필드 도입으로 **커밋 시점 외부 롤백의 자가 복구**. v2.8.0 의 post-apply 게이트가 잡지 못하던 timing (lint-staged pre-commit 훅 롤백) 을 `harness update --check` 가 스스로 분류한다.
+
+### Added
+
+- **매니페스트 엔트리에 `previousSha256` optional 필드** — `harness update` 완료 시 각 파일의 이전 `sha256` 값을 자동 기록. backward-compatible (필드 부재 매니페스트도 정상 동작, 다음 update 시 자연 채워짐).
+- **`diffAgainstPackage` 자가 복구 분기** — `userSha === previousSha256` 인 파일은 `modified-pristine` 으로 재분류하여 재-apply 허용. 기존 로직에서는 `divergent` (사용자 임의 수정) 로 오분류되어 교착 상태가 되던 케이스를 해소.
+- **테스트 5케이스 추가** — previousSha256 자동 기록 / userSha 매칭 재분류 / 자가 복구 통합 시나리오 / legacy 매니페스트 호환 / sha256 무변화 시 필드 비기록.
+
+### Behavior Changes
+
+- `harness update` 가 완료 시 sha256 이 변경된 파일의 매니페스트 엔트리에 `previousSha256` 필드를 기록한다
+- `harness update --check` 가 `userSha === previousSha256` 인 파일을 **`modified-pristine`** 으로 재분류 (기존: `divergent`)
+- `--apply-all-safe` 가 외부 롤백된 파일을 자동 감지하여 재적용 — **교착 상태가 코드 레벨에서 원천 해소**
+- legacy 매니페스트(필드 부재) 는 별도 migration 스텝 없이 다음 update 에서 자연 채워짐
+
+### Notes
+
+- Phase 2 (후속): `harness doctor` 가 previousSha256 매칭 건을 "외부 롤백 의심" 으로 별도 분류. merge type 스킵 / managed-block 외부 편집 오탐 방지 테스트 보강.
+- 이슈 [#89](https://github.com/coseo12/harness-setting/issues/89) (v2.8.0 post-apply 게이트) 과 상호보완 — v2.8.0 은 update 도중 개입 방어, v2.9.0 은 update 이후 롤백 자가 복구.
+- Gemini 교차검증에서 제안된 근본 해결책을 이슈 [#92](https://github.com/coseo12/harness-setting/issues/92) 로 분리 후 Phase 1 구현.
+- 근거: harness [#92](https://github.com/coseo12/harness-setting/issues/92), volt [#27](https://github.com/coseo12/volt/issues/27)
+
 ## [2.8.0] — 2026-04-18
 
 harness [#89](https://github.com/coseo12/harness-setting/issues/89) 반영 — `harness update --apply-all-safe` post-apply 검증 게이트 + `harness doctor` 매니페스트 해시 정합성 검증. v2.7.2 에서 박제한 "매니페스트 최신 ≠ 파일 적용 완료" 교착 상태를 코드 레벨에서 방어.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -143,7 +143,8 @@ AI가 생성하는 코드에서 반복되는 실패 패턴:
 - 예방 루틴: 패키지 업데이트 커밋 시 매니페스트와 파일을 **동일 커밋**에 묶고, 부분 실패 감지 시 전체 revert + 재시도를 부분 보수보다 우선한다
 - 선행 원인 lint-staged silent partial commit (volt [#13](https://github.com/coseo12/volt/issues/13)) 과 연쇄될 때 가장 자주 관찰됨
 - v2.8.0 (harness [#89](https://github.com/coseo12/harness-setting/issues/89)) 부터 **post-apply 검증 게이트** 도입: 파일 적용 직후 upstream 패키지 해시와 디스크 실측 해시를 비교하여 불일치 파일의 매니페스트 해시는 이전 값으로 유지(재-apply 시 pristine 재감지). 부분 실패 시 exit code 1 + stderr 경고. `harness doctor` 는 "매니페스트 해시 정합성" 항목으로 해시 위조를 감지한다.
-- 근거: volt [#27](https://github.com/coseo12/volt/issues/27). harness 코드 레벨 원자성 개선은 [#89](https://github.com/coseo12/harness-setting/issues/89) 에서 반영
+- v2.9.0 (harness [#92](https://github.com/coseo12/harness-setting/issues/92) Phase 1) 부터 매니페스트에 **`previousSha256`** 필드 자동 기록: `userSha === previousSha256` 인 파일은 `modified-pristine` 으로 재분류되어 `--apply-all-safe` 가 자가 복구한다. v2.8.0 이 못 잡던 타이밍(커밋 시점 lint-staged 롤백) 도 코드 레벨에서 해소.
+- 근거: volt [#27](https://github.com/coseo12/volt/issues/27). harness 코드 레벨 원자성 개선은 [#89](https://github.com/coseo12/harness-setting/issues/89)(v2.8.0) 과 [#92](https://github.com/coseo12/harness-setting/issues/92)(v2.9.0~) 에서 반영
 
 ### sub-agent 검증 완료 ≠ GitHub 박제 완료
 sub-agent(dev/qa 페르소나 등)는 빌드·테스트·브라우저 검증은 수행하면서도 **커밋/푸시/PR 생성/`gh pr comment` 박제** 같은 외부 가시성 단계에서 이탈하는 패턴이 반복된다(4회 관찰). sub-agent 관점 "작업 완료"와 harness 관점 "외부 가시성 있음"이 어긋나 메인 오케스트레이터가 매번 수동 보완해야 했다.

--- a/lib/update.js
+++ b/lib/update.js
@@ -57,6 +57,9 @@ function diffAgainstPackage(cwd, manifest) {
     const userSha = inUser ? categoricalSha256(rel, inUser) : null;
     const pkgSha = inPkg ? categoricalSha256(rel, inPkg) : null;
     const baseSha = inManifest ? inManifest.sha256 : null;
+    // v2.9.0 — previousSha256: 직전 update 에서 기록됐던 sha256.
+    // userSha 가 prevSha 와 일치하면 "외부 요인에 의한 롤백"으로 확정 (#92).
+    const prevSha = inManifest ? inManifest.previousSha256 : null;
 
     let action;
     if (!inManifest && inPkg && !inUser) action = 'added';
@@ -66,10 +69,11 @@ function diffAgainstPackage(cwd, manifest) {
     else if (inManifest && !inUser) action = 'missing-locally';
     else if (userSha === pkgSha) action = 'identical';
     else if (userSha === baseSha) action = 'modified-pristine';
+    else if (prevSha && userSha === prevSha) action = 'modified-pristine'; // 외부 롤백 자가 복구
     else if (pkgSha === baseSha) action = 'user-modified-stable';
     else action = 'divergent';
 
-    actions.push({ rel, category, action, userSha, pkgSha, baseSha });
+    actions.push({ rel, category, action, userSha, pkgSha, baseSha, prevSha });
   }
 
   return actions;
@@ -386,8 +390,21 @@ async function update(cwd = process.cwd(), opts = {}) {
     newManifest.installedAt = manifest.installedAt;
     newManifest.lastUpdatedAt = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
 
+    // v2.9.0 — previousSha256 자동 기록 (#92 자가 복구).
+    // sha256 이 변경된 파일은 "직전 sha256"을 previousSha256 으로 보존해,
+    // 다음 update 에서 사용자 파일이 prevSha 와 일치하면 외부 롤백으로 확정 분류.
+    for (const rel of Object.keys(newManifest.files)) {
+      const prevEntry = manifest.files[rel];
+      if (!prevEntry) continue;
+      const newSha = newManifest.files[rel].sha256;
+      if (prevEntry.sha256 !== newSha) {
+        newManifest.files[rel].previousSha256 = prevEntry.sha256;
+      }
+    }
+
     // rolled-back 파일은 이전 매니페스트 해시로 복원 — 재-apply 시 pristine 으로 재감지되도록.
     // 이전 매니페스트에도 없던 신규 파일이 롤백된 경우 엔트리 자체를 제거한다.
+    // (엔트리를 통째로 교체하므로 previousSha256 도 이전 값 그대로 유지됨)
     for (const rb of rolledBack) {
       if (manifest.files && manifest.files[rb.rel]) {
         newManifest.files[rb.rel] = manifest.files[rb.rel];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"

--- a/test/previous-sha256.test.js
+++ b/test/previous-sha256.test.js
@@ -1,0 +1,224 @@
+'use strict';
+
+/**
+ * previousSha256 자가 복구 — 커밋 시점 외부 롤백에서도 재-apply 성공.
+ *
+ * 시나리오 (v2.8.0 post-apply 게이트가 못 잡는 타이밍 커버):
+ *   1. 사용자 프로젝트에 oldContent 상태의 파일 A + 매니페스트에 oldSha 기록
+ *   2. `harness update --apply-all-safe` 실행 → 파일은 upstream 내용, 매니페스트는
+ *      { sha256: upstreamSha, previousSha256: oldSha } 로 갱신됨
+ *   3. 이 상태로 git commit — 성공
+ *   4. git commit 시점에 lint-staged 같은 외부 프로세스가 A 를 oldContent 로 revert
+ *      (매니페스트는 건드리지 않음)
+ *   5. 다시 `harness update --check` 실행 →
+ *      기존 로직: divergent (사용자 수정) 오분류 → 재-apply 스킵 (교착)
+ *      v2.9.0: userSha === previousSha256 이므로 modified-pristine 으로 재분류 → 재-apply 가능
+ *   6. `harness update --apply-all-safe` 재실행 → A 가 다시 upstream 으로 복원됨
+ *
+ * 이슈 #92 Phase 1
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+const crypto = require('node:crypto');
+
+const { update, check } = require('../lib/update');
+const { readManifest, writeManifest, categoricalSha256 } = require('../lib/manifest');
+
+const PKG_ROOT = path.resolve(__dirname, '..');
+
+function makeTmpCwd(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `harness-prev-${prefix}-`));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+function shaOf(text) {
+  return crypto.createHash('sha256').update(text).digest('hex');
+}
+
+function seedProject(cwd, rel, content) {
+  const abs = path.join(cwd, rel);
+  fs.mkdirSync(path.dirname(abs), { recursive: true });
+  fs.writeFileSync(abs, content);
+}
+
+test('previousSha256: update 완료 후 매니페스트에 이전 sha256 자동 기록', async () => {
+  const cwd = makeTmpCwd('record');
+  try {
+    const targetRel = 'docs/agents-guide.md';
+    const upstreamAbs = path.join(PKG_ROOT, targetRel);
+    if (!fs.existsSync(upstreamAbs)) return;
+
+    const oldContent = '# previousSha256 test 1\n';
+    const oldSha = shaOf(oldContent);
+    seedProject(cwd, targetRel, oldContent);
+    writeManifest(cwd, {
+      harnessVersion: '0.0.1',
+      installedAt: '2020-01-01T00:00:00Z',
+      files: { [targetRel]: { sha256: oldSha, category: 'atomic' } },
+    });
+
+    const result = await update(cwd, { applyAllSafe: true });
+    assert.strictEqual(result.ok, true, 'update 성공');
+
+    const after = readManifest(cwd);
+    const entry = after.files[targetRel];
+    assert.ok(entry, '대상 파일 엔트리 존재');
+    assert.strictEqual(entry.previousSha256, oldSha, 'previousSha256 이 이전 sha256 으로 기록돼야 함');
+    assert.notStrictEqual(entry.sha256, oldSha, '새 sha256 은 upstream 해시');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('previousSha256: userSha === prevSha 면 check 가 modified-pristine 으로 재분류', () => {
+  const cwd = makeTmpCwd('rollback-detect');
+  try {
+    const targetRel = 'docs/agents-guide.md';
+    const upstreamAbs = path.join(PKG_ROOT, targetRel);
+    if (!fs.existsSync(upstreamAbs)) return;
+
+    // 외부 롤백 상태를 수동 시뮬레이션:
+    //   파일 = oldContent (롤백됨), 매니페스트 sha256 = upstreamSha (최신), previousSha256 = oldSha
+    const oldContent = '# previousSha256 test 2 (rolled back)\n';
+    const oldSha = shaOf(oldContent);
+    const upstreamSha = categoricalSha256(targetRel, upstreamAbs);
+
+    seedProject(cwd, targetRel, oldContent);
+    writeManifest(cwd, {
+      harnessVersion: '0.0.1',
+      installedAt: '2020-01-01T00:00:00Z',
+      files: {
+        [targetRel]: {
+          sha256: upstreamSha, // 최신으로 기록돼 있지만 파일은 롤백된 상태
+          previousSha256: oldSha,
+          category: 'atomic',
+        },
+      },
+    });
+
+    const result = check(cwd);
+    assert.ok(result.ok);
+    const entry = result.actions.find((a) => a.rel === targetRel);
+    assert.ok(entry);
+    assert.strictEqual(
+      entry.action,
+      'modified-pristine',
+      `userSha === previousSha256 이면 modified-pristine. 실제: ${entry.action}`
+    );
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('previousSha256: 자가 복구 통합 — 외부 롤백 후 --apply-all-safe 재실행으로 복원', async () => {
+  const cwd = makeTmpCwd('self-heal');
+  try {
+    const targetRel = 'docs/agents-guide.md';
+    const upstreamAbs = path.join(PKG_ROOT, targetRel);
+    if (!fs.existsSync(upstreamAbs)) return;
+    const upstreamContent = fs.readFileSync(upstreamAbs, 'utf8');
+    const upstreamSha = categoricalSha256(targetRel, upstreamAbs);
+
+    const oldContent = '# previousSha256 test 3 (stale)\n';
+    const oldSha = shaOf(oldContent);
+    seedProject(cwd, targetRel, oldContent);
+    writeManifest(cwd, {
+      harnessVersion: '0.0.1',
+      installedAt: '2020-01-01T00:00:00Z',
+      files: { [targetRel]: { sha256: oldSha, category: 'atomic' } },
+    });
+
+    // 1차 update — 정상 apply
+    const first = await update(cwd, { applyAllSafe: true });
+    assert.strictEqual(first.ok, true);
+    const afterFirst = readManifest(cwd);
+    assert.strictEqual(afterFirst.files[targetRel].sha256, upstreamSha);
+    assert.strictEqual(afterFirst.files[targetRel].previousSha256, oldSha);
+
+    // 사용자 외부 롤백 모사 (commit 시점 lint-staged 가 파일만 되돌림, 매니페스트는 유지)
+    fs.writeFileSync(path.join(cwd, targetRel), oldContent);
+
+    // 2차 check — modified-pristine 으로 재감지돼야 함
+    const checkResult = check(cwd);
+    const entry = checkResult.actions.find((a) => a.rel === targetRel);
+    assert.strictEqual(entry.action, 'modified-pristine', '롤백된 파일이 modified-pristine 으로 재감지');
+
+    // 3차 apply — 자가 복구
+    const recover = await update(cwd, { applyAllSafe: true });
+    assert.strictEqual(recover.ok, true);
+    const restored = fs.readFileSync(path.join(cwd, targetRel), 'utf8');
+    assert.strictEqual(restored, upstreamContent, '자가 복구 후 파일이 upstream 과 일치');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('previousSha256: legacy 매니페스트(필드 부재)도 update 후 자연 채움', async () => {
+  const cwd = makeTmpCwd('legacy');
+  try {
+    const targetRel = 'docs/agents-guide.md';
+    const upstreamAbs = path.join(PKG_ROOT, targetRel);
+    if (!fs.existsSync(upstreamAbs)) return;
+
+    const oldContent = '# previousSha256 test 4 (legacy)\n';
+    const oldSha = shaOf(oldContent);
+    seedProject(cwd, targetRel, oldContent);
+    // 레거시 매니페스트: previousSha256 필드 없음
+    writeManifest(cwd, {
+      harnessVersion: '0.0.1',
+      installedAt: '2020-01-01T00:00:00Z',
+      files: { [targetRel]: { sha256: oldSha, category: 'atomic' } },
+    });
+    const before = readManifest(cwd);
+    assert.strictEqual(before.files[targetRel].previousSha256, undefined, '레거시는 필드 없음');
+
+    await update(cwd, { applyAllSafe: true });
+
+    const after = readManifest(cwd);
+    assert.strictEqual(
+      after.files[targetRel].previousSha256,
+      oldSha,
+      'update 후 previousSha256 이 자연 채워져야 함 (migration 스텝 불필요)'
+    );
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('previousSha256: sha256 이 변경되지 않은 update 는 previousSha256 을 새로 쓰지 않음', async () => {
+  const cwd = makeTmpCwd('no-change');
+  try {
+    const targetRel = 'docs/agents-guide.md';
+    const upstreamAbs = path.join(PKG_ROOT, targetRel);
+    if (!fs.existsSync(upstreamAbs)) return;
+    const upstreamSha = categoricalSha256(targetRel, upstreamAbs);
+    const upstreamContent = fs.readFileSync(upstreamAbs, 'utf8');
+
+    // 이미 최신 상태로 시드
+    seedProject(cwd, targetRel, upstreamContent);
+    writeManifest(cwd, {
+      harnessVersion: '0.0.1',
+      installedAt: '2020-01-01T00:00:00Z',
+      files: { [targetRel]: { sha256: upstreamSha, category: 'atomic' } },
+    });
+
+    await update(cwd, { applyAllSafe: true });
+
+    const after = readManifest(cwd);
+    // 변경 없으면 previousSha256 필드가 생성되지 않아야 함 (sha 가 같으므로 의미 없음)
+    assert.strictEqual(
+      after.files[targetRel].previousSha256,
+      undefined,
+      'sha256 변경 없으면 previousSha256 을 새로 기록하지 않음'
+    );
+  } finally {
+    cleanup(cwd);
+  }
+});


### PR DESCRIPTION
Refs: #92 (Phase 1 of 2)
Builds on: #89 (v2.8.0 post-apply 게이트와 상호보완)

## Summary

매니페스트 엔트리에 **`previousSha256`** optional 필드를 자동 기록하고, `userSha === previousSha256` 인 파일을 **`modified-pristine`** 으로 재분류한다. v2.8.0 의 post-apply 게이트가 잡지 못하던 타이밍 (lint-staged pre-commit 훅 롤백) 도 코드 레벨에서 자가 복구된다.

## Behavior Changes

- `harness update` 가 완료 시 sha256 이 변경된 파일의 매니페스트 엔트리에 `previousSha256` 필드를 기록
- `harness update --check` 가 `userSha === previousSha256` 인 파일을 `modified-pristine` 으로 재분류 (기존 로직: `divergent` 오분류)
- `--apply-all-safe` 가 외부 롤백된 파일을 자동 감지하여 재적용 → **교착 상태가 코드 레벨에서 원천 해소**
- legacy 매니페스트(필드 부재) 는 별도 migration 스텝 없이 다음 update 에서 자연 채워짐
- 정상 경로 및 `divergent` (진짜 사용자 수정) 처리에는 영향 없음 (backward-compatible)

## 완료 기준 (Phase 1)

- [x] `.harness/manifest.json` 엔트리에 `previousSha256` optional 필드 추가 — `lib/update.js:369-376`
- [x] `harness update` 완료 시 새 매니페스트에 이전 `sha256` 값 자동 복사
- [x] legacy 매니페스트도 update 실행 시 자연 채움 — `test/previous-sha256.test.js:161`
- [x] `diffAgainstPackage` 분기 추가 — `userSha === previousSha256` → `modified-pristine` — `lib/update.js:72`
- [x] Phase 1 통합 테스트: update → 외부 롤백 → check 재감지 → 재-apply 복원 — `test/previous-sha256.test.js:113`

## Changes

| 파일 | 변경 |
|------|------|
| `lib/update.js` | `diffAgainstPackage` 분기 +2줄, 매니페스트 갱신 단계 previousSha256 기록 +10줄 |
| `test/previous-sha256.test.js` | 신규 — 5케이스 |
| `package.json` | v2.8.0 → **v2.9.0** (MINOR) |
| `CHANGELOG.md` | v2.9.0 entry |
| `CLAUDE.md` | 매니페스트 원자성 섹션에 v2.9.0 개선 1줄 |

## Test Plan

- [x] `npm test` — **11/11 통과** (1.6초)
- [x] 한글 U+FFFD 검증 — 깨짐 없음

## Phase 2 (후속, #92 재사용)

- `harness doctor` 해시 정합성 항목이 previousSha256 매칭 건을 "외부 롤백 의심" 으로 별도 분류
- merge type 스킵 경로 테스트 (#89 교차검증 지적)
- managed-block 센티널 외부 편집 오탐 방지 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)