### PR TITLE
[#127] pr-review.yml 라벨 체계를 stage:* 로 일원화 (Plan 1, MINOR)

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -19,12 +19,13 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            // status:review 라벨 추가
+            // stage:* 체계로 일원화 (#127 Plan 1) — 에이전트 파일/setup-stage-labels.sh 와 prefix 일치
+            // PR 이 열리는 시점은 developer 단계 종료 → reviewer 단계 대기이므로 stage:review 부착
             await github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.payload.pull_request.number,
-              labels: ['status:review']
+              labels: ['stage:review']
             });
 
             // PR 본문에서 이슈 번호 추출
@@ -33,13 +34,14 @@ jobs:
             const issueMatch = body.match(/(?:Closes|Fixes|Resolves)\s+#(\d+)/i);
             if (issueMatch) {
               const issueNumber = parseInt(issueMatch[1]);
-              // 관련 이슈의 라벨 업데이트
+              // 관련 이슈를 stage:dev (developer 진행 중) 에서 stage:review 로 전이
+              // stage:dev 라벨이 없을 수도 있으므로 try/catch 로 안전 처리
               try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   issue_number: issueNumber,
-                  name: 'status:in-progress'
+                  name: 'stage:dev'
                 });
               } catch (e) {
                 // 라벨이 없으면 무시
@@ -48,6 +50,6 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
-                labels: ['status:review']
+                labels: ['stage:review']
               });
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [2.22.0] — 2026-04-20
+
+[#127](https://github.com/coseo12/harness-setting/issues/127) Plan 1 — 라벨 네이밍 `stage:*` / `status:*` 혼재 정리 (MINOR). 추가로 [#141](https://github.com/coseo12/harness-setting/issues/141) cross-validate 파싱 jq 전환 NO-OP ADR 박제.
+
+### Behavior Changes
+
+- **`.github/workflows/pr-review.yml` 라벨 체계 일원화** — PR 이 열리면 기존 `status:review` 대신 **`stage:review`** 부착. 연관 이슈에 대해서도 `status:in-progress` 제거 → `stage:dev` 제거 + `stage:review` 부착으로 전환. 에이전트 파일 (architect/developer/pm/qa/reviewer) + `scripts/setup-stage-labels.sh` 가 이미 `stage:*` 일관 사용 중이었고, workflow 만 구 체계에 머물러 있던 혼재를 해소.
+- 저장소 라벨 `status:review` 는 release 머지 후 삭제 예정 (구 workflow 가 main 에 반영되기 전까지 `status:review` 자동 부착 지속). 에이전트 실 사용 라벨 세트 = `stage:*` 6개 (planning / design / dev / review / qa / done) 로 일원화.
+
+### Added
+
+- **ADR `20260420-jq-based-parsing-no-op.md`** ([#141](https://github.com/coseo12/harness-setting/issues/141)) — `parse-cross-validate-outcome.sh` 의 jq 기반 전환을 **기각** 한 NO-OP 결정 박제. 후보 비교 (jq+fallback / jq 필수 / NO-OP) + 알려진 한계 (parse 정규식의 `\"` 해석 실패, 실 사용 필드 값이 enum/경로/번호라 raw `"` 구조적 제외) + 재검토 트리거 6개.
+- **경계 가드 테스트** (`test/parse-cross-validate-outcome-boundary.test.js`) — write/parse round-trip 을 `\` / tab / newline / CR 4종 + 혼합 `JSON.parse` 검증으로 지속 관측 (테스트 47 → 52).
+
+### Notes
+
+- #127 A (SSoT 중복 해소) 와 B-extended (`agent-dispatch.yml` 의 `status:*` 7개 라벨 분석) 는 본 PR 범위 밖 — 후속 이슈로 분리.
+
 ## [2.21.0] — 2026-04-19
 
 [#131](https://github.com/coseo12/harness-setting/issues/131) Phase B — 잔존 권고 2건 (4, 7) + reviewer/qa non-blocking 2건. `cross_validate.sh` probe 옵트아웃 / sleep cap 상한 / 공통 파싱 헬퍼 + fatal stdout 헤더 규약 박제.


### PR DESCRIPTION
## Summary

- [#127](https://github.com/coseo12/harness-setting/issues/127) Plan 1 — `.github/workflows/pr-review.yml` 의 `status:*` 라벨 참조를 **`stage:*`** 로 전환하여 에이전트 파일 / `setup-stage-labels.sh` 와의 혼재 해소
- 원 이슈 #127 은 두 주제 (A: SSoT 중복 / B: 라벨 네이밍) 가 묶여 있어 **Plan 1** 로 범위 축소 후 후속 이슈 2개로 분리

## 변경 내용

### `.github/workflows/pr-review.yml`

| 위치 | 이전 | 이후 |
|---|---|---|
| PR 부착 라벨 | `status:review` | **`stage:review`** |
| 이슈에서 제거할 라벨 | `status:in-progress` (저장소 미존재, noop) | **`stage:dev`** (developer 종료 → reviewer 대기) |
| 이슈 부착 라벨 | `status:review` | **`stage:review`** |

### `CHANGELOG.md`

v2.22.0 MINOR 엔트리 추가. Behavior Changes + #141 NO-OP ADR 합병 기록.

## 근거

- 에이전트 파일 5개 (architect / developer / pm / qa / reviewer) 는 이미 `stage:*` 일관 사용
- `scripts/setup-stage-labels.sh` 는 `stage:*` 6개만 생성 (`planning` / `design` / `dev` / `review` / `qa` / `done`)
- 저장소 라벨: `stage:*` 6개 + `status:review` 1개 orphan → 혼재의 근본 원인
- workflow 만 구 체계 (`status:*`) 에 머물러 있어 진실원 불일치

## 비목표 (후속 이슈로 분리)

- **[#145](https://github.com/coseo12/harness-setting/issues/145)**: 5개 에이전트 파일의 공통 JSON 스키마 SSoT 중복 해소
- **[#146](https://github.com/coseo12/harness-setting/issues/146)**: `.github/workflows/agent-dispatch.yml` 의 `status:*` 7개 라벨 분석 (죽은 코드 여부 판정 후 정리)

## 릴리스 계획

**v2.22.0 MINOR** — 자동화 라벨 문자열 변경이 에이전트 행동 경로에 영향. `### Behavior Changes` 섹션 필수.

### 저장소 라벨 `status:review` 삭제 시점

Release PR 머지 **후** 수동 삭제. 사유: 구 workflow 가 main 에 반영되기 전까지 새 PR 에 `status:review` 를 계속 부착하려 함. 사전 삭제하면 workflow 가 addLabels 에러.

절차:
1. 본 PR → develop 머지
2. Release PR develop → main 머지 + tag v2.22.0
3. 이후 `gh label delete status:review --yes` 수동 수행
4. 기존 머지된 PR 의 historical 라벨은 label 삭제 시 자동 제거됨 (GitHub 동작)

## Test plan

- [x] `npm test` — 기존 52/52 통과 유지 (workflow 변경은 테스트 영향 없음)
- [x] 한글 인코딩 — U+FFFD 없음
- [x] `grep -n 'status:' .github/workflows/pr-review.yml` → 0건 (전면 교체 확인)
- [ ] PR 열림 시 `stage:review` 부착 (이 PR 자체가 실측 — 단, 머지 전까지는 main 의 구 workflow 가 `status:review` 부착할 것)

## 완료 기준 (DoD)

- [x] `.github/workflows/pr-review.yml` 수정
- [x] `CHANGELOG.md` v2.22.0 엔트리 추가
- [x] 후속 이슈 2개 생성 (#145 / #146)
- [ ] 원 이슈 #127 본문에 Plan 1 / 분할 사실 박제 (이 PR 머지 후)
- [ ] Release PR 머지 후 `status:review` 라벨 삭제

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)