### PR TITLE
feat(release): release PR merge commit 전환 (v2.14.0 준비, #104)

### DIFF
--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -11,16 +11,18 @@ description: |
 
 구현 완료된 feature 브랜치에서 develop 브랜치로의 PR을 생성한다.
 
-## Base 선택 (gitflow)
+## Base 선택 + 머지 방식 (gitflow)
 
-| PR 타입 | base | head | 비고 |
-|---|---|---|---|
-| 일반 feature/fix | `develop` | `feature/*` 또는 `fix/*` | **기본값** — 99% 의 PR 이 이 형태 |
-| Release PR | `main` | `develop` | develop 의 누적 변경을 릴리스 시점에 main 에 1회 머지 |
-| Hotfix PR | `main` | `hotfix/*` | prod 긴급 패치. 머지 직후 merge-back PR 별도 생성 의무 |
-| Hotfix merge-back | `develop` | `main` | hotfix 머지 직후 동기화 전용 |
+| PR 타입 | base | head | 머지 방식 | 비고 |
+|---|---|---|---|---|
+| 일반 feature/fix | `develop` | `feature/*` 또는 `fix/*` | `--squash` | **기본값** — 99% 의 PR 이 이 형태 |
+| Release PR | `main` | `develop` | **`--merge` (merge commit)** | `--squash` 금지. merge-back 원천 방지 (ADR 20260419-release-merge-strategy) |
+| Hotfix PR | `main` | `hotfix/*` | `--squash` 또는 `--merge` | prod 긴급 패치. 머지 직후 merge-back PR 별도 생성 의무 |
+| Hotfix merge-back | `develop` | `main` | `--merge` | hotfix 머지 직후 동기화 전용 |
 
-**금지**: 일반 feature/fix PR 의 `base=main`. 과거 dual PR drift 재발 방지 (ADR 20260419).
+**금지**:
+- 일반 feature/fix PR 의 `base=main` — 과거 dual PR drift 재발 방지 (ADR 20260419-gitflow-main-develop)
+- Release PR 의 `--squash` 머지 — develop drift 유발 (v2.13.0 에서 관찰, v2.14.0 에서 merge commit 으로 전환)
 
 ## 절차
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -35,6 +35,7 @@ PR 타입에 맞는 한 줄만 체크. `base=main` 은 release/hotfix PR 만 허
 - [ ] CHANGELOG `[vX.Y.Z]` entry 작성 (Added / Behavior Changes / Notes)
 - [ ] `package.json` version bump
 - [ ] 태그 계획: `vX.Y.Z` (SemVer 분류 근거 명시)
+- [ ] **`gh pr merge <PR> --merge` (merge commit) 로 머지** — `--squash` 절대 사용 금지 (develop drift 유발, ADR 20260419-release-merge-strategy)
 - [ ] 머지 후 `git tag vX.Y.Z` + `gh release create` 수행 예정
 
 ### Hotfix PR 전용 (base=main, head=hotfix/*)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [2.14.0] — 2026-04-19
+
+Release PR merge 전략 전환 — `--merge` (merge commit) 로 고정하여 매 릴리스마다 강제되던 merge-back PR 을 원천 제거. v2.13.0 (#102) 에서 관찰한 "release 1회 = 3 PR + doctor drift 경고" 구조의 근본 해결. 후속 이슈 [#104](https://github.com/coseo12/harness-setting/issues/104) 해결.
+
+### Added
+
+- **`docs/decisions/20260419-release-merge-strategy.md` ADR** — 옵션 A (merge commit) / B (Action 자동화) / C (현재 유지) 비교 + merge commit 선택 근거 + 재검토 조건 (squash 실수 머지 3회 누적, 또는 대형 stabilization window 필요 시 옵션 재고).
+- **CLAUDE.md 릴리스 워크플로 업데이트** — release PR 에 `gh pr merge <PR> --merge` 사용 명시. `--squash` 금지 + 원리 설명 (main tip 이 develop tip 을 직계 조상으로 포함 → drift 원천 제거). drift 감지 섹션에 "squash 실수 머지" 힌트 추가 (`git show main --format=%P | wc -w` 로 부모 커밋 수 확인).
+- **PR 템플릿 Release PR 섹션 업데이트** — "`gh pr merge <PR> --merge` 로 머지, `--squash` 절대 사용 금지" 체크박스 추가 (ADR 근거 인라인).
+- **`.claude/skills/create-pr/SKILL.md` Base 선택 표 확장** — 머지 방식 컬럼 추가 (일반 feature/fix=squash, Release=merge commit, Hotfix=squash 또는 merge commit, Hotfix merge-back=merge commit). 금지 규칙에 "Release PR 의 squash 머지 금지" 명시.
+- **`harness doctor` drift 경고 문구 세분화** — "hotfix merge-back 누락" + "release PR 직후라면 `--squash` 로 실수 머지한 가능성" + 복구 방법 (merge-back PR 또는 release revert+재머지) 안내.
+
+### Behavior Changes
+
+- Release PR 은 **반드시 `--merge` (merge commit) 방식으로 머지**된다 (이전: `--squash` 사용으로 매 릴리스 drift 발생)
+- Release 후 merge-back PR 이 **불필요**해진다 — main tip 이 develop tip 을 직계 조상으로 포함 (이전: 매 릴리스 1회 sync-only PR 강제)
+- `harness doctor` 의 gitflow drift 경고 문구가 hotfix 누락과 release squash 실수를 구분 안내 (이전: 두 원인이 동일 메시지)
+- `create-pr` 스킬이 PR 타입별 머지 방식을 명시적으로 안내 (이전: 일반 feature/fix 기준 squash 만 안내)
+
+### Notes
+
+- **후속 이슈 해결**: [#104](https://github.com/coseo12/harness-setting/issues/104) 본 PR 로 close. [#106](https://github.com/coseo12/harness-setting/issues/106) 은 release merge-back 이 사라지므로 용어 일반화 불필요 — close 예정.
+- **후속 이슈 유지**: [#105](https://github.com/coseo12/harness-setting/issues/105) (drift 로직 unrelated histories 방어) 는 merge commit 전환과 독립 — 별도 처리. [#107](https://github.com/coseo12/harness-setting/issues/107) 은 Gemini API 복구 후 재시도.
+- **본 릴리스 자체가 새 전략의 첫 적용 사례** — release PR 을 `gh pr merge --merge` 로 머지. 기존 v2.13.0 squash merge 기전의 정반대로 첫 실 운영.
+- 재검토 조건: 6개월 후 (2026-10-19) 1인 + AI 운영에서 실수로 squash 머지한 사례가 3회 이상이면 옵션 B (Action 자동화) 재고.
+- 근거: ADR [20260419-release-merge-strategy.md](docs/decisions/20260419-release-merge-strategy.md), 상위 gitflow 결정 [20260419-gitflow-main-develop.md](docs/decisions/20260419-gitflow-main-develop.md)
+
 ## [2.13.0] — 2026-04-19
 
 gitflow 복원 — `main=배포 / develop=개발` 정석 워크플로로 전환. v2.12.0 이전 dual PR 변형 + 고빈도 작업 압박으로 develop 이 56 커밋 뒤처지는 drift 를 놓친 사례([ADR 20260419](docs/decisions/20260419-gitflow-main-develop.md))의 재발 방지. `harness doctor` 가 main vs develop 격차를 자동 점검한다.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,24 +48,29 @@ develop
 ```
 develop   (충분히 쌓이면)
    ↓ 단일 release PR (base=main, head=develop)
+   ↓ merge commit 방식으로 머지 — gh pr merge <PR> --merge
 main   ← 머지 + 태그 + gh release create
 ```
 - release PR 본문에 CHANGELOG 범위, Behavior Changes, 태그 계획 명시
+- **release PR 은 반드시 `--merge` (merge commit) 방식으로 머지** — `--squash` 금지. squash 로 머지하면 main 에 새 커밋이 생겨 develop 과 diverge 하며 매 릴리스마다 merge-back PR 이 강제된다. merge commit 은 main tip 이 develop tip 을 직계 조상으로 포함하게 하여 **merge-back 이 불필요**해진다. 결정 근거: [ADR 20260419-release-merge-strategy](docs/decisions/20260419-release-merge-strategy.md)
 - **dual PR 재발 방지**: feature/fix PR 은 `base=main` 을 사용하지 않는다 (PR 템플릿 가드)
 
 **3. 핫픽스 (prod 이슈)**
 ```
 hotfix/99-critical   (main 에서 분기)
-   ↓ PR (base=main)
+   ↓ PR (base=main, squash 또는 merge commit 가능)
 main   ← 머지 + 태그 vX.Y.Z+1
    ↓ 즉시 merge-back PR (base=develop, head=main)
 develop   ← 동기화 유지 (누락 시 drift)
 ```
+- hotfix 는 release 경로를 우회하므로 main 이 develop 보다 앞서게 되어 **merge-back 필수**. 이 경우만 merge-back PR 로 develop 을 동기화
+- merge commit 으로 release 를 해온 정상 운영에서는 hotfix 빈도가 적으므로 merge-back 오버헤드도 최소
 
 ### drift 감지
 - `harness doctor` 의 "gitflow 브랜치 정합성" 항목이 `origin/main` vs `origin/develop` 커밋 격차를 점검한다
-- 경고 조건: (a) `develop < main` 상태 (hotfix merge-back 누락 신호), (b) 둘 사이에 공통 조상이 없거나 fetch 실패
+- 경고 조건: `develop < main` 상태 (hotfix merge-back 누락 신호 — release PR 을 merge commit 으로 처리하면 원칙적으로 발생하지 않음)
 - 정상: `develop` 이 `main` 보다 앞섬 (다음 릴리스 대기) 또는 동일 커밋 (릴리스 직후)
+- 경고가 release 직후에 발생하면 **release PR 을 실수로 `--squash` 로 머지** 했을 가능성. `git show main --format=%P | wc -w` 로 merge commit 여부 확인 (2 이면 merge commit, 1 이면 squash)
 
 ## 커밋 컨벤션
 ```

--- a/docs/decisions/20260419-release-merge-strategy.md
+++ b/docs/decisions/20260419-release-merge-strategy.md
@@ -1,0 +1,75 @@
+# ADR: Release PR merge 전략 — merge commit 채택
+
+- 날짜: 2026-04-19
+- 상태: Accepted
+- 관련 이슈/PR: [#104](https://github.com/coseo12/harness-setting/issues/104), v2.14.0 PR
+- 선행 ADR: [20260419-gitflow-main-develop.md](20260419-gitflow-main-develop.md) (상위 gitflow 결정)
+
+## 배경
+
+v2.13.0 gitflow 복원 후 첫 릴리스 (PR #102 develop → main) 에서 **release PR 을 squash merge 하자 매번 merge-back PR 이 강제되는 구조** 가 드러났다. v2.13.0 릴리스만으로 3개 PR (#101 feature → develop, #102 release squash, #103 merge-back merge commit) 이 필요했고, 그중 #103 은 새 코드 변경이 없는 sync-only PR 이었다.
+
+### 근본 기전
+
+- squash merge 는 main 에 **새 squash commit** 을 생성한다
+- 이 commit 의 부모는 이전 main tip 하나뿐 — develop tip 을 조상으로 포함하지 않음
+- 결과: `main..develop = 0`, `develop..main = 1` → `harness doctor` 가 "gitflow 브랜치 정합성: main 이 develop 보다 앞섬" 으로 drift 경고
+- 해소 방법이 merge-back PR 밖에 없음 (force-push 는 CRITICAL #5 위반)
+
+### 운영 부담
+
+매 릴리스마다 3 PR. 연 10 릴리스 기준 연간 10개 추가 PR + doctor 경고 노이즈.
+
+## 후보 비교
+
+| 축 | A. Release PR merge commit | B. GitHub Action 자동 merge-back | C. 현재 유지 (수동 merge-back) |
+|---|---|---|---|
+| 초기 구현 | 거의 0 — 문서 규칙만 | 중간 — Action 1개 + 테스트 | 0 |
+| 유지 비용 (연간) | 0 | 저-중 — Action 디버깅/업데이트 | 릴리스마다 +1 PR |
+| main 히스토리 가독성 | 저하 — feature 커밋 섞임 | 양호 — release squash 1 줄 | 양호 |
+| doctor drift 로직 영향 | **drift 없음 (원천 제거)** | drift 발생 → Action 이 해소 | drift 발생 → 수동 해소 |
+| 회귀 위험 | 낮음 (GitHub 네이티브 지원) | 중간 (Action 실패 시 drift 방치) | 낮음 |
+| AI 에이전트 친화도 | 최고 — 단계 단순 | 중간 — 실패 복구 판단 필요 | 낮음 — 매번 판단 |
+| 릴리스 1회당 PR 수 | **2** (feature→dev, release→main) | 3 | 3 |
+| 실패 시 복구 | 자연 동기화 (불필요) | 수동 fallback | 원래 수동 |
+
+## 결정
+
+**A. Release PR 을 merge commit 방식으로 머지** 채택.
+
+- `gh pr merge <PR> --merge` 사용 (repo 기본 merge 전략은 squash 유지 — feature PR 에만 적용)
+- 일반 feature/fix PR 은 변경 없이 squash 유지
+- hotfix 는 기존 방식 유지 (main 분기 → main PR → merge-back PR). hotfix 는 main 이 develop 을 선행하는 정상 사례이므로 merge-back 불가피
+- PR 템플릿 / CLAUDE.md / create-pr 스킬 / doctor 경고 문구에 "release PR 은 merge commit" 규칙 박제
+
+### 근거
+
+1. v2.13.0 실 운영에서 merge-back PR 은 **내용 없는 sync-only PR** 로 확인됨 — 필요성 자체를 제거하는 것이 근본 해결
+2. 1인 + AI 페어 환경에서 GitHub Action 디버깅 비용이 비싸고, A 는 구현 비용 0
+3. main 로그 가독성 저하는 `gh release` 페이지 + CHANGELOG + `git log --first-parent main` 로 보완 가능
+4. Behavior Changes 가 PR 본문에 기록되므로 release merge commit 메시지가 아니라 PR 추적으로 릴리스 요약 접근
+
+### 채택하지 않은 옵션의 재검토 조건
+
+- **옵션 B (자동화 Action)**: 릴리스 빈도가 주당 3회 이상이 되고 merge commit 실수로 `--squash` 머지가 3회 이상 반복되면 Action 자동화 재고
+- **옵션 C (수동 merge-back)**: 채택 안 함. 매 릴리스마다 강제되는 sync-only PR 은 정보 가치 0
+
+## 결과 / Behavior Changes
+
+- CLAUDE.md 릴리스 워크플로에 "`gh pr merge <PR> --merge` 사용, `--squash` 금지" 명시
+- PR 템플릿 Release PR 섹션에 "merge commit 방식으로 머지" 체크박스 추가. merge-back 체크박스는 hotfix 전용으로 복원
+- create-pr 스킬 Base 선택 표에 머지 방식 컬럼 추가 (release=merge commit, 그 외=squash)
+- doctor 경고 문구에 "release PR 을 실수로 squash 머지한 가능성" 힌트 추가
+- 후속 이슈 #106 (PR 템플릿 merge-back 용어 일반화) 는 **불필요** — release merge-back 이 사라지므로 hotfix 전용 용어 유지
+
+## 재검토 조건
+
+- **6개월 후 (2026-10-19)**: 실제 1인 + AI 운영에서 실수로 squash 머지한 사례가 3회 이상이면 옵션 B (Action 자동화) 재고
+- **main 로그 가독성 불만 누적 시**: `git log --first-parent main --oneline` 을 기본 조회 명령으로 CLAUDE.md 에 박제하여 완화. 그래도 불만이면 옵션 C 복귀 검토
+- **대형 stabilization window 필요 시**: release branch 도입 (`release/vX.Y.Z` → main + develop 양쪽 머지) 으로 확장. 현재 구조의 자연스러운 진화 경로
+
+## 참고
+
+- 상위 gitflow 결정: [20260419-gitflow-main-develop.md](20260419-gitflow-main-develop.md)
+- v2.13.0 실 사례: PR [#101](https://github.com/coseo12/harness-setting/pull/101), [#102](https://github.com/coseo12/harness-setting/pull/102), [#103](https://github.com/coseo12/harness-setting/pull/103)
+- 후속 이슈: [#104](https://github.com/coseo12/harness-setting/issues/104) (본 ADR 이 해결), [#106](https://github.com/coseo12/harness-setting/issues/106) (불필요로 전환), [#105](https://github.com/coseo12/harness-setting/issues/105) (drift 로직 별도)

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -75,7 +75,7 @@ function classifyGitflowDrift(mainAhead, devAhead) {
   }
   return {
     status: 'warn',
-    detail: `main 이 develop 보다 ${mainAhead} 커밋 앞섬 — hotfix merge-back 누락 또는 release squash 동기화 누락 의심. \`git push origin main:develop\` 또는 merge-back PR 로 동기화 권장`,
+    detail: `main 이 develop 보다 ${mainAhead} 커밋 앞섬 — hotfix merge-back 누락 의심. release PR 직후라면 \`--squash\` 로 실수 머지한 가능성 (ADR: release PR 은 \`--merge\` 필수). merge-back PR 또는 release PR revert+재머지 로 복구`,
   };
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.13.0",
+  "version": "2.14.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Summary

#104 해결. Release PR 을 `--merge` (merge commit) 방식으로 고정하여 v2.13.0 에서 관찰된 "release 1회 = 3 PR + doctor drift" 구조의 근본 해결.

- **Closes**: #104
- **릴리스 분류**: MINOR (에이전트 행동 규칙 변경 — release PR 머지 방식 변경)

## 브랜치 / Base 확인 (gitflow)
- [x] **일반 feature/fix**: base=develop, head=feature/104-release-merge-commit

## 변경 사항

1. **ADR 신규** — `docs/decisions/20260419-release-merge-strategy.md` (옵션 A/B/C 비교 + merge commit 선택 근거)
2. **CLAUDE.md 릴리스 워크플로** — `gh pr merge --merge` 명시, `--squash` 금지, drift 감지 섹션에 squash 실수 힌트
3. **PR 템플릿 Release PR 섹션** — merge commit 체크박스 추가
4. **create-pr 스킬 Base 선택 표** — 머지 방식 컬럼 추가 (일반=squash, release=merge commit, hotfix=모두, merge-back=merge commit)
5. **harness doctor 경고 문구** — hotfix 누락 / release squash 실수 구분 안내

## Behavior Changes

- Release PR 은 반드시 `--merge` (merge commit) 방식으로 머지 (이전: squash)
- 매 릴리스마다 강제되던 merge-back PR 원천 제거 (이전: release 1회 = 3 PR)
- doctor drift 경고가 hotfix/release 원인 구분 안내

## 후속 이슈 상태

- **#104**: 본 PR 로 close (이 PR 이 직접 해결)
- **#106**: release merge-back 이 사라지므로 용어 일반화 불필요 → v2.14.0 릴리스 후 close
- **#105** (drift 로직): 본 PR 과 독립 — 별도 진행
- **#107** (Gemini 재검증): 본 ADR 박제 직후 cross-validate 루틴 수행 예정 (같은 이슈에 통합 가능)

## Test Plan

- [x] `npm test` — 22 PASS (doctor 문구 변경 후에도 기존 regex 테스트 통과 — "hotfix merge-back 누락" / "merge-back PR" 키워드 보존)
- [x] `node bin/harness.js doctor` 실행 — gitflow 브랜치 정합성 pass 확인
- [x] U+FFFD 검증 — 기존 규정 문구 외 깨짐 없음
- [x] 파일명 규칙 (kebab-case) 준수
- [x] CHANGELOG v2.14.0 entry + Behavior Changes 작성
- [x] package.json 2.13.0 → 2.14.0 bump

## 다음 단계 (본 PR 머지 후 — 새 전략 첫 적용)

1. Release PR 생성 (base=main, head=develop)
2. **`gh pr merge <PR> --merge` 로 머지** (첫 merge commit 릴리스 사례)
3. v2.14.0 태그 + gh release create
4. doctor 재실행하여 drift 발생하지 않음 확인 (새 전략 검증)
5. #106 close + #107 cross-validate 재시도

🤖 Generated with [Claude Code](https://claude.com/claude-code)