### PR TITLE
feat(cross-validate): #119 Phase 2 — 스크립트 레벨 429 폴백 하드코딩 + 스모크 테스트 (MINOR)

### DIFF
--- a/.claude/skills/cross-validate/scripts/cross_validate.sh
+++ b/.claude/skills/cross-validate/scripts/cross_validate.sh
@@ -48,10 +48,81 @@ log() {
 GEMINI_MODEL="${GEMINI_MODEL:-gemini-2.5-pro}"
 MAX_GEMINI_RETRIES=2
 
-# Gemini 실행 (읽기 전용, 실패 시 스킵)
+# Exit code 규약 (CLAUDE.md API capacity 폴백 프로토콜)
+# 0  = Gemini 정상 응답 수신
+# 77 = claude-only fallback (Gemini 429/timeout 최종 실패, 단일 모델 편향 노출 미확보)
+# 1  = 그 외 실패 (인자 오류 / 파일 부재 / 민감 파일 등)
+EXIT_CLAUDE_ONLY_FALLBACK=77
+
+# Gemini capacity 체크 — `gemini -p "hello"` 로 빠른 응답성 확인
+# CLAUDE.md `## 교차검증` API capacity 폴백 프로토콜 단계 1
+check_gemini_capacity() {
+  local probe_output
+  probe_output=$(gemini -m "${GEMINI_MODEL}" -p "hello" --approval-mode plan 2>&1) && return 0
+  if echo "${probe_output}" | grep -qE "RESOURCE_EXHAUSTED|429|503|500"; then
+    log "capacity 체크 결과: 여전히 용량 부족"
+    return 1
+  fi
+  log "capacity 체크 결과: 모델 응답은 살아있으나 hello 호출 실패 — $(echo "${probe_output}" | head -1)"
+  return 1
+}
+
+# reminder 이슈 생성 (dry-run 모드 기본)
+# CLAUDE.md 폴백 프로토콜 단계 3: 노출 효율 최대 앵커 해당 시 reminder 이슈 박제
+# 환경변수 REMINDER_ISSUE_DRYRUN=0 로 설정해야 실제 생성. 기본은 stderr 에 초안 출력.
+create_reminder_issue() {
+  local context="${1:-cross-validate}"
+  local anchor="${2:-MINOR-behavior-change}"
+  local body
+  body=$(cat <<BODY
+## 배경
+
+cross-validate 스킬 실행 중 Gemini API capacity 소진으로 **claude-only fallback** 발생. CLAUDE.md \`## 교차검증\` API capacity 폴백 프로토콜 단계 3 (노출 효율 최대 앵커 해당 시 reminder 이슈 박제) 에 따라 API 복구 후 재검증용 이슈 박제.
+
+## 맥락
+
+- 원 호출 컨텍스트: ${context}
+- 앵커 유형: ${anchor}
+- 호출 시각: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+- 로그 파일: ${LOG_FILE}
+
+## 재시도 시 확인 범주
+
+- 범주 오류 (categorical error)
+- 암묵 전제 누락 (unstated assumption)
+- 비목표 대조 (non-goal consistency check)
+
+## 완료 기준
+
+- [ ] Gemini API 복구 확인 (\`gemini -p "hello"\`)
+- [ ] 원 컨텍스트에 대해 cross-validate 재실행
+- [ ] 결과를 원 PR / ADR / CHANGELOG 해당 위치에 박제
+- [ ] 재시도 성공 시 본 이슈 close
+BODY
+)
+  local title="[cross-validate reminder] ${context} — Gemini capacity 복구 후 재시도 (${anchor})"
+  if [ "${REMINDER_ISSUE_DRYRUN:-1}" = "0" ]; then
+    log "reminder 이슈 생성 (실제)"
+    gh issue create --title "${title}" --body "${body}" --label "enhancement" 2>&1 | tee -a "${LOG_FILE}"
+  else
+    log "reminder 이슈 dry-run — 실제 생성하지 않음 (REMINDER_ISSUE_DRYRUN=0 으로 설정 시 실제 생성)"
+    {
+      echo "[reminder-issue-dryrun] 제목: ${title}"
+      echo "[reminder-issue-dryrun] 본문 요약: ${context} / ${anchor} / 로그 ${LOG_FILE}"
+    } >&2
+  fi
+}
+
+# Gemini 실행 (읽기 전용)
+# CLAUDE.md `## 교차검증` API capacity 폴백 프로토콜:
+#   1. 1차 429/timeout → capacity 체크 + 지연 후 1회 재시도
+#   2. 2차 실패 → claude-only analysis completed 프리픽스 + exit 77
+#   3. 앵커 해당 시 reminder 이슈 박제
+# 앵커 컨텍스트는 호출 측에서 CROSS_VALIDATE_ANCHOR 환경변수로 전달 가능
 run_gemini() {
   local prompt="$1"
   local attempt=1
+  local fatal=0
 
   while [ "${attempt}" -le "${MAX_GEMINI_RETRIES}" ]; do
     log "Gemini 실행 중 (모델: ${GEMINI_MODEL}, 시도: ${attempt}/${MAX_GEMINI_RETRIES})..."
@@ -63,18 +134,42 @@ run_gemini() {
 
     if echo "${output}" | grep -qE "RESOURCE_EXHAUSTED|429|503|500"; then
       log "경고: ${GEMINI_MODEL} 용량 부족 (시도 ${attempt}/${MAX_GEMINI_RETRIES})"
+      if [ "${attempt}" -lt "${MAX_GEMINI_RETRIES}" ]; then
+        # 폴백 프로토콜 단계 1: capacity 체크 + 지연 재시도
+        sleep $((attempt * 5))
+        if check_gemini_capacity; then
+          log "capacity 복구 감지 — 재시도 진행"
+        else
+          log "capacity 미복구 — 재시도는 진행하되 조기 포기 가능성 높음"
+        fi
+      fi
       attempt=$((attempt + 1))
-      sleep $((attempt * 5))
     else
-      log "경고: ${GEMINI_MODEL} 실패 — $(echo "${output}" | head -3)"
+      log "경고: ${GEMINI_MODEL} 실패 (비-capacity 오류) — $(echo "${output}" | head -3)"
       echo "${output}" >> "${LOG_FILE}"
+      fatal=1
       break
     fi
   done
 
-  log "교차검증 스킵: Gemini API 사용 불가. Claude 단독 분석으로 전환합니다."
+  # 폴백 프로토콜 단계 2: claude-only analysis completed 박제
+  local fallback_msg="claude-only analysis completed — 단일 모델 편향 노출 미확보"
+  log "${fallback_msg}"
+  echo "${fallback_msg}" >&2
   echo "⚠ 교차검증 불가 — Claude 단독 분석. Gemini ${GEMINI_MODEL} 응답 없음." | tee -a "${LOG_FILE}"
-  return 1
+
+  # 폴백 프로토콜 단계 3: 앵커 컨텍스트 있으면 reminder 이슈 (dry-run 기본)
+  if [ -n "${CROSS_VALIDATE_ANCHOR:-}" ]; then
+    create_reminder_issue "${TYPE}${TARGET:+:${TARGET}}" "${CROSS_VALIDATE_ANCHOR}"
+  else
+    log "앵커 컨텍스트 없음 (CROSS_VALIDATE_ANCHOR 미설정) — reminder 이슈 생략"
+  fi
+
+  # capacity 실패가 아닌 fatal 오류면 1, 그 외엔 claude-only 시그널 77
+  if [ "${fatal}" = "1" ]; then
+    return 1
+  fi
+  return "${EXIT_CLAUDE_ONLY_FALLBACK}"
 }
 
 # 민감 파일 필터링
@@ -109,7 +204,7 @@ case "${TYPE}" in
 한국어로 답변해주세요.
 PROMPT_END
 )"
-    run_gemini "${PROMPT}"
+    run_gemini "${PROMPT}" || RC=$?
     ;;
 
   code)
@@ -161,7 +256,7 @@ ${DIFF}
 한국어로 항목별 평가(양호/주의/위험)와 구체적 개선 제안을 해주세요.
 PROMPT_END
 )"
-    run_gemini "${PROMPT}"
+    run_gemini "${PROMPT}" || RC=$?
     ;;
 
   architecture)
