### PR TITLE
release: v2.16.1 — #118 #114 PATCH 묶음 (Behavior Changes: None)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,15 +12,16 @@
 ### Added
 
 - **CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 블록 불릿 분리** — "한 불릿 = 한 규칙" 컨벤션 수렴. 기존 3개 논리 혼합 불릿(메인 확인 명령 / GitHub 명령 세트 / keyword 문법 연결)을 3개 독립 불릿으로 분리. 향후 수정 시 개별 규칙 참조 용이.
+- **CLAUDE.md `## 실전 교훈` 도입부에 "블록 내 포인터 포맷 컨벤션" 명시** — 각 블록 말미의 `- 일반화된 설계 지식: [경로](링크) — 한 줄 요약` 포인터 포맷과 위치를 통일. 승격된 지식이 있을 때만 추가하고 빈 placeholder 는 금지 (없으면 생략). 기존 포인터 1건(매니페스트 블록)이 이미 컨벤션과 일치함을 확인.
 
 ### Behavior Changes: None — 문서만
 
-구조 리팩토링. 에이전트·스킬 행동 변화 없음. 기존 규칙 3개가 독립 불릿으로 표기 방식만 변경됨.
+구조 리팩토링 + 컨벤션 명시. 에이전트·스킬 행동 변화 없음. 기존 규칙 3개가 독립 불릿으로 표기 방식만 변경되고, 실전 교훈 섹션에 포맷 가이드만 추가.
 
 ### Notes
 
