### PR TITLE
[#202] verify-docs-links 삼항 단순화 + leading slash 회귀 가드 (PATCH)

### DIFF
--- a/lib/verify-docs-links.js
+++ b/lib/verify-docs-links.js
@@ -65,9 +65,10 @@ for (const url of extracted) {
   const filePart = url.split('#')[0];
   if (!filePart) continue;
 
-  const target = path.isAbsolute(filePart)
-    ? path.join(PROJECT_ROOT, filePart)
-    : path.join(PROJECT_ROOT, filePart);
+  // path.join 은 leading slash 를 무시하고 concat 하므로 `/docs/...` 와 `docs/...` 모두
+  // 프로젝트 루트 기준으로 올바르게 해석됨. path.resolve 로 바꾸면 leading slash 입력이
+  // 파일 시스템 루트로 빠져나가므로 금지 (volt 교차검증 오탐 케이스 — 회귀 가드는 테스트 참조).
+  const target = path.join(PROJECT_ROOT, filePart);
 
   if (!fs.existsSync(target)) {
     missing.push({ url, target });

--- a/test/verify-docs-links.test.js
+++ b/test/verify-docs-links.test.js
@@ -154,3 +154,23 @@ test('실제 CLAUDE.md 는 통과 (링크 유효성 회귀 가드)', () => {
   assert.equal(result.code, 0);
   assert.match(result.stdout, /모두 유효/);
 });
+
+// leading slash 링크는 프로젝트 루트 기준으로 해석되어야 한다.
+// path.resolve 로 구현하면 파일 시스템 루트로 빠져나가 오탐이 나는데,
+// 현재는 path.join 을 쓰므로 올바르게 동작한다. 교차검증 오탐 (Gemini 의
+// path.resolve 전환 제안) 이 재발하면 이 테스트가 터져서 차단한다.
+test('leading slash 링크도 프로젝트 루트 기준으로 해석', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '- 루트 상대: [claudemd](/CLAUDE.md)',
+    '- 루트 상대: [script](/scripts/verify-agent-ssot.sh)',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /모두 유효/);
+    assert.match(result.stdout, /2건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- `lib/verify-docs-links.js:68-70` 삼항 연산자의 양쪽이 동일 (`path.join(ROOT, filePart)`) — 1라인으로 단순화
- leading slash 링크 (`/docs/...`) 도 프로젝트 루트 기준으로 해석되는지 회귀 가드 테스트 추가
- PR #201 교차검증 (Gemini capacity 복구 후 재시도) 에서 나온 수용 건만 반영. `path.resolve` 전환 제안은 회귀 유발로 반려

## 배경
PR #201 머지 시점엔 Gemini 용량 부족 (429) 으로 Claude-only fallback 이었고, #202 로 재시도 이슈 박제됐음. 재시도 (2026-04-21) 에서 outcome=applied 로 성공 수신.

## 교차검증 재분석
- **수용**: 삼항 연산자 무의미 → 실제 양쪽 동일. 1라인 단순화
- **반려**: `path.resolve` 전환 → 실측 결과 `path.resolve(ROOT, '/docs/f.md')` 는 `/docs/f.md` 로 빠져나가 **파일 시스템 루트** 참조. 현재 `path.join` 동작 (`/Users/.../docs/f.md`) 이 올바름. 제안 수용 시 새 버그 유발

## 범위
- `lib/verify-docs-links.js` — 68~70 라인 단순화 + WHY 주석 추가
- `test/verify-docs-links.test.js` — leading slash 테스트 1건 추가 (10/10 pass)

## Behavior Changes
**None — 코드 청결성 + 회귀 가드 테스트만**. 실행 동작 변화 없음 (`path.join` 이 leading slash 를 이미 올바르게 처리).

## 릴리스 분류
**PATCH** — 행동 변화 없음. verify-docs-links 는 CI 검증 도구이며 판정 로직은 그대로.

## Test plan
- [x] `node --test test/verify-docs-links.test.js` — 10/10 pass
- [x] 실제 CLAUDE.md 대상 `node lib/verify-docs-links.js` — 9건 유효
- [x] `scripts/verify-claudemd-size.sh` — PR warn (43305, Phase 3 감축 대기)
- [x] 한글 인코딩 U+FFFD 검증 — clean

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)