### PR TITLE
chore(release): v2.24.0 — #153 CI npm test 복구 (develop → main)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,13 +12,46 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Node.js 프로젝트 감지
-      - name: Node.js 테스트
+      # Node.js 프로젝트 감지 (감지 메시지만 — 실제 실행은 아래 step 들)
+      - name: Node.js 프로젝트 감지
         if: hashFiles('package.json') != ''
         run: |
           node_version=$(jq -r '.engines.node // "20"' package.json | grep -oE '[0-9]+' | head -1)
           echo "Node.js ${node_version} 사용"
-        # Node 설정은 프로젝트별로 추가
+
+      # Node.js 실 테스트 (#153)
+      # - setup-node 는 package.json 존재 시 실행. node-version-file 이 engines.node 의 semver range 도 해석
+      # - cache 는 package-lock.json 이 있을 때만 활성화 (setup-node v4 가 알아서 skip)
+      # - npm ci 는 package-lock.json 이 있을 때만 (재현 가능한 정확한 설치)
+      # - npm install --no-audit --no-fund 는 lock 이 없는 Node 프로젝트 fallback
+      # - npm test --if-present 는 scripts.test 없으면 조용히 skip (다운스트림 호환성)
+      # setup-node@v4 는 cache: 'npm' 지정 시 package-lock.json 부재면 실제 fail
+       # (실측: "Dependencies lock file is not found" 에러로 step 실패) 하므로 분기 필수
+       # — Gemini non-blocking 권고 (단일화) 실측 오탐 확인, 2 step 유지
+      - name: Node.js setup (lockfile 있음, npm cache 활성)
+        if: hashFiles('package-lock.json') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Node.js setup (lockfile 없음, cache 비활성)
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: npm ci (lockfile 있을 때)
+        if: hashFiles('package-lock.json') != ''
+        run: npm ci
+
+      - name: npm install (lockfile 없을 때 fallback)
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == ''
+        run: npm install --no-audit --no-fund --ignore-scripts
+
+      - name: npm test
+        if: hashFiles('package.json') != ''
+        run: npm test --if-present
 
       # Python 프로젝트 감지
       - name: Python 테스트

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [2.24.0] — 2026-04-20
+
+[#153](https://github.com/coseo12/harness-setting/issues/153) — CI `detect-and-test` 의 Node.js `npm test` 실 실행 복구 (MINOR).
+
+### Behavior Changes
+
+- **CI `detect-and-test` 의 Node.js 브랜치가 실제 테스트를 실행** — 기존에는 `echo` 로 감지만 수행하여 모든 PR 이 CI 에서 테스트되지 않은 상태로 머지됐다. 이제 `actions/setup-node@v4` (node-version-file: `package.json` 의 `engines.node` 참조) + `npm ci` (lockfile 있을 때) 또는 `npm install --no-audit --no-fund --ignore-scripts` (없을 때 fallback) + `npm test --if-present` 실행. 로컬 통과와 CI 통과가 일치해야 PR 머지 가능 — 새 회귀 차단 게이트.
+- **harness 템플릿 호환성 유지**: `hashFiles('package.json')` / `hashFiles('package-lock.json')` 조건 게이트로 Node 프로젝트가 아닌 다운스트림은 step 전체 skip. `npm test --if-present` 는 `scripts.test` 미정의 프로젝트도 조용히 skip.
+
+### Fixed
+
+- 세션 전체 PR (`#144` / `#147` / `#150` / `#154`) 이 CI 에서 `npm test` 가 돌지 않은 채 머지됐던 구조적 결함 해소. 이번 PR 이후 머지되는 PR 부터 실 테스트가 회귀 게이트로 동작.
+
+### Notes
+
+- 이 저장소 자체는 의존성 0개 (`dependencies` / `devDependencies` 섹션 없음) + `package-lock.json` 부재. `npm install fallback` 분기를 통해 lock 없이도 테스트 실행.
+- Node version 은 `package.json::engines.node` (`>=16.7.0`) 의 semver range 를 `setup-node@v4` 가 해석.
+- **`scripts.test` 를 `--test-concurrency=1` 로 변경** — 착수 중 `test/previous-sha256.test.js:140` / `test/update-verification.test.js:172` 의 `post-apply 검증: 정상 apply 시 ok=true` 테스트가 병렬 실행 시 간헐 실패하는 flaky 확인. CI 안정성을 위해 순차 실행으로 임시 조치. 실행 시간 6s → 18s. 근본 원인 분석 + 병렬 복구는 후속 이슈 [#157](https://github.com/coseo12/harness-setting/issues/157) (low).
+
 ## [2.23.0] — 2026-04-20
 
 [#145](https://github.com/coseo12/harness-setting/issues/145) — 공통 JSON 스키마 (SSoT) drift 자동 가드 도입 (MINOR).

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "harness": "./bin/harness.js"
   },
   "scripts": {
-    "test": "node --test \"test/**/*.test.js\""
+    "test": "node --test --test-concurrency=1 \"test/**/*.test.js\""
   },
   "files": [
     "bin/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.23.0",
+  "version": "2.24.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Summary

v2.24.0 MINOR release merge PR (develop → main). **merge commit 방식 (`--merge`)** 필수.

## 포함된 변경

- [#153](https://github.com/coseo12/harness-setting/issues/153) — CI `detect-and-test` 의 `npm test` 실 실행 복구

## 포함된 PR

- [#158](https://github.com/coseo12/harness-setting/pull/158) `[#153] CI detect-and-test npm test 실 실행 복구 (MINOR)`
- [#159](https://github.com/coseo12/harness-setting/pull/159) `chore(release): v2.24.0` (version bump)

## Behavior Changes

- CI `detect-and-test` 가 실제 `npm test` 실행 (기존 `echo` 만 수행). PR 머지 전 새 회귀 차단 게이트
- `scripts.test` 를 `--test-concurrency=1` 로 변경 (flaky 임시 조치, 후속 #157)

## 머지 절차

1. `gh pr merge <이 PR> --merge`
2. `git push origin main:develop` — fast-forward
3. `git tag v2.24.0` + release
4. auto-close 검증: `#153`

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)