### PR TITLE
chore(release): v2.24.0 — #153 CI npm test 실 실행 복구 (MINOR)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Summary

v2.24.0 MINOR 릴리스 준비. `package.json` version bump.

- [#153](https://github.com/coseo12/harness-setting/issues/153) — CI `detect-and-test` 의 Node.js `npm test` 실 실행 복구
- 포함 PR: [#158](https://github.com/coseo12/harness-setting/pull/158)

## Behavior Changes

- CI `detect-and-test` 가 실제 `npm test` 실행 (기존 `echo` 만 수행). PR 머지 전 새 회귀 차단 게이트
- `scripts.test` 를 `--test-concurrency=1` 로 변경 (flaky 임시 조치, 후속 [#157](https://github.com/coseo12/harness-setting/issues/157))

## 후속 이슈

- [#157](https://github.com/coseo12/harness-setting/issues/157) — post-apply 검증 테스트 병렬 실행 간섭 근본 원인 분석 (low)

## 태그 계획

- `v2.24.0`
- `gh release create v2.24.0 --notes <CHANGELOG 인용>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)