### PR TITLE
[#200] CLAUDE.md 각인 예산 강제 메커니즘 (Phase 2, MINOR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,3 +266,17 @@ jobs:
       - name: release version bump 가드
         if: hashFiles('scripts/verify-release-version-bump.sh') != ''
         run: bash scripts/verify-release-version-bump.sh
+
+      # CLAUDE.md 각인 예산 가드 (#197 Phase 2)
+      # 45k chars 초과 시 exit 1 로 감축 PR 을 강제. 35k/40k 는 warn (exit 0).
+      # 지침: docs/guides/claudemd-governance.md §3 (정량 게이트)
+      - name: CLAUDE.md 각인 예산 가드
+        if: hashFiles('scripts/verify-claudemd-size.sh') != ''
+        run: bash scripts/verify-claudemd-size.sh
+
+      # CLAUDE.md 상대 링크 무결성 가드 (#197 Phase 2)
+      # CLAUDE.md → docs/ 포인터가 많아질수록 link rot 위험 증가 — 파일 존재 검증.
+      # 지침: docs/guides/claudemd-governance.md §4.3
+      - name: CLAUDE.md 상대 링크 무결성 가드
+        if: hashFiles('scripts/verify-docs-links.sh') != ''
+        run: bash scripts/verify-docs-links.sh

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -131,6 +131,32 @@ function runDoctor(cwd = process.cwd()) {
     critical.ok ? '상단 규칙 블록 존재' : 'CLAUDE.md 상단에 CRITICAL DIRECTIVES 블록이 없습니다'
   );
 
+  // 1b. CLAUDE.md 각인 예산 (#197 Phase 2)
+  // 지침: docs/guides/claudemd-governance.md §3 정량 게이트 (35k/40k/45k)
+  // 각인층은 매 세션 전량 어텐션 대상 — 크기가 커질수록 규칙의 상대적 비중 희석
+  if (critical.content) {
+    // 문자 수 (UTF-8 char 단위) — 한글 보정
+    const charCount = [...critical.content].length;
+    const WARN_BOUNDARY = 35000;
+    const WARN_PR = 40000;
+    const FAIL_THRESHOLD = 45000;
+    let status, detail;
+    if (charCount >= FAIL_THRESHOLD) {
+      status = 'fail';
+      detail = `${charCount.toLocaleString()} chars / ${FAIL_THRESHOLD.toLocaleString()} (초과) — 가지치기 필수. docs/guides/claudemd-governance.md §5 참조`;
+    } else if (charCount >= WARN_PR) {
+      status = 'warn';
+      detail = `${charCount.toLocaleString()} chars / PR warn ${WARN_PR.toLocaleString()} — 신규 인라인 블록 금지. 추가 규약은 docs/ 로 추출`;
+    } else if (charCount >= WARN_BOUNDARY) {
+      status = 'warn';
+      detail = `${charCount.toLocaleString()} chars / 경계 ${WARN_BOUNDARY.toLocaleString()} — 가지치기 후보 탐색 권장`;
+    } else {
+      status = 'pass';
+      detail = `${charCount.toLocaleString()} chars / 경계 ${WARN_BOUNDARY.toLocaleString()} (여유)`;
+    }
+    report.add(status, 'CLAUDE.md 각인 예산', detail);
+  }
+
   // 2. 한글 인코딩 깨짐 검사
   // U+FFFD를 문서에서 설명하는 라인(예시/규칙 인용)은 오탐이므로 제외
   if (critical.content) {

--- a/lib/verify-docs-links.js
+++ b/lib/verify-docs-links.js
@@ -1,0 +1,89 @@
+#!/usr/bin/env node
+'use strict';
+
+// CLAUDE.md 내 상대 링크 (docs/, .github/, scripts/, .claude/, test/ 등) 의 파일 존재를 검증.
+// 비대화 방지 지침에 따라 추출이 많아질수록 link rot 위험 증가 — 본 스크립트로 구조적 방어.
+//
+// 검증 범위:
+//   - 코드펜스 (```...```) 블록 내부 스킵
+//   - 인라인 코드 (`...`) 내부 스킵 (placeholder 표기로 간주)
+//   - 외부 URL (http*, //, mailto:, ftp:, data:) 스킵
+//   - 앵커 전용 링크 (#section) 스킵
+//   - 파일#anchor 링크는 파일 부분만 존재 확인
+//
+// 환경변수:
+//   CLAUDEMD_FILE : 검사 대상 파일 (기본 PROJECT_ROOT/CLAUDE.md)
+//
+// 근거: harness #197 Phase 2, docs/guides/claudemd-governance.md §4.3
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const TARGET_FILE = process.env.CLAUDEMD_FILE || path.join(PROJECT_ROOT, 'CLAUDE.md');
+
+if (!fs.existsSync(TARGET_FILE)) {
+  console.error(`verify-docs-links: 파일 없음: ${TARGET_FILE}`);
+  process.exit(1);
+}
+
+const content = fs.readFileSync(TARGET_FILE, 'utf8');
+const lines = content.split('\n');
+
+// 마크다운 링크 매처 — `[text](url)` 의 url 부분 추출
+const LINK_PATTERN = /\]\(([^)]+)\)/g;
+// 외부 URL 프리픽스
+const EXTERNAL_PREFIXES = [/^https?:\/\//, /^\/\//, /^mailto:/, /^ftp:/, /^data:/];
+
+let inFence = false;
+const extracted = [];
+
+for (const line of lines) {
+  if (line.startsWith('```')) {
+    inFence = !inFence;
+    continue;
+  }
+  if (inFence) continue;
+
+  // 인라인 코드 (단일 백틱 쌍) 제거 — 내부 예시 링크 표기 (예: `[foo](경로)`) 는 실제 링크 아님
+  const stripped = line.replace(/`[^`]*`/g, '');
+
+  let match;
+  LINK_PATTERN.lastIndex = 0;
+  while ((match = LINK_PATTERN.exec(stripped)) !== null) {
+    const url = match[1].trim();
+    if (!url) continue;
+    if (url.startsWith('#')) continue;
+    if (EXTERNAL_PREFIXES.some((re) => re.test(url))) continue;
+    extracted.push(url);
+  }
+}
+
+const missing = [];
+for (const url of extracted) {
+  // 파일#anchor 에서 파일 부분만 취함
+  const filePart = url.split('#')[0];
+  if (!filePart) continue;
+
+  const target = path.isAbsolute(filePart)
+    ? path.join(PROJECT_ROOT, filePart)
+    : path.join(PROJECT_ROOT, filePart);
+
+  if (!fs.existsSync(target)) {
+    missing.push({ url, target });
+  }
+}
+
+if (missing.length > 0) {
+  console.error(`❌ CLAUDE.md 내 깨진 상대 링크 ${missing.length}건:`);
+  for (const m of missing) {
+    console.error(`   - ${m.url} → ${m.target}`);
+  }
+  console.error('');
+  console.error('   원인: 파일 이동/삭제/오타 또는 Phase 3 감축 시 경로 업데이트 누락');
+  console.error('   대응: docs/guides/claudemd-governance.md §7.3 (SSoT 결합 체크리스트)');
+  process.exit(1);
+}
+
+console.log(`✅ CLAUDE.md 상대 링크 ${extracted.length}건 모두 유효`);
+process.exit(0);

--- a/scripts/verify-claudemd-size.sh
+++ b/scripts/verify-claudemd-size.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# verify-claudemd-size.sh
+# CLAUDE.md 의 char 수 (UTF-8 문자 단위) 를 측정하여 "각인 예산" 게이트를 강제한다.
+# 3단 게이트:
+#   - 35k 미만          : pass (조용)
+#   - 35k ~ 40k         : 경계 경보 (stdout 경보, exit 0)
+#   - 40k ~ 45k         : PR warn (신규 인라인 블록 금지 안내, exit 0)
+#   - 45k 이상          : fail (stderr + 가지치기 안내, exit 1)
+#
+# 근거: harness #197 Phase 1 지침 (docs/guides/claudemd-governance.md §3)
+# CLAUDE.md 는 매 세션 전량 어텐션 대상이라 크기가 커질수록 각 규칙의 상대적 비중이 희석.
+#
+# 호출 예:
+#   bash scripts/verify-claudemd-size.sh
+#     → 통과: exit 0, 경계/경고 상황에서도 exit 0
+#     → 실패: 45k 초과 시 exit 1 + stderr 가이드 링크
+#
+# 환경변수 override (테스트/재조정 용이성):
+#   CLAUDEMD_FILE           : 검사 대상 파일 경로 (기본 $PROJECT_DIR/CLAUDE.md)
+#   CLAUDEMD_SIZE_LIMIT_WARN_BOUNDARY : 경계 경보 임계 (기본 35000)
+#   CLAUDEMD_SIZE_LIMIT_WARN_PR       : PR warn 임계 (기본 40000)
+#   CLAUDEMD_SIZE_LIMIT_FAIL          : fail 임계 (기본 45000)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+CLAUDEMD_FILE="${CLAUDEMD_FILE:-${PROJECT_DIR}/CLAUDE.md}"
+WARN_BOUNDARY="${CLAUDEMD_SIZE_LIMIT_WARN_BOUNDARY:-35000}"
+WARN_PR="${CLAUDEMD_SIZE_LIMIT_WARN_PR:-40000}"
+FAIL_THRESHOLD="${CLAUDEMD_SIZE_LIMIT_FAIL:-45000}"
+
+if [ ! -f "${CLAUDEMD_FILE}" ]; then
+  echo "verify-claudemd-size: 파일 없음: ${CLAUDEMD_FILE}" >&2
+  exit 1
+fi
+
+# 한글 UTF-8 보정 — `wc -c` (바이트) 가 아닌 `wc -m` (문자) 사용.
+# macOS 기본 wc 는 로케일 의존이라 LC_ALL 강제.
+char_count=$(LC_ALL=en_US.UTF-8 wc -m < "${CLAUDEMD_FILE}" | tr -d ' ')
+
+# 숫자 검증 (unexpected output 방어)
+if ! [[ "${char_count}" =~ ^[0-9]+$ ]]; then
+  echo "verify-claudemd-size: char 수 파싱 실패: '${char_count}'" >&2
+  exit 1
+fi
+
+# 정량 게이트 판정
+if [ "${char_count}" -ge "${FAIL_THRESHOLD}" ]; then
+  echo "❌ CLAUDE.md 각인 예산 초과" >&2
+  echo "   현재: ${char_count} chars (fail 임계 ${FAIL_THRESHOLD})" >&2
+  echo "" >&2
+  echo "   올바른 대응: 예외 박제가 아니라 기존 블록 가지치기" >&2
+  echo "   - 상위 섹션 bytes 측정: awk '/^## /{if(n)print c\"\\t\"n; n=\$0; c=0; next} {c+=length(\$0)+1} END{if(n)print c\"\\t\"n}' CLAUDE.md | sort -rn" >&2
+  echo "   - 추출 기준: 매트릭스 3행+ / 코드 5라인+ / 프로토콜 3스텝+ / 근거 2+" >&2
+  echo "   - 상세: docs/guides/claudemd-governance.md §5 (가지치기 프로토콜)" >&2
+  exit 1
+fi
+
+if [ "${char_count}" -ge "${WARN_PR}" ]; then
+  echo "⚠️  CLAUDE.md 각인 예산 PR warn"
+  echo "   현재: ${char_count} chars (PR warn ${WARN_PR} / fail ${FAIL_THRESHOLD})"
+  echo "   신규 인라인 블록 금지 — 추가 규약은 docs/ 로 추출 후 포인터 1~3 줄만"
+  echo "   상세: docs/guides/claudemd-governance.md §3"
+  exit 0
+fi
+
+if [ "${char_count}" -ge "${WARN_BOUNDARY}" ]; then
+  echo "🟡 CLAUDE.md 각인 예산 경계 경보"
+  echo "   현재: ${char_count} chars (경계 ${WARN_BOUNDARY} / PR warn ${WARN_PR})"
+  echo "   가지치기 후보 탐색 권장 — 6개월 미수정 + 매트릭스/코드 블록 보유 섹션 우선"
+  exit 0
+fi
+
+echo "✅ CLAUDE.md 각인 예산 정상 (${char_count} / ${WARN_BOUNDARY} chars)"
+exit 0

--- a/scripts/verify-docs-links.sh
+++ b/scripts/verify-docs-links.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# verify-docs-links.sh
+# Node.js 기반 wrapper — CLAUDE.md 내 상대 링크의 파일 존재를 검증한다.
+# 실제 로직은 lib/verify-docs-links.js 에 있으며, 본 쉘 스크립트는 CI 에서 `bash scripts/...` 호출 일관성을 위해 존재.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+exec node "${PROJECT_DIR}/lib/verify-docs-links.js" "$@"

--- a/test/doctor-claudemd-budget.test.js
+++ b/test/doctor-claudemd-budget.test.js
@@ -1,0 +1,75 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const { runDoctor } = require('../lib/doctor');
+
+// CLAUDE.md 각인 예산 doctor 항목 (#197 Phase 2) 단위 테스트.
+// temp cwd 에 최소한의 CLAUDE.md 만 배치하고 charCount 판정을 확인.
+
+function findBudgetItem(report) {
+  return report.items.find((i) => i.name === 'CLAUDE.md 각인 예산');
+}
+
+function makeWorkspace(claudeMdContent) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'doctor-budget-'));
+  // runDoctor 가 CRITICAL DIRECTIVES 블록 존재 확인하므로 포함
+  const header = 'CRITICAL DIRECTIVES\n\n';
+  fs.writeFileSync(path.join(dir, 'CLAUDE.md'), header + claudeMdContent);
+  return dir;
+}
+
+test('20k chars → pass (여유)', () => {
+  const dir = makeWorkspace('a'.repeat(20000));
+  try {
+    const report = runDoctor(dir);
+    const item = findBudgetItem(report);
+    assert.ok(item, '각인 예산 항목이 리포트에 존재해야 함');
+    assert.equal(item.status, 'pass');
+    assert.match(item.detail, /여유/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('37k chars → warn (경계 경보)', () => {
+  const dir = makeWorkspace('a'.repeat(37000));
+  try {
+    const report = runDoctor(dir);
+    const item = findBudgetItem(report);
+    assert.equal(item.status, 'warn');
+    assert.match(item.detail, /경계/);
+    assert.doesNotMatch(item.detail, /PR warn/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('42k chars → warn (PR warn)', () => {
+  const dir = makeWorkspace('a'.repeat(42000));
+  try {
+    const report = runDoctor(dir);
+    const item = findBudgetItem(report);
+    assert.equal(item.status, 'warn');
+    assert.match(item.detail, /PR warn/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('46k chars → fail (초과)', () => {
+  const dir = makeWorkspace('a'.repeat(46000));
+  try {
+    const report = runDoctor(dir);
+    const item = findBudgetItem(report);
+    assert.equal(item.status, 'fail');
+    assert.match(item.detail, /초과/);
+    assert.match(item.detail, /가지치기/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/verify-claudemd-size.test.js
+++ b/test/verify-claudemd-size.test.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const SCRIPT = path.join(__dirname, '..', 'scripts', 'verify-claudemd-size.sh');
+
+function makeFixture(size) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claudemd-size-'));
+  const file = path.join(dir, 'CLAUDE.md');
+  // ASCII char 1 byte/char 로 정확히 size 문자 생성
+  fs.writeFileSync(file, 'a'.repeat(size));
+  return { dir, file };
+}
+
+function run(file, extraEnv = {}) {
+  try {
+    const stdout = execFileSync('bash', [SCRIPT], {
+      env: { ...process.env, CLAUDEMD_FILE: file, ...extraEnv },
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', code: 0 };
+  } catch (err) {
+    return {
+      stdout: err.stdout?.toString() || '',
+      stderr: err.stderr?.toString() || '',
+      code: err.status || 1,
+    };
+  }
+}
+
+test('35k 미만 → pass + 조용 (경고 없음)', () => {
+  const { dir, file } = makeFixture(20000);
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /정상/);
+    assert.doesNotMatch(result.stdout, /경계 경보/);
+    assert.doesNotMatch(result.stdout, /PR warn/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('35k 이상 40k 미만 → 경계 경보 (exit 0)', () => {
+  const { dir, file } = makeFixture(37000);
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /각인 예산 경계 경보/);
+    assert.doesNotMatch(result.stdout, /각인 예산 PR warn/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('40k 이상 45k 미만 → PR warn (exit 0)', () => {
+  const { dir, file } = makeFixture(42000);
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /각인 예산 PR warn/);
+    assert.match(result.stdout, /신규 인라인 블록 금지/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('45k 이상 → fail (exit 1 + stderr 가지치기 안내)', () => {
+  const { dir, file } = makeFixture(46000);
+  try {
+    const result = run(file);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /각인 예산 초과/);
+    assert.match(result.stderr, /가지치기/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('환경변수 override 로 임계 조정 가능', () => {
+  const { dir, file } = makeFixture(20000);
+  try {
+    // 15k 를 fail 임계로 낮추면 20k 파일은 fail
+    const result = run(file, { CLAUDEMD_SIZE_LIMIT_FAIL: '15000', CLAUDEMD_SIZE_LIMIT_WARN_PR: '10000', CLAUDEMD_SIZE_LIMIT_WARN_BOUNDARY: '5000' });
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /각인 예산 초과/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('파일 없음 → exit 1', () => {
+  const result = run('/tmp/does-not-exist-verify-size-test.md');
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /파일 없음/);
+});

--- a/test/verify-docs-links.test.js
+++ b/test/verify-docs-links.test.js
@@ -1,0 +1,156 @@
+'use strict';
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const SCRIPT = path.join(__dirname, '..', 'lib', 'verify-docs-links.js');
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+
+// fixture helper — temp 디렉토리에 CLAUDE.md 와 관련 파일 배치 후 PROJECT_ROOT 를 덮어쓰는 대신
+// CLAUDEMD_FILE 환경변수로 타깃을 지정. 존재 확인은 실제 PROJECT_ROOT 기준이므로
+// 유효 링크 fixture 는 실제 파일 경로 (CLAUDE.md / docs/ 등) 를 재사용한다.
+
+function makeTempClaudeMd(content) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-links-'));
+  const file = path.join(dir, 'CLAUDE.md');
+  fs.writeFileSync(file, content);
+  return { dir, file };
+}
+
+function run(file) {
+  try {
+    const stdout = execFileSync('node', [SCRIPT], {
+      env: { ...process.env, CLAUDEMD_FILE: file },
+      encoding: 'utf8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { stdout, stderr: '', code: 0 };
+  } catch (err) {
+    return {
+      stdout: err.stdout?.toString() || '',
+      stderr: err.stderr?.toString() || '',
+      code: err.status || 1,
+    };
+  }
+}
+
+test('유효 링크만 존재 → exit 0', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '- 가이드: [claudemd-governance](docs/guides/claudemd-governance.md)',
+    '- 스크립트: [verify](scripts/verify-agent-ssot.sh)',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /모두 유효/);
+    assert.match(result.stdout, /2건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('깨진 링크 1건 → exit 1 + stderr 보고', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '- 존재함: [real](CLAUDE.md)',
+    '- 깨짐: [ghost](docs/nonexistent-file-xyz.md)',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /깨진 상대 링크 1건/);
+    assert.match(result.stderr, /docs\/nonexistent-file-xyz\.md/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('외부 URL (http/https) 는 검증 대상 아님', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '- 외부: [github](https://github.com/coseo12/harness-setting)',
+    '- 외부: [example](http://example.com/foo)',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /0건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('앵커 전용 링크 (#section) 스킵', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '- 섹션 링크: [헤더로](#section-header)',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /0건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('코드펜스 내부 링크는 스킵 (문법 비활성)', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '```markdown',
+    '예시: [ghost](docs/this-file-does-not-exist.md)',
+    '```',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /0건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('인라인 코드 내부 링크는 스킵 (placeholder 표기)', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '- 포맷: `[placeholder](docs/fake-path.md)` 이런 식으로',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /0건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('파일#앵커 링크는 파일 부분만 검증', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '- 섹션 지정: [target](CLAUDE.md#some-anchor)',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /1건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('파일 없음 → exit 1', () => {
+  const result = run('/tmp/docs-links-does-not-exist-xyz.md');
+  assert.equal(result.code, 1);
+  assert.match(result.stderr, /파일 없음/);
+});
+
+test('실제 CLAUDE.md 는 통과 (링크 유효성 회귀 가드)', () => {
+  const result = run(path.join(PROJECT_ROOT, 'CLAUDE.md'));
+  assert.equal(result.code, 0);
+  assert.match(result.stdout, /모두 유효/);
+});


### PR DESCRIPTION
## Summary
- `scripts/verify-claudemd-size.sh` — 3단 게이트 (35k warn / 40k PR warn / 45k fail)
- `scripts/verify-docs-links.sh` + `lib/verify-docs-links.js` — CLAUDE.md 상대 링크 무결성 검증
- `.github/workflows/ci.yml` detect-and-test 에 두 가드 추가 (harness 전용, 다운스트림 skip)
- `lib/doctor.js` 에 "CLAUDE.md 각인 예산" 항목 추가

## Closes
Closes #200

## 실측 현황
- **CLAUDE.md 현재: 43,305 chars** → PR warn 구간 (exit 0, CI 통과)
- Phase 3 감축 PR 에서 35k chars 이하 복귀 예정

## 구현 상세

### 정량 게이트 (verify-claudemd-size.sh)
| 임계 | 동작 | exit |
|---|---|---|
| 35k 미만 | pass (조용) | 0 |
| 35k~40k | 🟡 경계 경보 | 0 |
| 40k~45k | ⚠️ PR warn (신규 인라인 금지 안내) | 0 |
| 45k 이상 | ❌ fail (가지치기 프로토콜 안내) | 1 |

환경변수 override: `CLAUDEMD_SIZE_LIMIT_FAIL` / `CLAUDEMD_SIZE_LIMIT_WARN_PR` / `CLAUDEMD_SIZE_LIMIT_WARN_BOUNDARY`

### 링크 무결성 (verify-docs-links.js)
- Node.js 기반 (기존 테스트 생태계 일치)
- 코드펜스 (```...```) 내부 스킵
- 인라인 코드 (`...`) 내부 placeholder 표기 스킵
- 외부 URL (http*/mailto:/ftp:/data:) 스킵
- 앵커 전용 링크 (#...) 스킵
- 파일#anchor 는 파일 부분만 검증

### harness doctor 항목
`runDoctor()` 에 "CLAUDE.md 각인 예산" 항목 추가. charCount 기반 pass/warn/fail 3단 분류.

## Test plan
- [x] `npm test` — 75 pass / 0 fail (+ 19 신규)
- [x] `bash scripts/verify-agent-ssot.sh` — 통과 (5 files × 9 fields)
- [x] `bash scripts/verify-release-version-bump.sh` — 통과
- [x] `bash scripts/verify-claudemd-size.sh` — PR warn (exit 0)
- [x] `bash scripts/verify-docs-links.sh` — 9건 모두 유효
- [x] `node bin/harness.js doctor` — 새 항목 정상 표시 (warn: 43,305 chars / PR warn 40,000)
- [x] U+FFFD 검증 통과 (기존 doctor.js 주석 매치는 의도된 설명)

## Behavior Changes (MINOR)
- CLAUDE.md 가 45k chars 초과 시 **CI fail** — PR 머지 차단
- CLAUDE.md 가 40k chars 초과 시 PR 체크 로그에 경고 노출 (exit 0 유지)
- `harness doctor` 에 "CLAUDE.md 각인 예산" 항목이 추가되어 로컬 상태 가시화
- CLAUDE.md 내 상대 링크가 깨지면 CI fail (link rot 방어)

## 비목표 (스프린트 계약 부합)
- Phase 3 의 본문 감축 실행 — 별도 이슈 #199
- 앵커 (#section) 세부 검증 — 본 단계 범위 밖
- 다른 `.md` 파일 크기 관리 — 비목표

## 교차검증 (cross-validate code)
PR diff 기준 cross-validate code 호출 예정 — **본 PR 생성 직후 별도 커밋으로 결과 박제**. Gemini 수용/기각 판정은 후속 PR 코멘트에 기록.

## 자체 점검 (CRITICAL DIRECTIVES)
- [x] `main` 직접 수정 없음 (base=develop)
- [x] 범위 명시 (#200 Phase 2 한정)
- [x] UI 변경 없음 — 3단계 검증 해당 없음
- [x] U+FFFD 검증 통과
- [x] 파괴적 작업 없음
- [x] 스프린트 계약 이슈 #200 에 명시

🤖 Generated with [Claude Code](https://claude.com/claude-code)