-- **이슈 해결**: [#118](https://github.com/coseo12/harness-setting/issues/118) 본 릴리스로 close (v2.16.0 PR #117 reviewer non-blocking 권고 5 의 분리 이슈).
-- PATCH — `Builds on: #117`.
+- **이슈 해결**: [#118](https://github.com/coseo12/harness-setting/issues/118) (sub-agent 블록 불릿 분리) + [#114](https://github.com/coseo12/harness-setting/issues/114) (실전 교훈 블록 링크 일관성) 본 릴리스로 close. 둘 다 v2.16.0 PR #117 / v2.15.1 PR #113 reviewer non-blocking 권고의 분리 이슈.
+- PATCH — `Builds on: #117 #113`.
 
 ## [2.16.0] — 2026-04-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [Unreleased]
+
+### Added
+
+- **CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 블록 불릿 분리** — "한 불릿 = 한 규칙" 컨벤션 수렴. 기존 3개 논리 혼합 불릿(메인 확인 명령 / GitHub 명령 세트 / keyword 문법 연결)을 3개 독립 불릿으로 분리. 향후 수정 시 개별 규칙 참조 용이.
+
+### Behavior Changes: None — 문서만
+
+구조 리팩토링. 에이전트·스킬 행동 변화 없음. 기존 규칙 3개가 독립 불릿으로 표기 방식만 변경됨.
+
+### Notes
+
+- **이슈 해결**: [#118](https://github.com/coseo12/harness-setting/issues/118) 본 릴리스로 close (v2.16.0 PR #117 reviewer non-blocking 권고 5 의 분리 이슈).
+- PATCH — `Builds on: #117`.
+
 ## [2.16.0] — 2026-04-19
 
 volt [#40](https://github.com/coseo12/volt/issues/40) + [#41](https://github.com/coseo12/volt/issues/41) 반영. GitHub auto-close keyword 문법 가드 + Gemini cross-validate 429 폴백 프로토콜. 조용한 누락(**이슈 OPEN 잔존** = 커밋 메시지 keyword 오문법으로 auto-close 실패 / **박제 직후 cross-validate 루틴을 단일 모델 편향 노출 기회가 가장 큰 시점에 포기** = Gemini 429 로 즉시 Claude 단독 폴백 후 흔적 없이 사라짐) 을 구조적으로 방어. 박제 직후 cross-validate (Gemini) 정상 수신 후 앵커 2 확장 + 박제 위치 우선순위 반영. follow-up 이슈 [#118](https://github.com/coseo12/harness-setting/issues/118) (CLAUDE.md 불릿 분리) / [#119](https://github.com/coseo12/harness-setting/issues/119) (sub-agent 프롬프트 하드코딩) 분리.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
-## [Unreleased]
+## [2.16.1] — 2026-04-19
+
+v2.16.0 reviewer non-blocking 권고에서 분리된 두 PATCH 이슈(#118 sub-agent 블록 불릿 분리 / #114 실전 교훈 포인터 포맷 컨벤션) 을 묶어 정리. 구조 리팩토링 + 컨벤션 명시만.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,6 +155,8 @@ UI가 포함된 작업에서 4축으로 품질을 평가한다:
 <!-- harness:managed:real-lessons:start -->
 ## 실전 교훈 (portfolio-26, simple-shop 등에서 추출)
 
+> **블록 내 포인터 포맷 컨벤션**: 각 실전 교훈 블록은 내용 불릿 → `근거:` 불릿 → (선택) `일반화된 설계 지식:` 불릿 순서로 마감한다. `docs/architecture/` 나 `docs/decisions/` 로 승격된 지식이 있을 때만 마지막 포인터를 추가하고, 없으면 생략한다 (빈 placeholder 금지). 형식: `- 일반화된 설계 지식: [docs/architecture/<파일>.md](경로) — 한 줄 요약`. 근거: PR [#113](https://github.com/coseo12/harness-setting/pull/113) reviewer 권고 3, 이슈 [#114](https://github.com/coseo12/harness-setting/issues/114).
+
 ### 빌드 성공 ≠ 동작하는 앱
 빌드 통과 + 단위 테스트 통과여도 실제 브라우저에서 동작하지 않는 경우가 빈번하다.
 커밋 전 반드시 브라우저에서 3단계 검증을 수행한다:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,12 @@ AI가 생성하는 코드에서 반복되는 실패 패턴:
 ### sub-agent 검증 완료 ≠ GitHub 박제 완료
 sub-agent(dev/qa 페르소나 등)는 빌드·테스트·브라우저 검증은 수행하면서도 **커밋/푸시/PR 생성/`gh pr comment` 박제** 같은 외부 가시성 단계에서 이탈하는 패턴이 반복된다(4회 관찰). sub-agent 관점 "작업 완료"와 harness 관점 "외부 가시성 있음"이 어긋나 메인 오케스트레이터가 매번 수동 보완해야 했다.
 
-- sub-agent 위임은 **"검증"까지는 신뢰하되 "박제"는 신뢰하지 말 것** — 메인 컨텍스트가 sub-agent 보고 수신 직후 `git log --oneline -1` / `gh pr list` / `gh pr view <번호> --json comments` / `gh issue view <auto-close 대상> --json state` 로 GitHub 상태를 직접 확인한다 (auto-close 검증은 PR 규칙 섹션 keyword 문법 가드와 연결 — `Closes: #A, #B` 콜론 문법은 #B 미인식)
+- sub-agent 위임은 **"검증"까지는 신뢰하되 "박제"는 신뢰하지 말 것** — sub-agent 의 보고는 의도이고 실제 외부 가시성은 별도
+- **메인이 직접 확인할 GitHub 명령 세트** — sub-agent 보고 수신 직후 메인 컨텍스트가 다음을 실행:
+  - `git log --oneline -1` — 커밋이 실제 반영됐는지
+  - `gh pr list` / `gh pr view <번호> --json comments` — PR·코멘트 박제 여부
+  - `gh issue view <auto-close 대상> --json state` — auto-close 실제 성공 여부
+- **auto-close 검증은 PR 규칙 섹션 keyword 문법 가드와 연결** — `Closes: #A, #B` 같은 콜론 문법은 #B 미인식 (PR 규칙 참조). 문법이 틀려도 sub-agent 는 "close 완료" 로 보고하므로 메인이 state 를 직접 확인
 - sub-agent 프롬프트 말미에 **마무리 체크리스트 JSON 반환** 을 요구한다 — 커밋 SHA / PR URL / 코멘트 URL / 라벨 전이 결과 / **auto-close 대상 이슈의 실제 state** 를 field로 명시해 누락을 구조적으로 감지
 - 누락 감지 시 메인이 직접 보완 박제 (커밋/PR/코멘트). sub-agent를 재호출해 같은 누락을 반복시키지 않는다
 - 근거: volt [#24](https://github.com/coseo12/volt/issues/24) — astro-simulator P6-B~E 에서 dev/qa sub-agent 마무리 단계 누락 4회 연속 관찰

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Release 범위

v2.16.0 → v2.16.1. **PATCH — 문서 구조만, 행동 변화 없음**.

| 커밋 | PR | 요약 |
|---|---|---|
| 65ef8788 | [#122](https://github.com/coseo12/harness-setting/pull/122) | Closes #118 — sub-agent 블록 불릿 분리 (한 불릿 = 한 규칙) |
| 3b2486e5 | [#123](https://github.com/coseo12/harness-setting/pull/123) | Closes #114 — 실전 교훈 포인터 포맷 컨벤션 명시 |
| 217f3188 | [#124](https://github.com/coseo12/harness-setting/pull/124) | chore — CHANGELOG `[2.16.1]` + package.json 2.16.1 |

## Behavior Changes

**None — 문서 구조 리팩토링 + 컨벤션 명시만**. 에이전트·스킬 동작 경로 변경 없음. frozen 파일(`.claude/`) 변경 없음.

## 이슈 auto-close 대상

- Closes #118 — sub-agent 블록 불릿 분리
- Closes #114 — 실전 교훈 포인터 포맷 컨벤션

머지 직후 `gh issue view 118 --json state` / `gh issue view 114 --json state` 로 검증 예정 (방금 v2.16.0 에 박제된 auto-close 검증 루틴 첫 적용).

## 머지 전략

`gh pr merge <PR> --merge` (merge commit, squash 금지).

## 릴리스 체크리스트

- [x] release PR 생성 (base=main, head=develop)
- [ ] merge commit 머지
- [ ] `git push origin main:develop` (fast-forward)
- [ ] `git tag v2.16.1` + `gh release create`
- [ ] `harness doctor` gitflow pass

## Test plan

- [x] U+FFFD 0건
- [x] npm test (v2.16.0 과 동일, 문서만 변경)
- [ ] 머지 직후 #118 #114 auto-close state 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)