### PR TITLE
Release v2.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [2.30.0] — 2026-04-20
+
+[#185](https://github.com/coseo12/harness-setting/pull/185) — volt #59 #60 반영. cross-validate 가드 2차 방어선 + 다운스트림 실측 최종 가드 (MINOR).
+
+### Behavior Changes
+
+- **cross-validate "외부 툴 동작 주장 실측" 가드 Claude 자신에게도 적용 명시** — 기존 "Gemini 제안 시" 가드가 표제 재기술 (`(Claude 도입 / Gemini 제안 공통)`) 로 확장. Claude 가 새 외부 도구 flag 를 도입할 때도 동일 4단계 실측 요구. 근거: volt [#59](https://github.com/coseo12/volt/issues/59) — v2.28.2 pnpm `--if-present` 셀프 위반 실증
+- **"같은 생태계 내 도구 간 flag 호환 가정 금지" 규약 추가** — npm/pnpm/yarn/bun 는 Node.js 생태계여도 CLI 독립 설계. flag 복사 금지 + 각 도구 개별 검증 필수. 그룹 B (호출 시점 가드) 로 체크리스트 2단계 편성
+- **cross-validate 호출 프롬프트에 '신규 외부 도구 flag 실측 질문' 명시 삽입 의무** — "Gemini 의 침묵 = 안전 아님" 박제. 주장하지 않으면 가드 미발동 (volt #59 관찰). 질문 템플릿: "도입한 `<도구>` 의 flag / 각 flag 의 공식 문서 명시 여부 / 같은 생태계 내 다른 도구 flag 복사 여부". volt [#61](https://github.com/coseo12/volt/issues/61) (1회 관찰 후보 추적) 간접 반영
+- **"다운스트림 실측이 최종 가드" 실전 교훈 신규 섹션** — upstream 3중 방어 (단위 테스트 + reviewer + cross-validate) blindspot 인정. upstream 사전 방어 3가지 (긴급 PATCH 파이프라인 템플릿 / 대표 다운스트림 튜플 규격화 / 회귀 가드 소급 승격). 5 적용 시나리오 (Rust crate / npm / Docker / DB migration / LLM 모델). 근거: volt [#60](https://github.com/coseo12/volt/issues/60) — v2.28.2 → astro-simulator#270 → v2.29.1 복구 체인
+
+### Notes
+
+- **cross-validate 폴백 박제 (volt #40 프로토콜)** — 본 PR #185 의 cross-validate 가 Gemini gemini-2.5-pro capacity 소진으로 2회 시도 모두 실패. outcome=`429-fallback-claude-only`. **claude-only analysis completed — 단일 모델 편향 노출 미확보**. 릴리스 후 reminder 이슈 수동 생성하여 API 복구 시 재검증 경로 확보 예정. CLAUDE.md 영구성 우선순위에 따라 본 CHANGELOG `### Notes` 에 1회 기록 (PR 코멘트/커밋/ADR 중복 기록 없음)
+- **1회 관찰 박제 예외 적용**: volt #59 는 "가드 자기 위반" 으로 compile 규약 "3회 이상" 예외 (즉시 박제). volt #60 은 1회 관찰 + 5 적용 시나리오로 관찰 등가 증거력 확보. volt #61 은 CLAUDE.md 편향 5종 박제 보류 (1회 + 일반화 범위 미증명 → 추적 이슈로 누적 대기)
+- **Reviewer 5 권고 전부 반영**: 6단계 → 2 그룹 (A: 사전 실측 / B: 호출 시점) 재구성 / "확장" → "직교 관계" 표현 완화 / 대표 다운스트림 튜플 규격화 / 표제 재기술 / 링크 일관성
+- **Reviewer SSoT `bg_process_handoff` 4번째 variance 관찰** — 본 PR #185 에서 `{}` (빈 객체) 반환. 이전 3회 (#167 누락 / #170 null / #178 누락) 와 다른 4번째 형태. harness [#184](https://github.com/coseo12/harness-setting/issues/184) (sub-agent 반환 JSON 런타임 SSoT 검증) 우선순위 재확인 근거 축적
+- **오늘 2026-04-20 9번째 MINOR 릴리스** — v2.24.0 부터 v2.30.0 까지. Phase 분리 리듬 유지, 각 릴리스 독립 관찰 가능
+
+
 ## [2.29.1] — 2026-04-20
 
 [#181](https://github.com/coseo12/harness-setting/issues/181) — CI pnpm 경로 `--if-present` 인자 forwarding 버그 수정 (PATCH — bug fix).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,6 +187,18 @@ UI가 포함된 작업에서 4축으로 품질을 평가한다:
 - **"로컬 통과 = 안전" 가정 금지** — CI 가 실질 회귀 게이트로 동작하지 않으면 로컬 miss 가 곧 main 오염
 - 근거: volt [#48](https://github.com/coseo12/volt/issues/48) — harness [#153](https://github.com/coseo12/harness-setting/issues/153) (v2.24.0). `.github/workflows/ci.yml` 의 `detect-and-test` 잡이 `echo "Node.js ${node_version} 사용"` 만 수행하고 `npm test` 를 돌리지 않은 채 4개 PR (#144/#147/#150/#154) 이 머지됐던 사례. "staging 성공 ≠ 커밋 내용" (volt [#13](https://github.com/coseo12/volt/issues/13)) 의 파이프라인 버전
 
+### 다운스트림 실측이 최종 가드 — upstream 3중 방어 blindspot
+upstream 의 **단위 테스트 / reviewer / cross-validate** 가 모두 통과해도, 다운스트림 **실 사용 환경** 에서만 드러나는 결함이 있다. upstream 자기 저장소의 테스트 환경이 다운스트림의 환경 매트릭스 전체를 원리적으로 커버할 수 없기 때문. "CI 통과 ≠ 테스트 실행" 과는 **흡수가 아닌 직교 관계** — volt #48 은 "테스트 자체가 안 돈 경우", 본 교훈은 "테스트가 정상적으로 돌았으나 환경 매트릭스 차이로 결함 잔존" 을 다룬다.
+
+- **upstream 이 자기 저장소에서 감지 불가능한 blindspot 존재를 인정**. 3중 방어 (자동 테스트 + reviewer + cross-validate) 의 한계를 받아들이고, release 를 막는 대신 **다운스트림 → upstream 역방향 피드백 속도** 를 최대화
+- **upstream 사전 방어 3가지**:
+  1. **긴급 PATCH 파이프라인 템플릿** — CHANGELOG 엔트리 템플릿 / hotfix 브랜치 규약 / 태그 자동화 (release PR 형식 표준화)
+  2. **대표 다운스트림 명시** — "이 버전을 먼저 적용하는 다운스트림" 을 `docs/downstream-representatives.md` (또는 해당 파일이 없으면 `(프로젝트명, 역할, CI 접근가능여부)` 튜플 형식) 으로 박제. 단순 프로젝트명 나열은 링크 rot 위험 — 튜플/외부화로 구조화
+  3. **회귀 가드 소급 승격** — 다운스트림에서 감지된 결함을 재현하는 테스트 fixture 를 upstream 에 통합. volt [#56](https://github.com/coseo12/volt/issues/56) "암묵 관례의 구조적 승격" 과 동일 패턴
+- **적용 가능 시나리오**: Rust crate ↔ downstream Cargo 빌드 / npm 패키지 ↔ downstream React 앱 / Docker 이미지 ↔ Kubernetes Pod / DB migration ↔ ETL 파이프라인 / LLM 모델 ↔ downstream agent 행동
+- 공통 조건: upstream 자기 테스트가 다운스트림 환경 매트릭스 전체를 커버 못함 + 다운스트림이 자동 CI/관찰 인프라 보유 + 양방향 보고 채널 존재
+- 근거: volt [#60](https://github.com/coseo12/volt/issues/60) — harness v2.28.2 pnpm `--if-present` 버그 (volt [#59](https://github.com/coseo12/volt/issues/59)) 가 upstream 3중 방어 모두 통과 후 다운스트림 [astro-simulator#270](https://github.com/coseo12/astro-simulator/pull/270) 이 v2.28.2 적용 직후 CI red 로 최초 감지 → 19분 내 v2.29.1 복구. harness 저장소 자체는 npm 으로만 테스트하여 pnpm 경로가 자기 CI 에서 실행조차 안 된 구조적 한계
+
 ### workflow_dispatch 2단계 함정 (GitHub Actions)
 `workflow_dispatch` 트리거를 쓰는 workflow 는 default branch (보통 `main`) 반영 후에만 UI/CLI 에서 discover 된다. feature/develop 에만 머지된 상태에서는 `gh workflow run ... --ref develop` 이 `HTTP 404: workflow not found on the default branch` 로 실패한다. 추가로 workflow 가 PR 을 자동 생성하려 하면 저장소 Settings 의 `can_approve_pull_request_reviews` 가 기본 OFF 라서 `##[error]GitHub Actions is not permitted to create or approve pull requests` 로 거부된다.
 
@@ -381,11 +393,18 @@ sub-agent에 적응적 질답·설계 같은 multi-turn 세션을 위임할 때,
   | 4 | **순수주의 원칙 적용** | 원칙 (예: "Fact-First") 을 디폴트 동작으로 문구 그대로 구현 + 기존 UX 관습·접근성 고려 미흡 | "원칙 문구 그대로 적용하면 첫 사용자 인상/학습 곡선이 깨지는가?" "원칙 경로가 '언제든 1-클릭 거리' 인가?" | 디폴트는 **관습·교육적 기본값** 유지 + 원칙 경로를 **접근성 보장** 형태로 제공 (문구 변경 금지, 운영 해석으로 흡수) |
 
   체크리스트 통과 못 한 항목이 있으면 해당 부분을 cross-validate 호출 프롬프트에 **명시적 질문으로 삽입** ("B2 결합 감지 요청" 등) — Gemini 가 그 축에 집중하도록 유도.
-- **외부 툴 동작 주장은 실측 필수** — Gemini 의 개선 제안이 **외부 툴 / CI / 프레임워크 기본값의 세부 동작** 에 관한 주장일 때는 **실측 없이 수용 금지**. "툴이 알아서 처리한다" 류 추측성 서술은 특히 위험. 수용 전 4단계:
-  1. **공식 문서 확인** — Gemini 주장이 공식 문서에 명시되어 있는가? 추측성 기술("자동 skip", "알아서 건너뜀") 은 가드 필요
+- **외부 툴 동작 주장은 실측 필수 (Claude 도입 / Gemini 제안 공통)** — Gemini 의 개선 제안뿐 아니라 **Claude 자신이 새 도구 flag 를 도입** 할 때도 동일 가드 적용. "툴이 알아서 처리한다" 류 추측성 서술은 특히 위험. 가드는 두 그룹:
+
+  **그룹 A — 사전 실측 (4단계)**:
+  1. **공식 문서 확인** — 주장이 공식 문서 / CLI `--help` 출력 / 공식 README 에 명시되어 있는가? **LLM training data cache 의존 금지** — 버전 업데이트로 flag 동작이 바뀌었을 수 있음
   2. **CI / 샌드박스 실측** — 반영 전 별도 커밋 / draft PR 로 동작 확인
   3. **revert 가능한 단위 커밋** — 실측 반증 시 롤백이 용이하도록 작은 단위 커밋
-  4. **오탐 근거 박제** — revert 시 커밋 메시지 + 파일 주석 + CHANGELOG Notes 3곳에 이유 명시 (미래 기여자의 재발굴 방지)
+  4. **오탐 근거 박제** — revert 시 커밋 메시지 + 파일 주석 + CHANGELOG Notes 3곳에 이유 명시
+
+  **그룹 B — 호출 시점 가드 (2단계)**:
+
+  5. **같은 생태계 내 도구 간 flag 호환 가정 금지** (volt [#59](https://github.com/coseo12/volt/issues/59) 가드 셀프 위반 근거) — npm / pnpm / yarn / bun 는 모두 Node.js 생태계여도 CLI 는 **독립 설계**. 한 도구에서 동작하는 flag 가 다른 도구에서 같게 작동한다고 **복사 금지**
+  6. **cross-validate 호출 프롬프트에 명시 질문 삽입** — 본 PR 이 새로 도입한 외부 도구가 있으면 프롬프트에 "**도입한 `<도구>` 의 flag / 각 flag 의 공식 문서 명시 여부 / 같은 생태계 내 다른 도구의 flag 복사 여부**" 질문을 명시적으로 삽입. Gemini 의 "침묵" 이 곧 "안전" 이 아니다 — 주장하지 않으면 가드 미발동 (volt #59)
 - **검증 필수도 매트릭스**:
 
   | 주장 카테고리 | 검증 필수도 | 검증 방법 |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.29.1",
+  "version": "2.30.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Release v2.30.0 (MINOR)

`develop → main` merge commit. 방식 `--merge`.

### 포함
- #185 — volt #59 #60 반영 (cross-validate 가드 2차 방어선 + 다운스트림 실측 최종 가드)
- #187 — CHANGELOG v2.30.0 + package.json bump

### Behavior Changes (CHANGELOG 참조)
- cross-validate 외부 툴 가드 Claude 자신 적용 명시
- 같은 생태계 flag 호환 가정 금지
- 신규 외부 도구 flag 실측 질문 프롬프트 삽입 의무
- '다운스트림 실측이 최종 가드' 실전 교훈 추가

### Notes
- cross-validate Gemini 429 폴백 — CHANGELOG Notes 에 `claude-only analysis completed` 박제
- Reviewer 5 권고 전부 반영
- sub-agent `bg_process_handoff` 4번째 variance 관찰 (harness #184 근거 축적)

🤖 Generated with [Claude Code](https://claude.com/claude-code)