### PR TITLE
feat(ci): Python/Go/Rust 실 실행 복구 + yarn (berry + classic) 지원 (MINOR)

### DIFF
--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -14,19 +14,44 @@ description: |
 
 ## 감지 순서
 
-아래 순서로 프로젝트의 테스트 환경을 감지한다. 첫 번째로 매칭되는 것을 사용한다.
+아래 우선순위로 프로젝트의 테스트 환경을 감지한다. 같은 언어 내에서는 **lock 파일 우선순위** 로 도구를 결정 (여러 lock 공존 시 상위 우선).
+
+### Node.js (lock 파일 우선순위)
+
+| 감지 파일 | 도구 | 실행 명령 |
+|---|---|---|
+| `pnpm-lock.yaml` | pnpm | `pnpm install --frozen-lockfile && pnpm test --if-present` |
+| `yarn.lock` + `.yarnrc.yml` | yarn berry (v2+) | `yarn install --immutable && yarn test` |
+| `yarn.lock` (`.yarnrc.yml` 부재) | yarn classic (v1) | `yarn install --frozen-lockfile && yarn test` |
+| `bun.lockb` | Bun | `bun install && bun test` (또는 `bun run test`) |
+| `deno.lock` / `deno.json` | Deno | `deno test` |
+| `package-lock.json` | npm | `npm ci && npm test --if-present` |
+| `package.json` (lock 없음) | npm fallback | `npm install --no-audit --no-fund --ignore-scripts && npm test --if-present` |
+
+### Python (lock/manifest 우선순위)
+
+| 감지 파일 | 도구 | 실행 명령 |
+|---|---|---|
+| `uv.lock` | uv | `uv sync --frozen && uv run pytest` |
+| `poetry.lock` | poetry | `poetry install && poetry run pytest` |
+| `Pipfile.lock` | pipenv | `pipenv sync --dev && pipenv run pytest` |
+| `requirements.txt` | pip | `pip install -r requirements.txt && pytest` |
+| `pyproject.toml` (lock 없음) | pip + PEP 621 | `pip install -e .[dev] \|\| pip install -e . && pytest` |
+| `setup.py` (legacy) | pip | `pip install -e . && pytest` |
+
+> **pytest exit code 5** (수집된 테스트 0건) 은 CI 에서 경고로 처리 권장: `pytest || [ $? = 5 ]`
+
+### 기타 언어
 
 | 감지 파일 | 실행 명령 |
-|-----------|-----------|
-| `package.json` (scripts.test 존재) | `npm test` 또는 `yarn test` |
-| `Makefile` (test 타겟 존재) | `make test` |
-| `pyproject.toml` 또는 `setup.py` | `pytest` 또는 `python -m pytest` |
+|---|---|
 | `go.mod` | `go test ./...` |
