### PR TITLE
docs(harness): 실전 교훈 블록 포인터 포맷 컨벤션 명시 (closes #114)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,16 @@
 ### Added
 
 - **CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 블록 불릿 분리** — "한 불릿 = 한 규칙" 컨벤션 수렴. 기존 3개 논리 혼합 불릿(메인 확인 명령 / GitHub 명령 세트 / keyword 문법 연결)을 3개 독립 불릿으로 분리. 향후 수정 시 개별 규칙 참조 용이.
+- **CLAUDE.md `## 실전 교훈` 도입부에 "블록 내 포인터 포맷 컨벤션" 명시** — 각 블록 말미의 `- 일반화된 설계 지식: [경로](링크) — 한 줄 요약` 포인터 포맷과 위치를 통일. 승격된 지식이 있을 때만 추가하고 빈 placeholder 는 금지 (없으면 생략). 기존 포인터 1건(매니페스트 블록)이 이미 컨벤션과 일치함을 확인.
 
 ### Behavior Changes: None — 문서만
 
-구조 리팩토링. 에이전트·스킬 행동 변화 없음. 기존 규칙 3개가 독립 불릿으로 표기 방식만 변경됨.
+구조 리팩토링 + 컨벤션 명시. 에이전트·스킬 행동 변화 없음. 기존 규칙 3개가 독립 불릿으로 표기 방식만 변경되고, 실전 교훈 섹션에 포맷 가이드만 추가.
 
 ### Notes
 
-- **이슈 해결**: [#118](https://github.com/coseo12/harness-setting/issues/118) 본 릴리스로 close (v2.16.0 PR #117 reviewer non-blocking 권고 5 의 분리 이슈).
-- PATCH — `Builds on: #117`.
+- **이슈 해결**: [#118](https://github.com/coseo12/harness-setting/issues/118) (sub-agent 블록 불릿 분리) + [#114](https://github.com/coseo12/harness-setting/issues/114) (실전 교훈 블록 링크 일관성) 본 릴리스로 close. 둘 다 v2.16.0 PR #117 / v2.15.1 PR #113 reviewer non-blocking 권고의 분리 이슈.
+- PATCH — `Builds on: #117 #113`.
 
 ## [2.16.0] — 2026-04-19
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,8 @@ UI가 포함된 작업에서 4축으로 품질을 평가한다:
 <!-- harness:managed:real-lessons:start -->
 ## 실전 교훈 (portfolio-26, simple-shop 등에서 추출)
 
+> **블록 내 포인터 포맷 컨벤션**: 각 실전 교훈 블록은 내용 불릿 → `근거:` 불릿 → (선택) `일반화된 설계 지식:` 불릿 순서로 마감한다. `docs/architecture/` 나 `docs/decisions/` 로 승격된 지식이 있을 때만 마지막 포인터를 추가하고, 없으면 생략한다 (빈 placeholder 금지). 형식: `- 일반화된 설계 지식: [docs/architecture/<파일>.md](경로) — 한 줄 요약`. 근거: PR [#113](https://github.com/coseo12/harness-setting/pull/113) reviewer 권고 3, 이슈 [#114](https://github.com/coseo12/harness-setting/issues/114).
+
 ### 빌드 성공 ≠ 동작하는 앱
 빌드 통과 + 단위 테스트 통과여도 실제 브라우저에서 동작하지 않는 경우가 빈번하다.
 커밋 전 반드시 브라우저에서 3단계 검증을 수행한다:


### PR DESCRIPTION
## Summary

v2.15.1 (PR #113) reviewer non-blocking 권고 3 에서 분리된 follow-up. CLAUDE.md `## 실전 교훈` 섹션 도입부에 **블록 내 포인터 포맷 컨벤션** 을 한 줄로 명시. 향후 `docs/architecture/` 또는 `docs/decisions/` 로 지식이 승격될 때마다 같은 포맷으로 포인터가 추가되도록 구조적 가드.

## 컨벤션

- **위치**: 내용 불릿 → `근거:` 불릿 → (선택) `- 일반화된 설계 지식:` 불릿 순서
- **형식**: `- 일반화된 설계 지식: [docs/architecture/<파일>.md](경로) — 한 줄 요약`
- **없으면 생략** (빈 placeholder 금지)

## 기존 포인터 검증

현재 유일한 포인터 (v2.15.1 에서 추가된 `매니페스트 최신 ≠ 파일 적용 완료` 블록, CLAUDE.md:227) 는 이 컨벤션과 **이미 일치**. 수정 불필요.

## 분류: PATCH

**Behavior Changes: None — 컨벤션 명시만**. 에이전트 동작 경로 변경 없음. 새 규칙 강제력은 향후 일반화 문서 추가 시점에 발동.

## 완료 기준

- [x] 실전 교훈 섹션 도입부에 포맷 가이드 한 줄 추가
- [x] 기존 포인터 1건이 컨벤션에 일치하는지 검증
- [x] 현재 일반화 문서가 없는 블록에 placeholder 추가하지 않음 (빈 placeholder 금지 규칙)
- [x] diff 로 행동 변화 없음 확인

## 비목표

- 기존 실전 교훈 블록 내용 수정
- 새 일반화 문서 작성 (별도 이슈)
- 실전 교훈 섹션 외 다른 섹션 리팩토링

## Test plan

- [x] `grep -n '�' CLAUDE.md CHANGELOG.md` U+FFFD 0건
- [x] `grep -n "일반화된 설계 지식" CLAUDE.md` — 컨벤션 선언부 + 기존 포인터 1건 둘 다 컨벤션 일치

## 근거

- Closes [#114](https://github.com/coseo12/harness-setting/issues/114)
- `Builds on:` [#113](https://github.com/coseo12/harness-setting/pull/113) (v2.15.1)
- reviewer non-blocking 권고 3 ("CLAUDE.md 실전 교훈 블록 말미 포인터 링크 일관성 리팩토링")

🤖 Generated with [Claude Code](https://claude.com/claude-code)