### PR TITLE
chore(release): v2.23.0 — #145 agent SSoT drift 자동 가드 (develop → main)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -51,6 +51,7 @@ PR 타입에 맞는 한 줄만 체크. `base=main` 은 release/hotfix PR 만 허
 - [ ] 커밋 컨벤션 준수
 - [ ] 불필요한 변경 없음
 - [ ] 보안 취약점 없음
+- [ ] CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 (SSoT 코어 필드 7개) 를 수정한 경우: 5개 에이전트 파일 (`.claude/agents/architect.md` / `developer.md` / `pm.md` / `qa.md` / `reviewer.md`) 의 `## 마무리 체크리스트 JSON 반환` 섹션 동기화 + `bash scripts/verify-agent-ssot.sh` 로컬 pass 확인 (CI 에서도 자동 검사 — #145)
 
 ### 관련 이슈
 Closes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,3 +48,11 @@ jobs:
           if grep -q "^test:" Makefile; then
             make test
           fi
+
+      # agent SSoT drift 가드 (#145)
+      # CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 7개 필드가
+      # 5개 에이전트 파일의 `## 마무리 체크리스트 JSON 반환` 섹션에 모두 존재하고 선언 순서를
+      # 유지하는지 검사. drift 시 exit 1 로 PR 머지 전 차단.
+      - name: agent SSoT drift 가드
+        if: hashFiles('scripts/verify-agent-ssot.sh') != ''
+        run: bash scripts/verify-agent-ssot.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [2.23.0] — 2026-04-20
+
+[#145](https://github.com/coseo12/harness-setting/issues/145) — 공통 JSON 스키마 (SSoT) drift 자동 가드 도입 (MINOR).
+
+### Behavior Changes
+
+- **`scripts/verify-agent-ssot.sh` 신규 검증 스크립트** — CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 코어 필드 7개 (`commit_sha` / `pr_url` / `pr_comment_url` / `labels_applied_or_transitioned` / `auto_close_issue_states` / `blocking_issues` / `non_blocking_suggestions`) 가 5개 에이전트 파일 (architect / developer / pm / qa / reviewer) 의 `## 마무리 체크리스트 JSON 반환` 섹션에 모두 존재하고 선언 순서를 유지하는지 검증. drift 시 누락 파일/필드/순서 이탈 지점을 stderr 에 보고하고 exit 1.
+- **CI `detect-and-test` 에 drift 가드 step 추가** — `.github/workflows/ci.yml` 이 `hashFiles('scripts/verify-agent-ssot.sh')` 조건으로 본 스크립트를 실행. PR 머지 전 자동 차단 게이트.
+- **PR 템플릿 체크박스 추가** — SSoT 코어 필드 수정 PR 시 5개 에이전트 파일 동기화 + 로컬 `verify-agent-ssot.sh` pass 확인 명시.
+- **CLAUDE.md SSoT 블록에 자동 가드 안내 1줄 박제** — 이 블록 수정 시 5개 에이전트 파일 동기화 의무 + 스크립트 경로 참조.
+
+### Added
+
+- **`test/agent-ssot-drift.test.js`** (node:test, 4 케이스, 총 52 → 56 tests):
+  1. 정상 상태 5 files × 7 fields = 35 checks pass
+  2. 필드 제거 → exit 1 + 누락 필드 이름 보고
+  3. 필드 순서 이탈 → exit 1 + 순서 키워드 보고
+  4. 에이전트 파일 누락 → exit 1 + 파일 없음 메시지
+
+### Notes
+
+- 착수 중 **CI `detect-and-test` 잡의 Node.js 브랜치가 실측 no-op** (범용 언어 detect 템플릿으로 `echo` 만 수행, `npm test` 미실행) 임을 발견. 본 릴리스에서 `scripts/verify-agent-ssot.sh` 전용 step 은 추가했으나 `npm test` 자체 복구는 **후속 이슈 [#153](https://github.com/coseo12/harness-setting/issues/153) 으로 분리** (medium 우선순위).
+
 ## [2.22.1] — 2026-04-20
 
 [#146](https://github.com/coseo12/harness-setting/issues/146) — 죽은 workflow `.github/workflows/agent-dispatch.yml` 제거 (PATCH).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -249,6 +249,7 @@ sub-agent(dev/qa 페르소나 등)는 빌드·테스트·브라우저 검증은 
   }
   ```
   누락 field 는 `null` 또는 빈 배열/객체로 **명시** (생략 금지). 공통 필드 검증 이후 에이전트별 `extends` 영역을 검증한다. 각 에이전트 파일의 `## 마무리 체크리스트 JSON 반환 (필수)` 섹션은 이 코어를 포함하고 특수 필드만 추가한다.
+- **SSoT 동기화 자동 가드 (#145, v2.23.0~)** — 위 공통 JSON 스키마 7개 필드는 **5개 에이전트 파일** (`.claude/agents/architect.md` / `developer.md` / `pm.md` / `qa.md` / `reviewer.md`) 의 체크리스트 JSON 블록에도 그대로 등장해야 한다 (sub-agent 가 system prompt 만 보고 반환할 수 있도록). 동기화 보장은 수동 체크박스가 아닌 **`scripts/verify-agent-ssot.sh`** 자동 검사로 강제된다 — 7개 필드 존재 + 선언 순서 준수를 검증하며, drift 시 누락 파일/필드와 순서 이탈 지점을 stderr 에 보고하고 exit 1. CI `detect-and-test` 에 통합되어 PR 머지 전 drift 차단. **이 SSoT 블록을 수정하는 PR 은 반드시 5개 에이전트 파일의 `## 마무리 체크리스트 JSON 반환` 섹션을 함께 갱신하고 `bash scripts/verify-agent-ssot.sh` 로 사전 확인한다.**
 - 누락 감지 시 메인이 직접 보완 박제 (커밋/PR/코멘트). sub-agent를 재호출해 같은 누락을 반복시키지 않는다
 - 근거: volt [#24](https://github.com/coseo12/volt/issues/24) — astro-simulator P6-B~E 에서 dev/qa sub-agent 마무리 단계 누락 4회 연속 관찰
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.22.1",
+  "version": "2.23.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"

--- a/scripts/verify-agent-ssot.sh
+++ b/scripts/verify-agent-ssot.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# verify-agent-ssot.sh
+# 5개 에이전트 파일의 `## 마무리 체크리스트 JSON 반환 (필수)` 섹션이
+# CLAUDE.md 의 공통 JSON 스키마 SSoT (코어 필드 7개) 를 모두 포함하는지 + 선언 순서대로
+# 나열되는지 검증한다. drift 발견 시 상세 원인과 함께 exit 1.
+#
+# SSoT 선언 위치: CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료`
+# 의 "공통 JSON 스키마 (SSoT)" 블록 (commit_sha / pr_url / pr_comment_url /
+# labels_applied_or_transitioned / auto_close_issue_states / blocking_issues /
+# non_blocking_suggestions).
+#
+# 호출 예:
+#   ./scripts/verify-agent-ssot.sh
+#     → 통과: exit 0, "✅ agent SSoT drift 없음 (5 files × 7 fields)"
+#     → 실패: exit 1, 누락/순서 이탈 파일·필드 상세 출력
+#
+# 관련 이슈: #145 (Z 옵션 — drift 자동 감지 게이트)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# 테스트 격리용 — 기본 프로젝트의 .claude/agents 외 경로를 검사하려면 AGENT_DIR override
+AGENT_DIR="${AGENT_DIR:-${PROJECT_DIR}/.claude/agents}"
+
+AGENTS=(architect developer pm qa reviewer)
+
+# SSoT 선언 순서 (CLAUDE.md 기준 고정) — 이 순서가 에이전트 JSON 블록에서도 유지되어야 한다
+CORE_FIELDS=(
+  commit_sha
+  pr_url
+  pr_comment_url
+  labels_applied_or_transitioned
+  auto_close_issue_states
+  blocking_issues
+  non_blocking_suggestions
+)
+
+errors=0
+checked_fields=0
+
+# "마무리 체크리스트 JSON 반환" 문구가 등장한 이후의 첫 `json ... ` 코드블록을 추출.
+# 헤더 형태가 파일마다 다르다 — 일부는 `## 마무리 체크리스트 JSON 반환 (필수)` 의 독립 섹션,
+# 일부는 번호 리스트 항목 (`12. **마무리 체크리스트 JSON 반환** — ...`) 형태.
+# 따라서 섹션 헤더 정규식이 아닌 "키 문구 등장 + 이후 첫 json 블록" 으로 식별한다.
+# 리스트 항목 형태는 json fence 가 들여쓰기된 경우도 있어 leading whitespace 를 허용.
+extract_json_block() {
+  local file="$1"
+  awk '
+    # 1. "마무리 체크리스트 JSON 반환" 키워드가 나올 때까지 무시
+    !seen && /마무리 체크리스트 JSON 반환/ { seen = 1; next }
+    # 2. 키워드 발견 후, 첫 ```json 코드블록 시작점을 찾음 (들여쓰기 허용)
+    seen && !in_json && /^[[:space:]]*```json[[:space:]]*$/ { in_json = 1; next }
+    # 3. 코드블록 내부에서 닫는 ``` 를 만나면 즉시 처리 종료
+    in_json && /^[[:space:]]*```[[:space:]]*$/ { exit }
+    # 4. 코드블록 내부에 있으면 해당 라인 수집
+    in_json { print }
+  ' "${file}"
+}
+
+check_agent() {
+  local agent="$1"
+  local file="${AGENT_DIR}/${agent}.md"
+
+  if [ ! -f "${file}" ]; then
+    echo "❌ [${agent}] 파일 없음 — ${file}" >&2
+    errors=$((errors + 1))
+    return
+  fi
+
+  local block
+  block=$(extract_json_block "${file}")
+
+  if [ -z "${block}" ]; then
+    echo "❌ [${agent}] '## 마무리 체크리스트 JSON 반환' 섹션의 \`\`\`json 블록 추출 실패 — ${file}" >&2
+    errors=$((errors + 1))
+    return
+  fi
+
+  # 각 CORE_FIELD 가 JSON 블록에 등장하는 라인 번호 수집
+  # "key": ... 형태만 매칭 (extends 내부 하위 키 오인 방지 위해 단순 grep)
+  local -a line_numbers=()
+  local missing=0
+  local idx=0
+  for field in "${CORE_FIELDS[@]}"; do
+    local line_no
+    line_no=$(echo "${block}" | grep -nE "^\s*\"${field}\"\s*:" | head -1 | cut -d: -f1 || true)
+    if [ -z "${line_no}" ]; then
+      echo "❌ [${agent}] 누락 필드: \"${field}\"" >&2
+      errors=$((errors + 1))
+      missing=1
+    else
+      line_numbers+=("${line_no}")
+      idx=$((idx + 1))
+    fi
+    checked_fields=$((checked_fields + 1))
+  done
+
+  # 순서 검증 — line_numbers 가 오름차순이어야 함
+  if [ "${missing}" -eq 0 ]; then
+    local prev=0
+    local i=0
+    for ln in "${line_numbers[@]}"; do
+      if [ "${ln}" -le "${prev}" ]; then
+        echo "❌ [${agent}] 필드 순서 이탈: \"${CORE_FIELDS[${i}]}\" (line ${ln}) 가 이전 필드 이후에 와야 하지만 line ${prev} 이전에 위치" >&2
+        errors=$((errors + 1))
+      fi
+      prev="${ln}"
+      i=$((i + 1))
+    done
+  fi
+}
+
+for agent in "${AGENTS[@]}"; do
+  check_agent "${agent}"
+done
+
+if [ "${errors}" -gt 0 ]; then
+  echo "" >&2
+  echo "agent SSoT drift 감지: ${errors} 건. CLAUDE.md '### sub-agent 검증 완료 ≠ GitHub 박제 완료' 의 공통 JSON 스키마와 5개 에이전트 파일을 재동기화." >&2
+  exit 1
+fi
+
+echo "✅ agent SSoT drift 없음 (${#AGENTS[@]} files × ${#CORE_FIELDS[@]} fields = ${checked_fields} checks)"

--- a/test/agent-ssot-drift.test.js
+++ b/test/agent-ssot-drift.test.js
@@ -1,0 +1,111 @@
+// agent SSoT drift 회귀 가드
+//
+// 검증: `scripts/verify-agent-ssot.sh` 가 5개 에이전트 파일 (architect/developer/pm/qa/reviewer)
+// 의 공통 코어 필드 7개 존재 + 순서 드리프트를 실제로 감지하는가.
+//
+// 테스트 전략:
+// - 실 상태에서 exit 0 (35 checks pass)
+// - 임시 디렉토리에 에이전트 파일을 복사 + 의도적 drift (필드 제거 / 순서 뒤집기) → exit 1 + 해당 필드 이름 보고
+// - AGENT_DIR 환경변수로 스크립트의 검사 대상 디렉토리를 격리
+//
+// 배경: #145 Z 옵션 — SSoT 동기화 보장을 "사람 체크박스" 가 아닌 자동 drift 가드로.
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const PROJECT_DIR = path.resolve(__dirname, '..');
+const SCRIPT_PATH = path.join(PROJECT_DIR, 'scripts/verify-agent-ssot.sh');
+const SOURCE_AGENT_DIR = path.join(PROJECT_DIR, '.claude/agents');
+const AGENTS = ['architect', 'developer', 'pm', 'qa', 'reviewer'];
+
+function runVerify(agentDir) {
+  return spawnSync('bash', [SCRIPT_PATH], {
+    encoding: 'utf8',
+    env: { ...process.env, AGENT_DIR: agentDir ?? SOURCE_AGENT_DIR },
+    timeout: 10_000,
+  });
+}
+
+function setupIsolatedAgentDir() {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-agent-ssot-'));
+  for (const a of AGENTS) {
+    fs.copyFileSync(path.join(SOURCE_AGENT_DIR, `${a}.md`), path.join(tmpDir, `${a}.md`));
+  }
+  return tmpDir;
+}
+
+test('agent SSoT drift guard: 정상 상태 — 5 files × 7 fields = 35 checks pass', () => {
+  const result = runVerify();
+  assert.strictEqual(result.status, 0, `exit 0 기대. status=${result.status} stderr=${result.stderr}`);
+  assert.ok(
+    result.stdout.includes('35 checks') || result.stdout.includes('drift 없음'),
+    `정상 메시지 기대. stdout=${result.stdout}`
+  );
+});
+
+test('agent SSoT drift guard: 필드 제거 시 실패 + 누락 필드 이름 보고', () => {
+  const tmpDir = setupIsolatedAgentDir();
+  try {
+    // reviewer.md 에서 `"pr_comment_url"` 줄을 삭제 — 누락 drift 유도
+    const file = path.join(tmpDir, 'reviewer.md');
+    const original = fs.readFileSync(file, 'utf8');
+    const mutated = original.replace(/^\s*"pr_comment_url".*$/m, '');
+    assert.notStrictEqual(mutated, original, '테스트 사전조건: mutation 이 실제로 적용되어야 함');
+    fs.writeFileSync(file, mutated);
+
+    const result = runVerify(tmpDir);
+    assert.strictEqual(result.status, 1, `drift 감지 exit 1 기대. status=${result.status}`);
+    assert.ok(
+      result.stderr.includes('[reviewer]') && result.stderr.includes('pr_comment_url'),
+      `[reviewer] + 필드명 기대. stderr=${result.stderr}`
+    );
+    assert.ok(result.stderr.includes('누락'), `누락 키워드 기대. stderr=${result.stderr}`);
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('agent SSoT drift guard: 필드 순서 이탈 시 실패 + 순서 키워드 보고', () => {
+  const tmpDir = setupIsolatedAgentDir();
+  try {
+    // qa.md 에서 `commit_sha` 와 `pr_url` 라인 순서 뒤집기 — 순서 drift
+    const file = path.join(tmpDir, 'qa.md');
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+    const commitIdx = lines.findIndex((l) => /^\s*"commit_sha"\s*:/.test(l));
+    const prIdx = lines.findIndex((l) => /^\s*"pr_url"\s*:/.test(l));
+    assert.ok(commitIdx > -1 && prIdx > -1, '테스트 사전조건: 두 필드 라인 발견');
+    assert.ok(commitIdx < prIdx, '테스트 사전조건: 원본에서 commit_sha 가 pr_url 보다 앞에 있음');
+    // 두 인덱스 위치의 라인만 서로 스왑 — 의도: "두 필드 라인을 교환한다"
+    [lines[commitIdx], lines[prIdx]] = [lines[prIdx], lines[commitIdx]];
+    fs.writeFileSync(file, lines.join('\n'));
+
+    const result = runVerify(tmpDir);
+    assert.strictEqual(result.status, 1, `drift 감지 exit 1 기대. status=${result.status}`);
+    assert.ok(
+      result.stderr.includes('[qa]') && result.stderr.includes('순서'),
+      `[qa] + 순서 키워드 기대. stderr=${result.stderr}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('agent SSoT drift guard: 에이전트 파일 누락 시 실패', () => {
+  const tmpDir = setupIsolatedAgentDir();
+  try {
+    // pm.md 삭제
+    fs.unlinkSync(path.join(tmpDir, 'pm.md'));
+    const result = runVerify(tmpDir);
+    assert.strictEqual(result.status, 1, `파일 누락 감지 exit 1 기대. status=${result.status}`);
+    assert.ok(
+      result.stderr.includes('[pm]') && result.stderr.includes('파일 없음'),
+      `[pm] + 파일 없음 메시지 기대. stderr=${result.stderr}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

v2.23.0 MINOR release merge PR (develop → main). **merge commit 방식 (`--merge`)** 필수.

## 포함된 변경

- [#145](https://github.com/coseo12/harness-setting/issues/145) — agent SSoT drift 자동 가드 (Z 옵션)

## 포함된 PR

- [#154](https://github.com/coseo12/harness-setting/pull/154) `[#145] agent SSoT drift 자동 가드 (MINOR, Z 옵션)`
- [#155](https://github.com/coseo12/harness-setting/pull/155) `chore(release): v2.23.0` (version bump)

## Behavior Changes

- CI `detect-and-test` 에 `verify-agent-ssot.sh` drift 가드 step 추가 (PR 머지 전 자동 차단)
- PR 템플릿 SSoT 동기화 체크박스

## 머지 절차

1. `gh pr merge <이 PR> --merge`
2. `git push origin main:develop` — fast-forward
3. `git tag v2.23.0` + release
4. auto-close 검증: `#145`

Closes #145

🤖 Generated with [Claude Code](https://claude.com/claude-code)