### PR TITLE
chore(gitignore): .claude/logs/ + test-results/ 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Harness 로그 (상태 파일은 추적)
 .harness/logs/
+.claude/logs/
 
 # OS
 .DS_Store
@@ -18,3 +19,7 @@ Thumbs.db
 
 # Node.js
 node_modules/
+
+# 테스트 산출물 (Playwright, Vitest 등)
+test-results/
+playwright-report/


### PR DESCRIPTION
## Summary

세션 작업 중 관찰된 미-ignore 디렉토리 housekeeping. 릴리스 없이 단순 정리.

- `.claude/logs/` — cross-validate 스킬이 Gemini 응답을 로그로 남기는 경로
- `test-results/` — Playwright 테스트 산출물 (예제 프로젝트용)
- `playwright-report/` — Playwright HTML 리포트 (방어적 추가)

## Behavior Changes

**None** — 추적 대상 파일에 영향 없음. 기존 tracked 파일은 `git ls-files` 로 확인했을 때 0건이라 `git rm --cached` 불필요 (볼트 #13 교훈 준수).

## Test Plan

- [x] `git ls-files` — 새 ignore 패턴에 기존 tracked 파일 없음 확인
- [x] 로컬 working tree clean 상태 유지 (next-env.d.ts Next.js 자동 생성 변경은 원복)

## Notes

- 버전 bump 없음 — 사용자 관찰 가능한 행동 변화가 없고 npm registry 배포 대상도 아님
- CHANGELOG entry 없음 — 순수 housekeeping

🤖 Generated with [Claude Code](https://claude.com/claude-code)