-| `Cargo.toml` | `cargo test` |
-| `build.gradle` 또는 `build.gradle.kts` | `./gradlew test` |
+| `Cargo.toml` | `cargo test --release --lib` (장기 테스트 이원화는 volt #54 참조) |
+| `build.gradle` / `build.gradle.kts` | `./gradlew test` |
 | `pom.xml` | `mvn test` |
+| `Makefile` (`test:` target) | `make test` |
 
-감지되지 않으면 사용자에게 테스트 실행 방법을 질문한다.
+감지되지 않으면 사용자에게 테스트 실행 방법을 질문한다. 하이브리드 상태 (예: `pnpm-lock.yaml` + `package-lock.json` 혼재) 발견 시 우선순위 상위만 실행하되 **경고** 출력 — 통상 lock 하나만 유지해야 재현성 보장.
 
 ## 실행 절차
 

--- a/.claude/skills/run-tests/SKILL.md
+++ b/.claude/skills/run-tests/SKILL.md
@@ -23,8 +23,8 @@ description: |
 | `pnpm-lock.yaml` | pnpm | `pnpm install --frozen-lockfile && pnpm test --if-present` |
 | `yarn.lock` + `.yarnrc.yml` | yarn berry (v2+) | `yarn install --immutable && yarn test` |
 | `yarn.lock` (`.yarnrc.yml` 부재) | yarn classic (v1) | `yarn install --frozen-lockfile && yarn test` |
-| `bun.lockb` | Bun | `bun install && bun test` (또는 `bun run test`) |
-| `deno.lock` / `deno.json` | Deno | `deno test` |
+| `bun.lockb` | Bun | `bun install && bun test` (또는 `bun run test`) ¹ |
+| `deno.lock` / `deno.json` | Deno | `deno test` ¹ |
 | `package-lock.json` | npm | `npm ci && npm test --if-present` |
 | `package.json` (lock 없음) | npm fallback | `npm install --no-audit --no-fund --ignore-scripts && npm test --if-present` |
 
@@ -39,6 +39,8 @@ description: |
 | `pyproject.toml` (lock 없음) | pip + PEP 621 | `pip install -e .[dev] \|\| pip install -e . && pytest` |
 | `setup.py` (legacy) | pip | `pip install -e . && pytest` |
 
+> ¹ **Bun / Deno — 감지 테이블 정의만, CI 자동 실행 미구현**: 현재 `.github/workflows/ci.yml` 에는 Bun/Deno 경로 step 없음. 다운스트림이 직접 step 추가 필요 (volt #49 주석-구현 drift 경계). 향후 harness 에 추가 검토 — volt 후속 이슈 대상.
+>
 > **pytest exit code 5** (수집된 테스트 0건) 은 CI 에서 경고로 처리 권장: `pytest || [ $? = 5 ]`
 
 ### 기타 언어

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,24 +12,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Node.js 프로젝트 감지 (감지 메시지만 — 실제 실행은 아래 step 들)
+      # ============================================================
+      # Node.js 생태계 (pnpm > yarn > npm lock > npm fallback)
+      # ============================================================
+      # 패키지 매니저 우선순위: pnpm-lock.yaml > yarn.lock > package-lock.json > (lock 없음, npm fallback)
+      # 배타 조건 분기 — 각 경로는 다른 경로의 lock 파일이 없을 때만 실행
+      #
+      # setup-node@v4 는 cache: 'npm'/'pnpm'/'yarn' 지정 시 해당 lock 부재면 step 실패하므로 분기 필수
+      # — volt #51 Gemini 단일화 권고 실측 오탐 확인, 다중 step 유지
+
       - name: Node.js 프로젝트 감지
         if: hashFiles('package.json') != ''
         run: |
           node_version=$(jq -r '.engines.node // "20"' package.json | grep -oE '[0-9]+' | head -1)
           echo "Node.js ${node_version} 사용"
-
-      # Node.js 실 테스트 (#153 / pnpm 지원 #175)
-      # 패키지 매니저 우선순위: pnpm-lock.yaml > package-lock.json > (lock 없음, npm fallback)
-      # 배타 조건 분기 — pnpm 과 npm step 은 동시에 실행되지 않는다
-      #
-      # - pnpm 경로: pnpm-lock.yaml 감지 → pnpm/action-setup (package.json::packageManager 자동 감지)
-      #   + setup-node cache='pnpm' + pnpm install --frozen-lockfile + pnpm test --if-present
-      # - npm lock 경로: package-lock.json 감지 (pnpm-lock 없음) → setup-node cache='npm' + npm ci + npm test
-      # - lock 없음 fallback: package.json 만 있을 때 → setup-node (cache 비활성) + npm install + npm test
-      #
-      # setup-node@v4 는 cache: 'npm'/'pnpm' 지정 시 해당 lock 부재면 실패하므로 분기 필수
-      # — Gemini non-blocking 권고 (단일화) 실측 오탐 확인, 다중 step 유지
 
       # --- pnpm 경로 ---
       - name: pnpm setup
@@ -51,54 +47,173 @@ jobs:
         if: hashFiles('pnpm-lock.yaml') != ''
         run: pnpm test --if-present
 
-      # --- npm 경로 (pnpm-lock 없을 때만) ---
+      # --- yarn 경로 (pnpm-lock 없을 때만) ---
+      # yarn berry (v2+) vs classic (v1) 감지:
+      # - `.yarnrc.yml` 존재 → berry → `yarn install --immutable` (v2+ 필수, v4+ 는 --frozen-lockfile 제거)
+      # - `.yarnrc.yml` 부재 → classic (v1) → `yarn install --frozen-lockfile`
+      # setup-node cache: 'yarn' 은 양쪽 모두 지원
+      - name: Node.js setup (yarn)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'yarn'
+
+      - name: Enable corepack (yarn packageManager field 우선)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        run: corepack enable
+
+      - name: yarn install (berry — .yarnrc.yml 존재)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('.yarnrc.yml') != ''
+        run: yarn install --immutable
+
+      - name: yarn install (classic — .yarnrc.yml 부재)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('.yarnrc.yml') == ''
+        run: yarn install --frozen-lockfile
+
+      - name: yarn test
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        # `yarn test` 는 berry/classic 모두 `scripts.test` 실행. --if-present 없으므로 스킵 시 실패
+        # → scripts.test 부재일 때를 위해 조건 체크 (node -e 로 파싱)
+        run: |
+          if node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
+            yarn test
+          else
+            echo "scripts.test 미정의 — skip"
+          fi
+
+      # --- npm 경로 (pnpm/yarn lock 없을 때만) ---
       - name: Node.js setup (lockfile 있음, npm cache 활성)
-        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == ''
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
         uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
           cache: 'npm'
 
       - name: Node.js setup (lockfile 없음, cache 비활성)
-        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == ''
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
         uses: actions/setup-node@v4
         with:
           node-version-file: 'package.json'
 
       - name: npm ci (lockfile 있을 때)
-        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == ''
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
         run: npm ci
 
       - name: npm install (lockfile 없을 때 fallback)
-        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == ''
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
         run: npm install --no-audit --no-fund --ignore-scripts
 
       - name: npm test
-        if: hashFiles('package.json') != '' && hashFiles('pnpm-lock.yaml') == ''
+        if: hashFiles('package.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
         run: npm test --if-present
 
-      # Python 프로젝트 감지
-      - name: Python 테스트
-        if: hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != ''
-        run: |
-          echo "Python 프로젝트 감지됨"
-        # Python 설정은 프로젝트별로 추가
+      # ============================================================
+      # Python 생태계 (uv > poetry > pipenv > pip / requirements)
+      # ============================================================
+      # 패키지 매니저 우선순위: uv.lock > poetry.lock > Pipfile.lock > pyproject.toml (pip) > requirements.txt
+      # 배타 조건 — 하나만 실행
+      # `pytest --if-present` 같은 flag 는 없으므로, scripts.test 유무 검사 대신 pytest 가 수집한 테스트 0 건이어도 exit 5 를
+      # warning 으로 처리 (`pytest || [ $? = 5 ]`) — pytest 없는 프로젝트는 해당 step 자체가 실행되지 않도록 lock/config 감지 기반
 
-      # Go 프로젝트 감지
-      - name: Go 테스트
+      - name: Python 프로젝트 감지
+        if: hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != ''
+        run: echo "Python 프로젝트 감지됨"
+
+      # --- uv 경로 ---
+      - name: uv 설치 + sync + pytest (uv.lock)
+        if: hashFiles('uv.lock') != ''
+        run: |
+          curl -LsSf https://astral.sh/uv/install.sh | sh
+          export PATH="$HOME/.local/bin:$PATH"
+          uv sync --frozen
+          uv run --no-sync pytest || [ $? = 5 ]
+
+      # --- poetry 경로 ---
+      - name: Python setup (poetry)
+        if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: 'pyproject.toml'
+          cache: 'poetry'
+
+      - name: poetry install + pytest
+        if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
+        run: |
+          pipx install poetry || pip install --user poetry
+          poetry install --no-interaction --no-ansi
+          poetry run pytest || [ $? = 5 ]
+
+      # --- pipenv 경로 ---
+      - name: Python setup (pipenv)
+        if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version-file: 'Pipfile'
+          cache: 'pipenv'
+
+      - name: pipenv install + pytest
+        if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
+        run: |
+          pip install --user pipenv
+          pipenv sync --dev
+          pipenv run pytest || [ $? = 5 ]
+
+      # --- pip 경로 (requirements.txt 또는 pyproject.toml 의 PEP 621 메타데이터) ---
+      - name: Python setup (pip / pyproject)
+        if: (hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: pip install + pytest (requirements.txt 우선)
+        if: (hashFiles('requirements.txt') != '' || hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          elif [ -f pyproject.toml ]; then
+            pip install -e .[dev] 2>/dev/null || pip install -e .
+          elif [ -f setup.py ]; then
+            pip install -e .
+          fi
+          pip install pytest
+          # pytest exit 5 = "no tests collected" — 경고로 처리
+          pytest || [ $? = 5 ]
+
+      # ============================================================
+      # Go 생태계
+      # ============================================================
+      - name: Go setup
         if: hashFiles('go.mod') != ''
-        run: |
-          echo "Go 프로젝트 감지됨"
-        # Go 설정은 프로젝트별로 추가
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
 
-      # Rust 프로젝트 감지
-      - name: Rust 테스트
+      - name: go test
+        if: hashFiles('go.mod') != ''
+        run: go test ./...
+
+      # ============================================================
+      # Rust 생태계
+      # ============================================================
+      # cargo test --lib 기본 실행. 장기 테스트 이원화 (volt #54) 는 다운스트림이
+      # 별도 test-long-integration job 으로 확장 — 본 step 은 일상 경로만
+      - name: Rust toolchain setup
         if: hashFiles('Cargo.toml') != ''
-        run: |
-          echo "Rust 프로젝트 감지됨"
-        # Rust 설정은 프로젝트별로 추가
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
 
-      # Makefile 기반
+      - name: cargo test (일상 경로, --lib)
+        if: hashFiles('Cargo.toml') != ''
+        run: cargo test --release --lib
+
+      # ============================================================
+      # 기타 (Makefile 폴백)
+      # ============================================================
       - name: Make 테스트
         if: hashFiles('Makefile') != ''
         run: |
@@ -106,6 +221,9 @@ jobs:
             make test
           fi
 
+      # ============================================================
+      # harness 저장소 전용 가드 (다운스트림은 hashFiles 조건으로 skip)
+      # ============================================================
       # agent SSoT drift 가드 (#145)
       # CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 9개 필드가
       # 5개 에이전트 파일의 `## 마무리 체크리스트 JSON 반환` 섹션에 모두 존재하고 선언 순서를

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,36 +136,50 @@ jobs:
           uv run --no-sync pytest || [ $? = 5 ]
 
       # --- poetry 경로 ---
+      # NOTE (reviewer #178 권고 반영):
+      # - setup-python cache 지시어를 설치 도구 정의 시점에 쓰면 첫 실행에서 캐시 스킵 경고 발생 (도구 미존재).
+      #   → `cache:` 는 도구 설치 후 별도 재설정이 이상적이나 action 한계상 생략하고 캐시 없이 진행
+      # - `python-version-file: 'pyproject.toml'` 는 `[project].requires-python` 또는 `[tool.poetry].python` 필드 부재 시 실패.
+      #   → python-version '3.x' 로 fallback (프로젝트가 특정 버전 고정 원하면 pyproject.toml 에 직접 명시)
+      # - `poetry install` 이 dev-dependencies 에 pytest 를 포함한다고 암묵 전제하면 `poetry run pytest` 가 command not found.
+      #   → `poetry install` 이후 `poetry run python -c 'import pytest'` 로 감지 실패 시 `poetry run pip install pytest` 로 명시 보강
       - name: Python setup (poetry)
         if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
         uses: actions/setup-python@v5
         with:
-          python-version-file: 'pyproject.toml'
-          cache: 'poetry'
+          python-version: '3.x'
 
       - name: poetry install + pytest
         if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
         run: |
           pipx install poetry || pip install --user poetry
           poetry install --no-interaction --no-ansi
+          poetry run python -c "import pytest" 2>/dev/null || poetry run pip install pytest
           poetry run pytest || [ $? = 5 ]
 
       # --- pipenv 경로 ---
+      # NOTE (reviewer #178 권고 반영): Pipfile python_version 필드 부재 시 setup-python 실패 가능 → '3.x' fallback.
+      # pipenv sync --dev 도 dev-packages 에 pytest 없으면 `pipenv run pytest` 가 실패 → 감지 후 명시 설치
       - name: Python setup (pipenv)
         if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
         uses: actions/setup-python@v5
         with:
-          python-version-file: 'Pipfile'
-          cache: 'pipenv'
+          python-version: '3.x'
 
       - name: pipenv install + pytest
         if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
         run: |
           pip install --user pipenv
           pipenv sync --dev
+          pipenv run python -c "import pytest" 2>/dev/null || pipenv run pip install pytest
           pipenv run pytest || [ $? = 5 ]
 
       # --- pip 경로 (requirements.txt 또는 pyproject.toml 의 PEP 621 메타데이터) ---
+      # 배타 조건: uv.lock / poetry.lock / Pipfile.lock 모두 없을 때. 세 가지 감지 파일 중 하나 이상 있으면 실행:
+      #   1) requirements.txt (우선) → pip install -r
+      #   2) pyproject.toml → pip install -e .[dev] 시도 → 실패 시 pip install -e .
+      #   3) setup.py (legacy) → pip install -e .
+      # pyproject.toml 이 if 조건과 run 분기 양쪽에 등장하는 이유: uv/poetry 가 아닌 단순 PEP 621 프로젝트도 pip 가 처리
       - name: Python setup (pip / pyproject)
         if: (hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
         uses: actions/setup-python@v5
@@ -205,17 +219,19 @@ jobs:
       # ============================================================
       # Rust 생태계
       # ============================================================
-      # cargo test --lib 기본 실행. 장기 테스트 이원화 (volt #54) 는 다운스트림이
+      # cargo test --lib 기본 실행 (debug 빌드). 장기 테스트 이원화 (volt #54) 는 다운스트림이
       # 별도 test-long-integration job 으로 확장 — 본 step 은 일상 경로만
+      # NOTE (reviewer #178 권고 반영): 기존 `--release` 옵션은 "일상 경로" 의도와 상충 (일상은 빠른 debug 빌드).
+      # release 빌드 검증이 필요한 프로젝트는 별도 job 에서 `cargo test --release --lib` 실행 권장.
       - name: Rust toolchain setup
         if: hashFiles('Cargo.toml') != ''
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: stable
 
-      - name: cargo test (일상 경로, --lib)
+      - name: cargo test (일상 경로, --lib, debug)
         if: hashFiles('Cargo.toml') != ''
-        run: cargo test --release --lib
+        run: cargo test --lib
 
       # ============================================================
       # 기타 (Makefile 폴백)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,17 @@ jobs:
         run: echo "Python 프로젝트 감지됨"
 
       # --- uv 경로 ---
-      - name: uv 설치 + sync + pytest (uv.lock)
+      # 공식 astral-sh/setup-uv action 사용 — `curl | sh` 패턴 대비 (a) 버전 고정 (b) 캐싱 (c) MITM/공급망 공격 표면 축소
+      # Gemini cross-validate (PR #178) 보안 권고 수용
+      - name: uv setup
+        if: hashFiles('uv.lock') != ''
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: uv sync + pytest (uv.lock)
         if: hashFiles('uv.lock') != ''
         run: |
-          curl -LsSf https://astral.sh/uv/install.sh | sh
-          export PATH="$HOME/.local/bin:$PATH"
           uv sync --frozen
           uv run --no-sync pytest || [ $? = 5 ]
 


### PR DESCRIPTION
## Summary

세션 내부 "패키지 관리자 대응 리뷰" 결과물. High 우선순위 [A][B][C] + Medium 의 yarn (berry 포함) 통합 반영.

### 반영 서브항목

| 항목 | 내용 | 근거 |
|---|---|---|
| [A] Python | echo-only → pytest 실 실행. uv/poetry/pipenv/pip/requirements/setup.py 6 도구 분기 | volt [#48](https://github.com/coseo12/volt/issues/48) "CI 통과 ≠ 테스트 실행" 재발 방지 |
| [B] Go | echo-only → setup-go@v5 + go test ./... | 동일 |
| [C] Rust | echo-only → setup-rust-toolchain + cargo test --release --lib | 동일. 장기 테스트 이원화(volt [#54](https://github.com/coseo12/volt/issues/54))는 다운스트림 옵션 |
| [D] yarn | yarn.lock 감지 + berry/classic 자동 분기 (`.yarnrc.yml` 유무) | 리뷰에서 사용자 지정 |

## Behavior Changes (요약)

- **Python/Go/Rust 프로젝트**: CI 가 처음으로 **실제 테스트** 를 돌림. 기존 echo-only 상태에서 초록 체크 머지 가능하던 no-op 함정 해소
- **Node.js yarn**: 배타 조건 분기 (pnpm > yarn > npm lock > npm fallback)
  - yarn berry: `yarn install --immutable` + `yarn test`
  - yarn classic: `yarn install --frozen-lockfile` + `yarn test`
  - corepack enable 로 `packageManager` 필드 우선 존중

## 외부 툴 주장 실측 가드 준수 (volt #51)

- setup-node@v4 의 `cache: 'yarn'` 은 `yarn.lock` 부재 시 실패 — 기존 pnpm 경로와 동일 패턴. 단일화 대신 배타 조건 다중 step 유지
- pytest exit 5 (수집 0건) 는 CI 에서 경고 처리 (`pytest || [ $? = 5 ]`) — 파이썬 미설정 시 프로젝트에서 false positive 방지
- yarn `--if-present` flag 없음 → `scripts.test` 유무 체크 스크립트 삽입

## run-tests 스킬 동기화

- 감지 테이블 확장: Node.js 7 lock 우선순위 + Python 6 도구 분기
- lock 혼재 경고 원칙 명시 (`pnpm-lock.yaml` + `package-lock.json` 혼재 등)

## Test plan

- [x] `bash scripts/verify-agent-ssot.sh` — 45/45
- [x] `bash scripts/verify-release-version-bump.sh` — 정합
- [x] `npm test` — 56 pass / 0 fail
- [x] YAML 구조 검증 (node 파싱) — 31 steps, 문법 정상
- [x] 한글 U+FFFD 0건
- [ ] reviewer sub-agent 정적 리뷰
- [ ] Gemini cross-validate (MINOR behavior change 앵커)
- [ ] CI 자체 실행 — 본 PR 이 harness 저장소이므로 Node.js (npm) 경로만 커버. 다른 생태계 분기는 다운스트림 프로젝트에서 실측 예정

## 비-범위

- yarn 은 berry + classic 만 (deno/bun 은 Medium Low 로 분리 — 후속 PR)
- `verify-release-version-bump.sh` 의 다언어 확장 (Cargo.toml / pyproject.toml) — Future 로 분리
- `harness doctor` 에 감지된 패키지 관리자 리포트 — Future 로 분리

🤖 Generated with [Claude Code](https://claude.com/claude-code)