### PR TITLE
docs(harness): sub-agent 체크리스트 블록 불릿 분리 (closes #118)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [Unreleased]
+
+### Added
+
+- **CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 블록 불릿 분리** — "한 불릿 = 한 규칙" 컨벤션 수렴. 기존 3개 논리 혼합 불릿(메인 확인 명령 / GitHub 명령 세트 / keyword 문법 연결)을 3개 독립 불릿으로 분리. 향후 수정 시 개별 규칙 참조 용이.
+
+### Behavior Changes: None — 문서만
+
+구조 리팩토링. 에이전트·스킬 행동 변화 없음. 기존 규칙 3개가 독립 불릿으로 표기 방식만 변경됨.
+
+### Notes
+
+- **이슈 해결**: [#118](https://github.com/coseo12/harness-setting/issues/118) 본 릴리스로 close (v2.16.0 PR #117 reviewer non-blocking 권고 5 의 분리 이슈).
+- PATCH — `Builds on: #117`.
+
 ## [2.16.0] — 2026-04-19
 
 volt [#40](https://github.com/coseo12/volt/issues/40) + [#41](https://github.com/coseo12/volt/issues/41) 반영. GitHub auto-close keyword 문법 가드 + Gemini cross-validate 429 폴백 프로토콜. 조용한 누락(**이슈 OPEN 잔존** = 커밋 메시지 keyword 오문법으로 auto-close 실패 / **박제 직후 cross-validate 루틴을 단일 모델 편향 노출 기회가 가장 큰 시점에 포기** = Gemini 429 로 즉시 Claude 단독 폴백 후 흔적 없이 사라짐) 을 구조적으로 방어. 박제 직후 cross-validate (Gemini) 정상 수신 후 앵커 2 확장 + 박제 위치 우선순위 반영. follow-up 이슈 [#118](https://github.com/coseo12/harness-setting/issues/118) (CLAUDE.md 불릿 분리) / [#119](https://github.com/coseo12/harness-setting/issues/119) (sub-agent 프롬프트 하드코딩) 분리.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,12 @@ AI가 생성하는 코드에서 반복되는 실패 패턴:
 ### sub-agent 검증 완료 ≠ GitHub 박제 완료
 sub-agent(dev/qa 페르소나 등)는 빌드·테스트·브라우저 검증은 수행하면서도 **커밋/푸시/PR 생성/`gh pr comment` 박제** 같은 외부 가시성 단계에서 이탈하는 패턴이 반복된다(4회 관찰). sub-agent 관점 "작업 완료"와 harness 관점 "외부 가시성 있음"이 어긋나 메인 오케스트레이터가 매번 수동 보완해야 했다.
 
-- sub-agent 위임은 **"검증"까지는 신뢰하되 "박제"는 신뢰하지 말 것** — 메인 컨텍스트가 sub-agent 보고 수신 직후 `git log --oneline -1` / `gh pr list` / `gh pr view <번호> --json comments` / `gh issue view <auto-close 대상> --json state` 로 GitHub 상태를 직접 확인한다 (auto-close 검증은 PR 규칙 섹션 keyword 문법 가드와 연결 — `Closes: #A, #B` 콜론 문법은 #B 미인식)
+- sub-agent 위임은 **"검증"까지는 신뢰하되 "박제"는 신뢰하지 말 것** — sub-agent 의 보고는 의도이고 실제 외부 가시성은 별도
+- **메인이 직접 확인할 GitHub 명령 세트** — sub-agent 보고 수신 직후 메인 컨텍스트가 다음을 실행:
+  - `git log --oneline -1` — 커밋이 실제 반영됐는지
+  - `gh pr list` / `gh pr view <번호> --json comments` — PR·코멘트 박제 여부
+  - `gh issue view <auto-close 대상> --json state` — auto-close 실제 성공 여부
+- **auto-close 검증은 PR 규칙 섹션 keyword 문법 가드와 연결** — `Closes: #A, #B` 같은 콜론 문법은 #B 미인식 (PR 규칙 참조). 문법이 틀려도 sub-agent 는 "close 완료" 로 보고하므로 메인이 state 를 직접 확인
 - sub-agent 프롬프트 말미에 **마무리 체크리스트 JSON 반환** 을 요구한다 — 커밋 SHA / PR URL / 코멘트 URL / 라벨 전이 결과 / **auto-close 대상 이슈의 실제 state** 를 field로 명시해 누락을 구조적으로 감지
 - 누락 감지 시 메인이 직접 보완 박제 (커밋/PR/코멘트). sub-agent를 재호출해 같은 누락을 반복시키지 않는다
 - 근거: volt [#24](https://github.com/coseo12/volt/issues/24) — astro-simulator P6-B~E 에서 dev/qa sub-agent 마무리 단계 누락 4회 연속 관찰


### PR DESCRIPTION
## Summary

v2.16.0 (PR #117) reviewer non-blocking 권고 5 에서 분리된 follow-up. CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 블록의 **한 불릿 3개 논리 혼합** 을 분리하여 "한 불릿 = 한 규칙" 컨벤션에 수렴.

## Before / After

**Before** (3개 논리 혼합):

```
- sub-agent 위임은 "검증까지는 신뢰, 박제는 신뢰하지 말 것" — 메인 컨텍스트가 
  sub-agent 보고 수신 직후 git log / gh pr list / gh pr view / gh issue view 로 
  GitHub 상태를 직접 확인한다 (auto-close 검증은 PR 규칙 섹션 keyword 문법 가드와 
  연결 — Closes: #A, #B 콜론 문법은 #B 미인식)
```

**After** (3개 독립 불릿):

```
- 위임 신뢰 원칙 (불릿 1)
- 메인이 실행할 GitHub 명령 세트 3종 (불릿 2, 하위 bullet 3)
- auto-close 검증과 PR 규칙 keyword 가드의 연결 (불릿 3)
```

## 분류: PATCH

**Behavior Changes: None — 문서 구조만**. 에이전트가 실행하는 명령 세트도 동일, 규칙 내용도 동일, 표기 방식만 분리.

## 완료 기준

- [x] 한 불릿 3개 논리를 3개 독립 불릿으로 분리
- [x] 각 불릿이 "한 규칙" 에 대응 (명령 세트 불릿은 하위 bullet 로 세부 명시)
- [x] 행동 변화 없음 확인 (diff 로 규칙 변화 0)
- [x] CHANGELOG Unreleased PATCH entry + `Behavior Changes: None` 명시

## 비목표

- 규칙 내용 수정 (금지 — 순수 구조 리팩토링)
- 다른 sub-agent 블록 (`sub-agent multi-turn 라운드 이탈`) 리팩토링 (별도 이슈)
- auto-close 검증 루틴 자체 변경

## Test plan

- [x] `grep -n '�' CLAUDE.md` U+FFFD 0건
- [x] diff 확인 — 신규 내용 없이 불릿 구조만 변경됨

## 근거

- Closes [#118](https://github.com/coseo12/harness-setting/issues/118)
- `Builds on:` [#117](https://github.com/coseo12/harness-setting/pull/117) (v2.16.0)
- reviewer non-blocking 권고 5 ("한 불릿이 명령·연결성·문법가드 3개 논리를 품고 있어 향후 수정 시 분리 고려")

🤖 Generated with [Claude Code](https://claude.com/claude-code)