### PR TITLE
release: v2.28.2 — #175 CI pnpm 프로젝트 지원 (PATCH bug fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,38 +19,62 @@ jobs:
           node_version=$(jq -r '.engines.node // "20"' package.json | grep -oE '[0-9]+' | head -1)
           echo "Node.js ${node_version} 사용"
 
-      # Node.js 실 테스트 (#153)
-      # - setup-node 는 package.json 존재 시 실행. node-version-file 이 engines.node 의 semver range 도 해석
-      # - cache 는 package-lock.json 이 있을 때만 활성화 (setup-node v4 가 알아서 skip)
-      # - npm ci 는 package-lock.json 이 있을 때만 (재현 가능한 정확한 설치)
-      # - npm install --no-audit --no-fund 는 lock 이 없는 Node 프로젝트 fallback
-      # - npm test --if-present 는 scripts.test 없으면 조용히 skip (다운스트림 호환성)
-      # setup-node@v4 는 cache: 'npm' 지정 시 package-lock.json 부재면 실제 fail
-       # (실측: "Dependencies lock file is not found" 에러로 step 실패) 하므로 분기 필수
-       # — Gemini non-blocking 권고 (단일화) 실측 오탐 확인, 2 step 유지
+      # Node.js 실 테스트 (#153 / pnpm 지원 #175)
+      # 패키지 매니저 우선순위: pnpm-lock.yaml > package-lock.json > (lock 없음, npm fallback)
+      # 배타 조건 분기 — pnpm 과 npm step 은 동시에 실행되지 않는다
+      #
+      # - pnpm 경로: pnpm-lock.yaml 감지 → pnpm/action-setup (package.json::packageManager 자동 감지)
+      #   + setup-node cache='pnpm' + pnpm install --frozen-lockfile + pnpm test --if-present
+      # - npm lock 경로: package-lock.json 감지 (pnpm-lock 없음) → setup-node cache='npm' + npm ci + npm test
+      # - lock 없음 fallback: package.json 만 있을 때 → setup-node (cache 비활성) + npm install + npm test
+      #
+      # setup-node@v4 는 cache: 'npm'/'pnpm' 지정 시 해당 lock 부재면 실패하므로 분기 필수
+      # — Gemini non-blocking 권고 (단일화) 실측 오탐 확인, 다중 step 유지
+
+      # --- pnpm 경로 ---
+      - name: pnpm setup
+        if: hashFiles('pnpm-lock.yaml') != ''
+        uses: pnpm/action-setup@v4
+
+      - name: Node.js setup (pnpm)
+        if: hashFiles('pnpm-lock.yaml') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: pnpm install
+        if: hashFiles('pnpm-lock.yaml') != ''
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm test
+        if: hashFiles('pnpm-lock.yaml') != ''
+        run: pnpm test --if-present
+
+      # --- npm 경로 (pnpm-lock 없을 때만) ---
       - name: Node.js setup (lockfile 있음, npm cache 활성)
-        if: hashFiles('package-lock.json') != ''
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == ''
         uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
           cache: 'npm'
 
       - name: Node.js setup (lockfile 없음, cache 비활성)
-        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == ''
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == ''
         uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
 
       - name: npm ci (lockfile 있을 때)
-        if: hashFiles('package-lock.json') != ''
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == ''
         run: npm ci
 
       - name: npm install (lockfile 없을 때 fallback)
-        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == ''
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == ''
         run: npm install --no-audit --no-fund --ignore-scripts
 
       - name: npm test
-        if: hashFiles('package.json') != ''
+        if: hashFiles('package.json') != '' && hashFiles('pnpm-lock.yaml') == ''
         run: npm test --if-present
 
       # Python 프로젝트 감지

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [2.28.2] — 2026-04-20
+
+[#175](https://github.com/coseo12/harness-setting/issues/175) — CI 템플릿 (`.github/workflows/ci.yml`) 의 `detect-and-test` job 에 pnpm 프로젝트 지원 추가 (PATCH — bug fix).
+
+### Behavior Changes
+
+- **pnpm 프로젝트**: 이전에 `sh: 1: pnpm: not found` 로 실패하던 `detect-and-test` 가 정상 동작. `pnpm/action-setup@v4` + `setup-node cache='pnpm'` + `pnpm install --frozen-lockfile` + `pnpm test --if-present` 경로 신규
+- **npm 프로젝트**: 영향 없음. 기존 npm 경로에 `hashFiles('pnpm-lock.yaml') == ''` 배타 조건만 추가 (lock 파일 우선순위 명시)
+- **lock 없는 Node 프로젝트**: 영향 없음
+
+### Fixed
+
+- **CI `detect-and-test` pnpm 지원** — `.github/workflows/ci.yml` 에 pnpm-lock.yaml 감지 분기 추가. 패키지 매니저 우선순위 명시: `pnpm-lock.yaml > package-lock.json > (lock 없음, npm fallback)`. pnpm 과 npm step 은 `hashFiles` 조건으로 **배타 실행** (lock 충돌 시 pnpm 우선)
+- v2.15.0 (#153) 에서 `detect-and-test` 가 "감지만" 에서 "실제 실행" 으로 확장됐을 때 누락된 pnpm 경로 복구. 다운스트림 관찰: astro-simulator#270 에서 v2.15.0 → v2.28.1 업데이트 시 CI red
+
+### Notes
+
+- pnpm 버전은 `package.json::packageManager` 필드에서 자동 감지 (pnpm/action-setup@v4 기본 동작). `packageManager` 필드 부재 시 action 이 명시 에러 → 다운스트림에 명확한 시그널
+- PATCH 분류 근거: 기존 npm 프로젝트 행동 불변 + pnpm 프로젝트는 "실패 → 복구" 범주 (다른 결과가 아닌 원래 의도대로 동작). `### Behavior Changes` 는 frozen 파일 변경 원칙(CLAUDE.md `### 릴리스`) 에 따라 명시
+
 ## [2.28.1] — 2026-04-20
 
 v2.26.0 ~ v2.28.0 의 `package.json` `version` bump 누락 복구 + 회귀 가드 도입 (PATCH).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.28.1",
+  "version": "2.28.2",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Summary

v2.28.2 PATCH release — CI 템플릿의 pnpm 프로젝트 미지원 회귀 복구.

## Behavior Changes

- **pnpm 프로젝트**: 이전에 `sh: 1: pnpm: not found` 로 실패하던 `detect-and-test` 가 정상 동작
- **npm / lock 없는 프로젝트**: 영향 없음 (기존 npm step 에 배타 조건만 추가)

## Range

- v2.28.1..v2.28.2
- 포함 PR: #176 (fix #175)

## 태그 계획

- `v2.28.2` 태그 생성 + GitHub release

## 다운스트림 관찰

- [astro-simulator#270](https://github.com/coseo12/astro-simulator/pull/270) — 본 릴리스 적용 후 재-`harness update` → `detect-and-test` green

## Test plan

- [x] develop 기반 CI 통과 (#176 에서 확인)
- [x] `verify-release-version-bump.sh` 2.28.2 일치
- [x] `npm test` 56 pass / 0 fail
- [ ] merge commit 방식으로 머지 (--merge, --squash 금지)
- [ ] main tip → develop fast-forward push
- [ ] `git tag v2.28.2 + gh release create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)