### PR TITLE
chore(release): v2.20.0 — #131 Phase A cross-validate refinements (MINOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
-## [Unreleased]
+## [2.20.0] — 2026-04-19
 
 [#131](https://github.com/coseo12/harness-setting/issues/131) Phase A — reviewer 권고 5건 중 4건 반영 (1, 2, 3, 6). `cross_validate.sh` stdout 대칭성 / capacity 반환 코드 분리 / exponential backoff / 복구 분기 stateful 테스트.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.19.0",
+  "version": "2.20.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Summary

v2.20.0 릴리스 bump — CHANGELOG `[Unreleased]` → `[2.20.0]` + package.json 2.19.0 → 2.20.0.

## 포함 PR
- #137 — [#131] cross-validate Phase A (권고 1/2/3/6 반영)

## Behavior Changes (3건)
1. fallback 경로 stdout 대칭 — `[claude-only-fallback]` 헤더
2. 재시도 sleep 지수 증가 (5s → 10s @ MAX_RETRIES=2)
3. `check_gemini_capacity` 반환 코드 3값 분리

## Test plan
- [x] CHANGELOG / package.json 만 변경 (코드 변경 없음)
- [x] 테스트 변경 없음 — 선행 PR #137 에서 38/38 통과 확인됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)