### PR TITLE
chore(release): v2.25.0 — #157 .claude/logs user-only + 테스트 병렬 복구 (MINOR)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.24.0",
+  "version": "2.25.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Summary

v2.25.0 MINOR. `package.json` version bump.

- [#157](https://github.com/coseo12/harness-setting/issues/157) — `.claude/logs/` 를 `user-only` 로 분류 + 테스트 병렬 실행 복구
- 포함 PR: [#161](https://github.com/coseo12/harness-setting/pull/161)

## Behavior Changes

- `.claude/logs/**` 가 tracked 에서 제외 → `harness update` 대상 아님
- 다운스트림 매니페스트 기존 엔트리 있으면 `removed-upstream` 정리
- `scripts.test` 병렬 실행 복구 (sequential 18s → parallel 7.5s, CI 2.4s)

## 태그 계획

- `v2.25.0`
- `gh release create v2.25.0 --notes <CHANGELOG 인용>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)