@@ -203,7 +298,7 @@ ${DOC_CONTENT}
 한국어로 항목별 평가와 개선 제안을 해주세요.
 PROMPT_END
 )"
-    run_gemini "${PROMPT}"
+    run_gemini "${PROMPT}" || RC=$?
     ;;
 
   skill)
@@ -254,7 +349,7 @@ ${EVALS_INFO}
 한국어로 항목별 평가와 개선 제안을 해주세요.
 PROMPT_END
 )"
-    run_gemini "${PROMPT}"
+    run_gemini "${PROMPT}" || RC=$?
     ;;
 
   *)
@@ -266,3 +361,6 @@ esac
 log ""
 log "=== 교차검증 완료 ==="
 log "로그: ${LOG_FILE}"
+
+# run_gemini 가 77 (claude-only fallback) 또는 1 (fatal) 을 반환한 경우 스크립트도 동일 코드로 종료
+exit "${RC:-0}"

--- a/.claude/skills/cross-validate/scripts/cross_validate.sh
+++ b/.claude/skills/cross-validate/scripts/cross_validate.sh
@@ -47,6 +47,8 @@ log() {
 # Gemini 모델 설정 — 경량 모델 폴백 없음 (교차검증 품질 보존)
 GEMINI_MODEL="${GEMINI_MODEL:-gemini-2.5-pro}"
 MAX_GEMINI_RETRIES=2
+# 재시도 간 sleep 단위 (초). 테스트에서는 0 으로 설정해 실행 시간 단축.
+GEMINI_RETRY_SLEEP_SECONDS="${GEMINI_RETRY_SLEEP_SECONDS:-5}"
 
 # Exit code 규약 (CLAUDE.md API capacity 폴백 프로토콜)
 # 0  = Gemini 정상 응답 수신
@@ -73,6 +75,8 @@ check_gemini_capacity() {
 create_reminder_issue() {
   local context="${1:-cross-validate}"
   local anchor="${2:-MINOR-behavior-change}"
+  # 호출 측이 GH_PR_CONTEXT 를 설정하면 본문에 원 PR 링크 추적성 보강
+  local pr_ref="${GH_PR_CONTEXT:-}"
   local body
   body=$(cat <<BODY
 ## 배경
@@ -83,6 +87,7 @@ cross-validate 스킬 실행 중 Gemini API capacity 소진으로 **claude-only 
 
 - 원 호출 컨텍스트: ${context}
 - 앵커 유형: ${anchor}
+- 원 PR/ADR 참조: ${pr_ref:-"(GH_PR_CONTEXT 미설정 — 호출 측이 수동 링크 필요)"}
 - 호출 시각: $(date -u +%Y-%m-%dT%H:%M:%SZ)
 - 로그 파일: ${LOG_FILE}
 
@@ -136,7 +141,10 @@ run_gemini() {
       log "경고: ${GEMINI_MODEL} 용량 부족 (시도 ${attempt}/${MAX_GEMINI_RETRIES})"
       if [ "${attempt}" -lt "${MAX_GEMINI_RETRIES}" ]; then
         # 폴백 프로토콜 단계 1: capacity 체크 + 지연 재시도
-        sleep $((attempt * 5))
+        # 테스트 환경에서는 GEMINI_RETRY_SLEEP_SECONDS=0 으로 sleep 생략
+        if [ "${GEMINI_RETRY_SLEEP_SECONDS}" -gt 0 ]; then
+          sleep $((attempt * GEMINI_RETRY_SLEEP_SECONDS))
+        fi
         if check_gemini_capacity; then
           log "capacity 복구 감지 — 재시도 진행"
         else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [Unreleased]
+
+[#119](https://github.com/coseo12/harness-setting/issues/119) Phase 2 — v2.17.0 Phase 1 (에이전트 프롬프트 하드코딩) 에 이어 **스크립트 레벨 강제** 완성. `cross_validate.sh` 에 CLAUDE.md `## 교차검증` API capacity 폴백 프로토콜 3단계 하드코딩 + reminder 이슈 dry-run + 스모크 테스트.
+
+### Added
+
+- **`.claude/skills/cross-validate/scripts/cross_validate.sh` 폴백 프로토콜 하드코딩**:
+  - `check_gemini_capacity()` 함수 — `gemini -p "hello"` 로 capacity 응답성 확인 (폴백 프로토콜 단계 1)
+  - `run_gemini()` 재시도 루프에 capacity 체크 통합 — 1차 429 후 sleep + capacity 체크 + 2차 재시도
+  - 최종 실패 시 **stderr 에 `claude-only analysis completed — 단일 모델 편향 노출 미확보` 프리픽스** 출력 + **exit code 77 (EXIT_CLAUDE_ONLY_FALLBACK)** 반환 (폴백 단계 2)
+  - `create_reminder_issue()` 함수 — `CROSS_VALIDATE_ANCHOR` 환경변수 설정 시 reminder 이슈 생성 (기본 dry-run, `REMINDER_ISSUE_DRYRUN=0` 으로 실제 생성) (폴백 단계 3)
+  - Exit code 규약 섹션 추가 — 0 (정상) / 77 (claude-only fallback) / 1 (fatal 오류)
+- **`test/cross-validate-fallback.test.js` 스모크 테스트 신규** — mock gemini 바이너리 (`429` / `ok` / `fatal` 모드) 로 5개 분기 검증:
+  1. 429 응답 → exit 77 + claude-only 프리픽스
+  2. `CROSS_VALIDATE_ANCHOR` 설정 시 reminder dry-run 출력
+  3. 앵커 미설정 시 dry-run 생략
+  4. 정상 응답 → exit 0 + 프리픽스 없음
+  5. 비-capacity fatal 오류 → exit 1
+- **CLAUDE.md `## 교차검증` 에 스크립트 레벨 강제 1줄 추가** — cross_validate.sh 하드코딩 박제 + 스모크 테스트 경로 명시 + `CROSS_VALIDATE_ANCHOR` / `REMINDER_ISSUE_DRYRUN` 환경변수 규약.
+
+### Behavior Changes
+
+- **cross_validate.sh 종료 코드 차별화** (이전: 실패 시 전부 일반 종료) — 정상 0 / claude-only fallback 77 / fatal 1. 호출 측(에이전트/hooks)이 77 을 감지해 "선언만 상태" 를 프로그램적으로 분기 가능
+- **429 최종 실패 시 stderr 에 `claude-only analysis completed` 프리픽스 출력** (이전: "교차검증 스킵. Claude 단독 분석으로 전환" 메시지만). 메인 오케스트레이터가 stderr grep 으로 폴백 감지 가능
+- **`CROSS_VALIDATE_ANCHOR` 환경변수 설정 시 fallback 경로에서 reminder 이슈 박제 (기본 dry-run)** (이전: reminder 이슈 로직 없음). 노출 효율 최대 앵커에서 cross-validate 포기 시 자동 재시도 큐잉 가능
+- **스모크 테스트가 프롬프트 레벨 규약 회귀 방지 가드** — `npm test` 에 `test/cross-validate-fallback.test.js` 포함되어 향후 스크립트 수정 시 폴백 프로토콜 준수 자동 검증 (총 테스트 28 → 33)
+
+### Notes
+
+- **`Builds on:` [#126](https://github.com/coseo12/harness-setting/pull/126)** (v2.17.0 Phase 1) — 프롬프트 레벨 + 스크립트 레벨 양쪽 강제로 "wishful documentation" 완전 해소.
+- **#119 이슈 close 예정** — Phase 1 (#126) + Phase 2 (이 PR) 로 완료 기준 1/2/3/4/5/6/7 모두 충족. release PR 머지 시 `Closes #119` 트리거.
+- **Gemini cross-validate 수행 예정**: 본 릴리스도 MINOR Behavior Changes 4개 + 스크립트 레벨 강제 = 노출 효율 최대 앵커. 박제 직후 1회 호출. 429 발생 시 방금 박제된 폴백 프로토콜의 **본격 자기 적용** (v2.17.0 PR #126 보다 한 단계 더 깊은 셀프 적용).
+- **자동 파서 회귀 가드**: v2.17.0 Notes 에서 "향후 CI 레벨 파이프라인 자동화 도입 시 `extends` 중첩 파싱 고려" 를 명시했으나, Phase 2 에서 스모크 테스트가 JSON 구조 자체는 검증하지 않고 exit code / stderr 규약만 검증. `extends` 구조 회귀 가드는 별도 이슈 후보.
+
 ## [2.17.0] — 2026-04-19
 
 [#119](https://github.com/coseo12/harness-setting/issues/119) Phase 1 — sub-agent 공통 JSON 스키마 SSoT 박제 + 5개 페르소나 (developer / qa / reviewer / architect / pm) 마무리 체크리스트 하드코딩. v2.16.0 에서 박제된 CLAUDE.md 선언적 규칙을 프롬프트 레벨로 강제. Phase 2 (cross_validate.sh 폴백 보강 + 스모크 테스트) 는 별도 릴리스.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -293,6 +293,7 @@ sub-agent에 적응적 질답·설계 같은 multi-turn 세션을 위임할 때,
 
      reminder 이슈 제목 예시 `[#<원 PR 번호>] cross-validate 재시도 — Gemini capacity 복구 후`. 본문에 원 PR/ADR 링크 + 재시도 시 확인할 범주(범주 오류 / 암묵 전제 / 비목표 대조) 명시. API 복구 후 close 또는 재검증 결과 반영
 - 근거 (폴백 프로토콜): volt [#40](https://github.com/coseo12/volt/issues/40) — v2.13.0 / v2.15.0 박제 직후 Gemini 429 2회 관찰. harness [#107](https://github.com/coseo12/harness-setting/issues/107) 선례 (복구 후 재시도 이슈 박제 → 2차 성공 후 close)
+- **스크립트 레벨 강제 (v2.18.0~)** — [.claude/skills/cross-validate/scripts/cross_validate.sh](.claude/skills/cross-validate/scripts/cross_validate.sh) 는 폴백 프로토콜을 하드코딩한다. 429 수신 시 `check_gemini_capacity()` (`gemini -p "hello"`) + 지연 후 재시도 → 최종 실패 시 **stderr 에 `claude-only analysis completed — 단일 모델 편향 노출 미확보` 프리픽스 출력 + exit code 77** 반환. 호출 측이 `CROSS_VALIDATE_ANCHOR` 환경변수 (`MINOR-behavior-change` / `ADR-new-or-amendment` / `CRITICAL-directive-revision`) 를 설정하면 **reminder 이슈 생성** (기본 dry-run, `REMINDER_ISSUE_DRYRUN=0` 으로 실제 생성). 스모크 테스트는 `test/cross-validate-fallback.test.js` 가 mock gemini 바이너리로 각 분기를 검증
 - **정책·설계·ADR 박제 직후 1회 루틴** — 정책 문서, ADR, CRITICAL DIRECTIVE 등을 박제한 직후 cross-validate 스킬을 1회 호출한다. 단일 모델 편향(범주 오류/암묵 전제 누락)은 박제 직후가 노출 효율이 가장 높다. v2.6.2→v2.6.3(SemVer 세분화) 사례 참조.
 - **교차검증 결과는 Claude가 재분석**: Gemini 산출물을 합의/이견/고유발견으로 분류하고, 과대 대응은 근거와 함께 반려. 맹목 수용 금지.
 - **고유 발견의 수용 vs 후속 분리 3단 프로토콜** — #23 의 반려 기준을 보완하는 수용/분리 기준:

--- a/test/cross-validate-fallback.test.js
+++ b/test/cross-validate-fallback.test.js
@@ -1,0 +1,140 @@
+// cross_validate.sh 의 API capacity 폴백 프로토콜 스모크 테스트
+// CLAUDE.md `## 교차검증` API capacity 폴백 프로토콜 준수 여부를
+// mock gemini 바이너리로 시뮬레이션해 검증한다.
+//
+// 검증 항목:
+// - 429 시뮬레이션 → capacity 체크 실행 + 재시도 + 최종 claude-only fallback
+// - exit code 77 (EXIT_CLAUDE_ONLY_FALLBACK) 반환
+// - stderr 에 "claude-only analysis completed" 프리픽스 출력
+// - CROSS_VALIDATE_ANCHOR 환경변수 있을 때 reminder 이슈 dry-run 출력
+// - CROSS_VALIDATE_ANCHOR 없을 때 dry-run 생략
+// - 정상 응답 시 exit 0 + dry-run 출력 없음
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { execSync, spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const PROJECT_DIR = path.resolve(__dirname, '..');
+const SCRIPT_PATH = path.join(PROJECT_DIR, '.claude/skills/cross-validate/scripts/cross_validate.sh');
+
+// mock gemini 바이너리 생성 헬퍼
+// mode: '429' | 'ok' | 'fatal'
+function setupMockGemini(mode) {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-cv-mock-'));
+  const mockPath = path.join(tmpDir, 'gemini');
+  let script;
+  if (mode === '429') {
+    // 모든 호출 실패 (capacity 체크 + 재시도 모두 429)
+    script = `#!/bin/bash\necho "Error: 429 RESOURCE_EXHAUSTED" >&2\nexit 1\n`;
+  } else if (mode === 'ok') {
+    script = `#!/bin/bash\necho "mock gemini response"\nexit 0\n`;
+  } else if (mode === 'fatal') {
+    script = `#!/bin/bash\necho "Error: invalid argument" >&2\nexit 2\n`;
+  } else {
+    throw new Error(`unknown mode: ${mode}`);
+  }
+  fs.writeFileSync(mockPath, script, { mode: 0o755 });
+  return { tmpDir, mockPath };
+}
+
+function runScript(args, env) {
+  const result = spawnSync('bash', [SCRIPT_PATH, ...args], {
+    cwd: PROJECT_DIR,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+    timeout: 60_000,
+  });
+  return result;
+}
+
+test('cross-validate: 429 응답 → claude-only fallback exit code 77', () => {
+  const { tmpDir, mockPath } = setupMockGemini('429');
+  try {
+    // MAX_GEMINI_RETRIES 는 스크립트 내부 고정값(2) — 실행 시간 단축 위해 sleep 을 회피하는
+    // 환경변수가 없으므로 짧은 structure 프롬프트로 테스트 (sleep 총 5초 이내)
+    const result = runScript(['structure'], {
+      PATH: `${tmpDir}:${process.env.PATH}`,
+      REMINDER_ISSUE_DRYRUN: '1',
+    });
+    assert.strictEqual(result.status, 77, `exit code 77 기대, 실제: ${result.status}`);
+    assert.ok(
+      result.stderr.includes('claude-only analysis completed'),
+      `stderr 에 claude-only 프리픽스 기대. 실제 stderr: ${result.stderr}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('cross-validate: CROSS_VALIDATE_ANCHOR 설정 시 reminder 이슈 dry-run 출력', () => {
+  const { tmpDir } = setupMockGemini('429');
+  try {
+    const result = runScript(['structure'], {
+      PATH: `${tmpDir}:${process.env.PATH}`,
+      REMINDER_ISSUE_DRYRUN: '1',
+      CROSS_VALIDATE_ANCHOR: 'MINOR-behavior-change',
+    });
+    assert.strictEqual(result.status, 77);
+    assert.ok(
+      result.stderr.includes('[reminder-issue-dryrun]'),
+      `reminder dry-run prefix 기대. 실제 stderr: ${result.stderr}`
+    );
+    assert.ok(
+      result.stderr.includes('MINOR-behavior-change'),
+      `앵커 유형 출력 기대. 실제 stderr: ${result.stderr}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('cross-validate: CROSS_VALIDATE_ANCHOR 미설정 시 dry-run 생략', () => {
+  const { tmpDir } = setupMockGemini('429');
+  try {
+    const result = runScript(['structure'], {
+      PATH: `${tmpDir}:${process.env.PATH}`,
+      REMINDER_ISSUE_DRYRUN: '1',
+      CROSS_VALIDATE_ANCHOR: '',
+    });
+    assert.strictEqual(result.status, 77);
+    assert.ok(
+      !result.stderr.includes('[reminder-issue-dryrun]'),
+      `앵커 미설정 시 dry-run 출력 없어야 함. 실제 stderr: ${result.stderr}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('cross-validate: 정상 응답 → exit 0', () => {
+  const { tmpDir } = setupMockGemini('ok');
+  try {
+    const result = runScript(['structure'], {
+      PATH: `${tmpDir}:${process.env.PATH}`,
+      REMINDER_ISSUE_DRYRUN: '1',
+    });
+    assert.strictEqual(result.status, 0, `정상 응답은 exit 0. 실제: ${result.status}, stderr: ${result.stderr}`);
+    assert.ok(
+      !result.stderr.includes('claude-only analysis completed'),
+      `정상 응답에는 fallback 프리픽스 없어야 함`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('cross-validate: 비-capacity fatal 오류 → exit 1 (claude-only 시그널 아님)', () => {
+  const { tmpDir } = setupMockGemini('fatal');
+  try {
+    const result = runScript(['structure'], {
+      PATH: `${tmpDir}:${process.env.PATH}`,
+      REMINDER_ISSUE_DRYRUN: '1',
+    });
+    assert.strictEqual(result.status, 1, `fatal 오류는 exit 1. 실제: ${result.status}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});

--- a/test/cross-validate-fallback.test.js
+++ b/test/cross-validate-fallback.test.js
@@ -43,7 +43,12 @@ function setupMockGemini(mode) {
 function runScript(args, env) {
   const result = spawnSync('bash', [SCRIPT_PATH, ...args], {
     cwd: PROJECT_DIR,
-    env: { ...process.env, ...env },
+    env: {
+      ...process.env,
+      // 테스트에서는 sleep 생략 — 재시도 로직 자체만 검증
+      GEMINI_RETRY_SLEEP_SECONDS: '0',
+      ...env,
+    },
     encoding: 'utf8',
     timeout: 60_000,
   });


### PR DESCRIPTION
## Summary

[#119](https://github.com/coseo12/harness-setting/issues/119) Phase 2. v2.17.0 Phase 1 (에이전트 프롬프트 하드코딩) 에 이어 **스크립트 레벨 강제** 완성. CLAUDE.md 선언적 규칙(v2.16.0) + 에이전트 프롬프트(v2.17.0) + **스크립트 구현(이 PR)** 의 3층 방어 완성.

## 변경

### cross_validate.sh 폴백 프로토콜 하드코딩

- `check_gemini_capacity()` — `gemini -p "hello"` probe (폴백 단계 1)
- `run_gemini()` 재시도 루프에 capacity 체크 통합 + 지연
- 최종 실패 시 **stderr `claude-only analysis completed` 프리픽스** + **exit code 77** (폴백 단계 2)
- `create_reminder_issue()` — `CROSS_VALIDATE_ANCHOR` 환경변수 시 dry-run 기본 reminder 이슈 (폴백 단계 3)
- Exit code 규약: 0 (정상) / 77 (claude-only fallback) / 1 (fatal)

### 스모크 테스트 (test/cross-validate-fallback.test.js 신규)

mock gemini 바이너리 (`429` / `ok` / `fatal` 3 모드) 로 5개 분기 검증:
1. 429 → exit 77 + claude-only 프리픽스
2. `CROSS_VALIDATE_ANCHOR` 설정 시 reminder dry-run 출력
3. 앵커 미설정 시 dry-run 생략
4. 정상 응답 → exit 0 + 프리픽스 없음
5. 비-capacity fatal → exit 1

**테스트 28 → 33 (+5)**. `npm test` 자동 포함.

### CLAUDE.md 교차검증 섹션 1줄 보강

스크립트 레벨 강제 박제 + 환경변수 규약 (`CROSS_VALIDATE_ANCHOR` / `REMINDER_ISSUE_DRYRUN`).

## 분류: MINOR

**Behavior Changes 4개**:
1. cross_validate.sh exit code 차별화 (0/77/1)
2. 429 최종 실패 시 stderr `claude-only analysis completed` 프리픽스
3. `CROSS_VALIDATE_ANCHOR` 환경변수 + reminder 이슈 dry-run 경로
4. npm test 에 cross-validate-fallback 회귀 가드 포함

## 스프린트 계약 대조 (#119 전체)

| # | 완료 기준 | Phase | 상태 |
|---|---|---|---|
| 1 | 공통 템플릿 마무리 체크리스트 JSON 스키마 하드코딩 | 1 | ✓ (v2.17.0) |
| 2 | cross_validate.sh 429 폴백 로직 하드코딩 | 2 | ✓ (이 PR) |
| 3 | reminder 이슈 dry-run 스니펫 | 2 | ✓ (이 PR) |
| 4 | 기존 체크리스트 중복 정리 | 1 | ✓ (v2.17.0) |
| 5 | 스모크 테스트 | 2 | ✓ (이 PR, +5 tests) |
| 6 | 분류 MINOR + Behavior Changes 최소 3항목 | 1+2 | ✓ (Phase 1: 5개 / Phase 2: 4개) |
| 7 | frozen 파일 관리 경계 유지 | 1+2 | ✓ (`.claude/` upstream 관리) |

**Closes [#119](https://github.com/coseo12/harness-setting/issues/119)** (release PR main 머지 시 auto-close).

## Test plan

- [x] `npm test` 33/33 pass (+5 신규)
- [x] `bash -n` 구문 검증
- [x] mock gemini 수동 실행 확인 (usage 표시 정상)
- [x] U+FFFD 0건
- [ ] 박제 직후 cross-validate — MINOR 앵커, 본 PR 이 방금 하드코딩한 폴백 프로토콜의 **실 자기 적용**. 429 발생 시 프리픽스 + exit 77 확인 가능

## 근거

- Closes [#119](https://github.com/coseo12/harness-setting/issues/119)
- `Builds on:` [#126](https://github.com/coseo12/harness-setting/pull/126) (v2.17.0 Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)