### PR TITLE
[#196] .github/workflows/ 책임 분리 — harness-* (frozen) + ci.yml (user-only) + 자동 마이그레이션 (MAJOR v3.0.0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,34 +249,11 @@ jobs:
           fi
 
       # ============================================================
-      # harness 저장소 전용 가드 (다운스트림은 hashFiles 조건으로 skip)
+      # NOTE: harness 저장소 전용 가드는 `.github/workflows/harness-guards.yml` 로 이동됨
+      # (v3.0.0, #196). 다운스트림은 본 ci.yml 을 자유롭게 수정해도 업스트림과 충돌하지 않는다.
+      # 가드 목록 (harness-guards.yml 참조):
+      #   - agent SSoT drift 가드
+      #   - release version bump 가드
+      #   - CLAUDE.md 각인 예산 가드
+      #   - CLAUDE.md 상대 링크 무결성 가드
       # ============================================================
-      # agent SSoT drift 가드 (#145)
-      # CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 9개 필드가
-      # 5개 에이전트 파일의 `## 마무리 체크리스트 JSON 반환` 섹션에 모두 존재하고 선언 순서를
-      # 유지하는지 검사. drift 시 exit 1 로 PR 머지 전 차단.
-      - name: agent SSoT drift 가드
-        if: hashFiles('scripts/verify-agent-ssot.sh') != ''
-        run: bash scripts/verify-agent-ssot.sh
-
-      # release version bump 가드 (v2.28.1 복구와 함께 도입)
-      # chore(release) PR 에서 CHANGELOG 를 업데이트했으나 package.json::version bump 를 누락하는 회귀를 차단.
-      # 세션 3연속 릴리스 (v2.26.0~v2.28.0) 에서 실제 발생 → v2.28.1 로 복구 + 본 가드 도입.
-      # CHANGELOG 최신 `## [X.Y.Z]` 엔트리와 package.json::version 일치 검증, 불일치 시 exit 1.
-      - name: release version bump 가드
-        if: hashFiles('scripts/verify-release-version-bump.sh') != ''
-        run: bash scripts/verify-release-version-bump.sh
-
-      # CLAUDE.md 각인 예산 가드 (#197 Phase 2)
-      # 45k chars 초과 시 exit 1 로 감축 PR 을 강제. 35k/40k 는 warn (exit 0).
-      # 지침: docs/guides/claudemd-governance.md §3 (정량 게이트)
-      - name: CLAUDE.md 각인 예산 가드
-        if: hashFiles('scripts/verify-claudemd-size.sh') != ''
-        run: bash scripts/verify-claudemd-size.sh
-
-      # CLAUDE.md 상대 링크 무결성 가드 (#197 Phase 2)
-      # CLAUDE.md → docs/ 포인터가 많아질수록 link rot 위험 증가 — 파일 존재 검증.
-      # 지침: docs/guides/claudemd-governance.md §4.3
-      - name: CLAUDE.md 상대 링크 무결성 가드
-        if: hashFiles('scripts/verify-docs-links.sh') != ''
-        run: bash scripts/verify-docs-links.sh

--- a/.github/workflows/harness-guards.yml
+++ b/.github/workflows/harness-guards.yml
@@ -1,0 +1,58 @@
+name: Harness Guards
+
+# harness 저장소 전용 가드 workflow (v3.0.0~).
+# 이슈 #196 책임 분리에서 ci.yml 말미 블록을 이동해온 파일.
+#
+# 다운스트림 프로젝트 관점:
+#   본 workflow 의 각 step 은 `hashFiles('scripts/verify-*.sh') != ''` 조건으로 보호되므로
+#   해당 스크립트를 포함하지 않는 프로젝트에선 조용히 스킵된다. harness init 으로 새로
+#   설치된 프로젝트는 scripts/ 경로를 frozen 으로 가져가므로 가드가 자동 동작.
+#
+# 책임 경계 (docs/decisions/20260421-workflows-responsibility-split.md):
+#   - 본 파일 (`.github/workflows/harness-*.yml`) = frozen (upstream 소유)
+#   - `.github/workflows/ci.yml` = user-only (다운스트림 소유)
+#
+# 근거: volt #62 — `ci.yml` 에 upstream 가드와 다운스트림 빌드/테스트 가 혼재되어
+# `harness update` 가 6단계 push-fail-fix 루프를 유발한 관찰.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+jobs:
+  harness-guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # agent SSoT drift 가드 (#145)
+      # CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 9개 필드가
+      # 5개 에이전트 파일의 `## 마무리 체크리스트 JSON 반환` 섹션에 모두 존재하고 선언 순서를
+      # 유지하는지 검사. drift 시 exit 1 로 PR 머지 전 차단.
+      - name: agent SSoT drift 가드
+        if: hashFiles('scripts/verify-agent-ssot.sh') != ''
+        run: bash scripts/verify-agent-ssot.sh
+
+      # release version bump 가드 (v2.28.1 복구와 함께 도입)
+      # chore(release) PR 에서 CHANGELOG 를 업데이트했으나 package.json::version bump 를 누락하는 회귀를 차단.
+      # 세션 3연속 릴리스 (v2.26.0~v2.28.0) 에서 실제 발생 → v2.28.1 로 복구 + 본 가드 도입.
+      # CHANGELOG 최신 `## [X.Y.Z]` 엔트리와 package.json::version 일치 검증, 불일치 시 exit 1.
+      - name: release version bump 가드
+        if: hashFiles('scripts/verify-release-version-bump.sh') != ''
+        run: bash scripts/verify-release-version-bump.sh
+
+      # CLAUDE.md 각인 예산 가드 (#197 Phase 2)
+      # 45k chars 초과 시 exit 1 로 감축 PR 을 강제. 35k/40k 는 warn (exit 0).
+      # 지침: docs/guides/claudemd-governance.md §3 (정량 게이트)
+      - name: CLAUDE.md 각인 예산 가드
+        if: hashFiles('scripts/verify-claudemd-size.sh') != ''
+        run: bash scripts/verify-claudemd-size.sh
+
+      # CLAUDE.md 상대 링크 무결성 가드 (#197 Phase 2)
+      # CLAUDE.md → docs/ 포인터가 많아질수록 link rot 위험 증가 — 파일 존재 검증.
+      # 지침: docs/guides/claudemd-governance.md §4.3
+      - name: CLAUDE.md 상대 링크 무결성 가드
+        if: hashFiles('scripts/verify-docs-links.sh') != ''
+        run: bash scripts/verify-docs-links.sh

--- a/.github/workflows/harness-pr-review.yml
+++ b/.github/workflows/harness-pr-review.yml
@@ -1,4 +1,4 @@
-name: PR 자동 리뷰 트리거
+name: Harness PR 자동 리뷰 트리거
 
 on:
   pull_request:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,54 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [3.0.0] — 2026-04-22
+
+[#196](https://github.com/coseo12/harness-setting/issues/196) — `.github/workflows/` 책임 분리 (**MAJOR** — breaking: 파일 rename + 카테고리 재분류). volt [#62](https://github.com/coseo12/volt/issues/62) 실측 (astro-simulator PR #270 6단계 push-fail-fix 루프) 근거.
+
+### Behavior Changes
+
+- **`.github/workflows/harness-*.yml` 만 frozen (upstream 소유)** — `lib/categorize.js` 규칙 변경. 이전에는 `.github/workflows/` 디렉토리 전체가 frozen 이었음. **다운스트림 ci.yml 을 이제 자유롭게 수정 가능** — upstream `harness update --apply-all-safe` 가 더 이상 ci.yml 을 덮어쓰지 않는다. 근거: volt #62 에서 관찰된 "upstream 가드 vs 다운스트림 빌드 혼재" 구조 문제 해소
+- **`.github/workflows/ci.yml` → user-only 로 재분류** — 말미 harness 전용 가드 블록 (agent SSoT / release version bump / CLAUDE.md 각인 / CLAUDE.md 링크) 4개가 신규 `harness-guards.yml` 로 이동. ci.yml 에는 `detect-and-test` (다언어 자동 감지/실행) 만 잔존
+- **`.github/workflows/harness-guards.yml` 신설 (frozen)** — upstream 전용 가드 workflow. 각 step 은 `hashFiles('scripts/verify-*.sh') != ''` 조건으로 보호돼 해당 스크립트 미보유 다운스트림에선 조용히 스킵
+- **`.github/workflows/pr-review.yml` → `harness-pr-review.yml` rename** — 내부 `name:` 도 `Harness PR 자동 리뷰 트리거` 로 갱신. harness- prefix 관습 준수
+- **자동 마이그레이션 hook 도입** — `lib/migrations/2.31.0-to-3.0.0.js` 가 3단 매칭으로 기존 다운스트림을 자동 전환:
+  - **6a** (ci.yml 순정 v2.31.0) → 완전 덮어쓰기
+  - **6b** (detect-and-test 수정 + 가드 블록 byte-exact 원형) → 가드 블록만 제거
+  - **6c** (가드 블록 자체 수정) → 스킵 + stderr 수동 가이드 (`docs/harness-ci-migration.md`)
+- **백업 보장** — 모든 마이그레이션 경로가 원본 ci.yml / pr-review.yml 을 `.harness/backup/ci-split-<ISO-timestamp>/` 에 자동 보존. 실패 시 수동 복원 경로 명확
+- **마이그레이션 실패 시 `exit 1` 금지** — 6c 경로는 notes + stderr 경고 반환, `harness update` 전체가 실패하지 않도록 보장 (CLAUDE.md "매니페스트 최신 ≠ 파일 적용 완료" 교훈)
+- **`docs/frozen-file-split.md` / `docs/harness-update-compat-checklist.md` 갱신** — v3.0.0 책임 경계 명문화. 기존 "옵션 C (divergent 수정)" 의 단점이 해소됐음을 명시
+- **`docs/harness-ci-migration.md` 신설** — 6c 경로 발동 시 수동 마이그레이션 가이드 (단계별 체크리스트 + 제거 대상 step 목록)
+
+### Migration Guide (다운스트림)
+
+```bash
+# 1. harness update 실행 (자동 마이그레이션 시도)
+npx github:coseo12/harness-setting update --apply-all-safe
+
+# 2. 출력에서 분기 확인:
+#    - "가드 블록 제거 완료 (6a/6b 경로)" → 성공
+#    - "6c — 사용자 수정 감지" (stderr) → 수동 절차 필요 → docs/harness-ci-migration.md
+
+# 3. 검증
+npx github:coseo12/harness-setting doctor
+```
+
+자세한 경로 판정 로직: [docs/decisions/20260421-workflows-responsibility-split.md](docs/decisions/20260421-workflows-responsibility-split.md) §3단 매칭.
+
+### Notes
+
+- **MAJOR 정당화 근거** — `lib/categorize.js` 의 공개 계약 (카테고리 분류 규칙) 이 변경됐고, 파일 rename (`pr-review.yml` → `harness-pr-review.yml`) 이 다운스트림 브랜치 보호 룰의 required check 이름에도 영향. SemVer 분류 기준상 "하위 호환 깨지는 변경" 에 해당
+- **ADR 박제** — `docs/decisions/20260421-workflows-responsibility-split.md` (후보 비교 4개 축 + 결정 근거 + Concrete Prediction 3개 + 재검토 트리거 4개). architect 코멘트에 "생성 완료" 로 표기됐으나 디스크엔 부재였던 누락을 보완
+- **Concrete Prediction 실증** — (1) 다운스트림 ci.yml 커스터마이즈 유지 확인 / (2) upstream harness-guards.yml 자동 전파 / (3) 멱등성 (2회차 변경 0) 3건 모두 테스트로 검증 완료 (`test/ci-split-migration.test.js` 7 테스트 통과)
+- **Phase 분리 고려** — 본 릴리스는 카테고리 변경 + 파일 rename + 마이그레이션을 한 번에 묶었다. Phase 1 (categorize 수정) + Phase 2 (마이그레이션) 분리도 검토했으나, Phase 1 단독 배포 시 기존 다운스트림에서 "가드 블록이 ci.yml 과 harness-guards.yml 양쪽에서 실행" 되는 상태가 발생해 backward-compat 조건 불만족 → 단일 릴리스로 통합. CLAUDE.md `### 릴리스` "Phase 분리 리듬" 판정 기준 적용
+- **upstream 3중 방어 blindspot 인지** — 다운스트림 실 적용이 최종 가드 (CLAUDE.md 교훈). 본 PR 머지 후 대표 다운스트림 (astro-simulator) 에서 `harness update` 실행 결과를 1차 모니터링 대상. 6c 경로 발동 빈도가 재검토 트리거
+
+### Breaking Changes Summary
+
+다운스트림이 본 릴리스 적용 시 **수동 개입이 필요한 유일한 경우**는 `.github/workflows/ci.yml` 의 가드 블록을 **byte-exact 원형에서 벗어나게 수정**한 경우 (6c 경로). 이 경우 `docs/harness-ci-migration.md` 를 참조한 수동 절차 필요. 그 외 모든 경우 `harness update` 1회 실행으로 자동 마이그레이션.
+
+
 ## [2.31.0] — 2026-04-20
 
 [#191](https://github.com/coseo12/harness-setting/pull/191) — volt [#62](https://github.com/coseo12/volt/issues/62) [#63](https://github.com/coseo12/volt/issues/63) 반영. 세션 의도 이탈 감지 + harness update 부합성 체크리스트 (MINOR). volt [#64](https://github.com/coseo12/volt/issues/64) 는 [harness#190](https://github.com/coseo12/harness-setting/issues/190) 실행 이슈로 분리.

--- a/docs/decisions/20260421-workflows-responsibility-split.md
+++ b/docs/decisions/20260421-workflows-responsibility-split.md
@@ -1,0 +1,121 @@
+# ADR: `.github/workflows/` 책임 분리 — harness-* vs user-only
+
+- 날짜: 2026-04-21
+- 상태: Accepted
+- 관련 이슈/PR: [#196](https://github.com/coseo12/harness-setting/issues/196) — v3.0.0 MAJOR
+- 선행 근거: volt [#62](https://github.com/coseo12/volt/issues/62) (astro-simulator PR #270 6단계 push-fail-fix 루프 실측)
+- 관련 ADR: [ADR 20260419-gitflow-main-develop](20260419-gitflow-main-develop.md) (브랜치 전략 독립 운영)
+
+## 배경
+
+v2.31.0 까지 `.github/workflows/` 전체 디렉토리는 `lib/categorize.js:19` 에서 **`frozen`** 으로 분류됐다. 즉 `harness update --apply-all-safe` 가 해당 디렉토리 모든 yml 파일을 **upstream 으로 자동 덮어쓰기** 했다.
+
+문제는 `ci.yml` 의 내용이 두 부류로 혼재돼 있었던 것이다:
+
+1. **harness 고유 가드** (upstream 소유로 자동 전파돼야 정상):
+   - `agent SSoT drift 가드` (#145)
+   - `release version bump 가드` (v2.28.1~)
+   - `CLAUDE.md 각인 예산 가드` / `상대 링크 무결성 가드` (#197 Phase 2)
+2. **다운스트림 프로젝트의 빌드/테스트** (다운스트림이 자유롭게 수정해야 정상):
+   - `detect-and-test` 잡: Node/Python/Go/Rust 자동 감지 + 실행
+
+**결과: `ci.yml` 한 줄 upstream 개선만 있어도 파일 전체가 덮어쓰기 대상이 되어, 다운스트림의 `detect-and-test` 커스터마이즈가 매번 충돌.** astro-simulator PR #270 에서 v2.15.0 → v2.29.1 적용 과정 중 **6단계 push-fail-fix 루프** 로 실측 (volt #62):
+
+1. `npm test` → `sh: pnpm: not found` (v2.28.2)
+2. `pnpm test --if-present` → vitest "Unknown option" (v2.29.1)
+3. `pnpm -r test` → `wasm-pack not found`
+4. physics-wasm 제외 → shared dist 없음 → build 선행 필요
+5. `pnpm -r build` 필터 → root.build 재귀로 physics-wasm 재포함
+6. core build → `@astro-simulator/physics-wasm` 타입 의존 해결 불가
+
+3 ~ 6 단계는 다운스트림 특수성 (WASM / 모노레포 빌드 순서) 에서 발생한 건데, ci.yml 이 frozen 이라 다운스트림이 CI 를 자유롭게 수정할 수 없었던 게 구조적 원인이었다.
+
+### Concrete Prediction (구현 후 실증 목표)
+
+1. 다운스트림 ci.yml 커스터마이즈 후 `harness update --check` 의 diff listing 에 ci.yml 이 등장하지 않는다 (0 라인)
+2. upstream `harness-guards.yml` 에 신규 step 추가 → 다운스트림 `harness update --apply-all-safe` 로 자동 적용
+3. 마이그레이션 반복 호출 → 2회차부터 파일 시스템 변경 0 (멱등성)
+
+## 후보 비교
+
+| 축 | **A. 파일 분리 (harness-*.yml vs ci.yml)** | B. 전체 user-only | C. Reusable workflow | D. 센티널 / AST 기반 부분 수정 |
+|---|---|---|---|---|
+| 구조적 명확성 | **최고** — 파일명 prefix 로 책임 경계 시각화 | 낮음 — 가드가 upstream 에서 소실됨 | 중 — 레포 간 참조 관계 복잡 | 낮음 — YAML 파서 필요, 규칙 애매 |
+| 구현 비용 | 중 — categorize 수정 + 마이그레이션 1 개 | **최저** — categorize 1 라인 | 높음 — actions/workflow-dispatch 설계 + 권한 문제 | **최고** — YAML AST 파싱 로직 + 센티널 관리 |
+| upstream 3중 방어 (가드 자동 전파) | **유지됨** | **파괴됨** — 각 다운스트림이 수동 복붙 | 유지되나 GitHub 인프라 의존 | 유지되나 복잡도 폭증 |
+| GitHub Actions 런타임 동작 | 각 yml 독립 실행 (자연) | 동일 | 호출 체인 발생 (오버헤드) | 파일 하나지만 step 관리 복잡 |
+| 다운스트림 학습 곡선 | 낮음 — 파일 분리 관습 | **낮음** | 중 — reusable workflow 개념 | 높음 — 센티널 개념 |
+| 기존 다운스트림 호환 | 마이그레이션 1회 필요 | **심각** — 기존 가드 모두 소실 | 전면 재작성 | 센티널 도입에 사용자 수동 개입 필요 |
+| 재검토 비용 | 낮음 — 되돌리기 쉬움 | 중 — 가드 복원 번거로움 | 높음 — 인프라 결합 | 높음 — 센티널 스펙 고정 |
+| MAJOR 정당화 | **적절** — breaking 은 categorize 만 | 과소 — user-only 로 degrade | 과대 — 인프라 전면 변경 | 과대 — 복잡도 불균형 |
+
+## 결정
+
+**A. 파일 분리 — `harness-*.yml` (frozen) + 나머지 (user-only)** 를 채택한다.
+
+### 실행 계획 (v3.0.0)
+
+1. **`lib/categorize.js`** 규칙 수정: `.github/workflows/harness-` prefix → `frozen`, 나머지 → `user-only`
+2. **`.github/workflows/harness-guards.yml`** 신규 생성 — 기존 ci.yml 말미 가드 블록 이동
+3. **`.github/workflows/pr-review.yml`** → **`harness-pr-review.yml`** rename + 내부 `name:` 갱신
+4. **`.github/workflows/ci.yml`** 말미 가드 블록 제거 (대체 안내 주석 삽입)
+5. **`lib/migrations/2.31.0-to-3.0.0.js`** 신규 작성 — 기존 migrations 패턴에 자연 합류 (3단 매칭: 6a / 6b / 6c)
+6. **`docs/harness-ci-migration.md`** — 6c 경로 수동 가이드
+7. **`docs/frozen-file-split.md`** / **`docs/harness-update-compat-checklist.md`** 갱신
+
+### 핵심 결정 (요약)
+
+1. **파일 경계 = 책임 경계** — GitHub Actions 가 `.github/workflows/` 내 모든 yml 을 독립 workflow 로 실행하므로 파일 분리가 GitHub 인프라와 정합적
+2. **마이그레이션 hook 은 `lib/migrations/` 편입** — 별도 `scripts/migrate-ci-split.js` 가 아닌 기존 migration 체인. dry-run 지원 + manifest 기반 조건 분기 재사용
+3. **보수적 3단 매칭**:
+   - 6a: 사용자 미수정 → 완전 덮어쓰기
+   - 6b: `detect-and-test` 수정 + 가드 블록 byte-exact 원형 유지 → 블록만 제거
+   - 6c: 가드 블록 자체 수정 → 스킵 + stderr 수동 가이드
+4. **실패는 `exit 1` 금지** — notes 반환 + 원본 유지. `harness update` 전체 실패보다 부분 성공 + 명확 안내 우선 ([CLAUDE.md "매니페스트 최신 ≠ 파일 적용 완료"](../../CLAUDE.md) 교훈)
+5. **백업** — `.harness/backup/ci-split-<ISO-timestamp>/` 에 원본 ci.yml + pr-review.yml 자동 보존
+
+### 기각한 후보 상세
+
+- **B. 전체 user-only** — upstream 가드의 3중 방어 (agent SSoT / release version bump / CLAUDE.md 가드) 자동 전파 포기. 각 다운스트림이 수동으로 복붙해야 하고 drift 위험. upstream 정당성 상실
+- **C. Reusable workflow** — GitHub Actions `workflow_call` 은 레포 간 호출 가능하나 권한 경계 / 인프라 의존성이 커짐. 다운스트림이 harness-setting 레포에 대해 `actions: read` 권한을 가져야 하고, 레지스트리/버전 관리 별도 필요. MAJOR 비용 대비 이득 낮음
+- **D. 센티널 / AST 기반 부분 수정** — YAML AST 파싱 의존성 + 센티널 관리 규약 / 정규식 한계 / 사용자 편집 허용 경계 모호. 복잡도 폭증 대비 파일 분리 대비 이득 없음
+
+## 결과·재검토 조건
+
+### 즉시 효과 (v3.0.0)
+
+- **다운스트림 ci.yml 자유 수정** — WASM / 모노레포 빌드 순서 / 특수 도구 세팅 충돌 없이 가능
+- **upstream 가드 자동 전파 유지** — harness-guards.yml 이 frozen 이므로 기존 3중 방어 정책 보존
+- **기존 다운스트림 자동 마이그레이션** — `harness update` 1회 실행으로 3단 매칭 (6a/6b/6c) + 백업 + 수동 가이드
+- **테스트 카운트**: +7 (fixture 기반 통합 테스트 7건)
+
+### Concrete Prediction 재검증 (구현 PR 에서)
+
+1. 다운스트림 ci.yml 커스터마이즈 → `harness update --check` 의 diff listing 0 라인
+   → **검증 방법**: `test/ci-split-migration.test.js` 의 `customized-detect` fixture 에서 커스텀 라인 보존 확인 (통과)
+2. upstream `harness-guards.yml` 신규 step 추가 → 다운스트림 `--apply-all-safe` 자동 적용
+   → **검증 방법**: harness-guards.yml 이 frozen 카테고리임을 단위 확인 (`categorize` 테스트, 통과)
+3. 마이그레이션 반복 호출 → 2회차부터 파일 시스템 변경 0
+   → **검증 방법**: 멱등성 테스트 (snapshot diff 0, 통과)
+
+### 재검토 트리거 (하나라도 해당 시 ADR 폐기 + 신규 결정 필요)
+
+1. **6c 경로 발동 빈도 폭증** — 6개월 내 3+ 다운스트림에서 6c 경로가 발동되면 byte-exact 문자열 매칭이 실용적이지 않다는 증거. YAML AST 기반 부분 수정 (후보 D) 재평가 필요
+2. **GitHub Actions reusable workflow 성숙** — `workflow_call` + `secrets: inherit` + 권한 모델이 단순해지면 파일 분리보다 상속 모델이 유리해질 가능성. 후보 C 재평가
+3. **upstream 가드 자체가 파일 수준을 넘는 모듈화 요구** — 여러 guards 파일 (`harness-guards-ssot.yml`, `harness-guards-release.yml` 등) 로 분할하고 싶은 수요 발생. 현재는 단일 `harness-guards.yml` 로 충분하나 가드 수가 10+ 로 늘면 분할 검토
+4. **사용자 요청으로 harness-* 충돌 허용 모드 필요** — 예: 특정 다운스트림이 `harness-guards.yml` 을 확장하고 싶을 때. `.harnessignore` 현행 메커니즘으로 충분한지 실측 후 결정
+
+### 관측 지표
+
+- **다운스트림 volt 이슈** 에 "harness update ci.yml 충돌" 관찰이 v3.0.0 이후 사라지는가
+- **upstream `harness-guards.yml`** 변경 PR 이 다운스트림 CI 를 깨지 않고 자연 전파되는가
+- 6c 경로 발동 수 (자동 통계 없음 — 다운스트림 수동 보고에 의존)
+
+## 교차검증 메모
+
+- **cross-validate outcome**: `applied` (Gemini 2.5 Pro, 정상 응답)
+- **합의**: 후보 B/C/D 기각 논리 / 마이그레이션 실패 시 `exit 1` 대신 수동 가이드 / SHA 해시 보수적 매칭 + 백업
+- **이견 수용**: `harness init` 의 `lib/copy-template.js` 재귀 복사 영향 명시 (코드 수정 없지만 영향 모듈 투명성)
+- **기각**: 문서 업데이트 범위 확장 (skills-guide.md / agents-guide.md) — 실측 결과 해당 파일에 ci.yml 참조 없음
+- **고유 발견 후속 분리**: 없음 — Gemini 가 범주 오류 / 암묵 전제 (reusable workflow, 리소스 비용 등) 를 지적하지 않음
+- **Claude 편향 4종 셀프 체크**: 낙관일정 / 결합간과 / 폐기프레이밍 3축은 cross-validate 프롬프트에 명시 질문으로 삽입 후 통과. 순수주의 축은 fallback 경로 (6c 수동 가이드) 존재로 사전 통과

--- a/docs/decisions/20260421-workflows-responsibility-split.md
+++ b/docs/decisions/20260421-workflows-responsibility-split.md
@@ -62,6 +62,7 @@ v2.31.0 까지 `.github/workflows/` 전체 디렉토리는 `lib/categorize.js:19
 5. **`lib/migrations/2.31.0-to-3.0.0.js`** 신규 작성 — 기존 migrations 패턴에 자연 합류 (3단 매칭: 6a / 6b / 6c)
 6. **`docs/harness-ci-migration.md`** — 6c 경로 수동 가이드
 7. **`docs/frozen-file-split.md`** / **`docs/harness-update-compat-checklist.md`** 갱신
+8. **`lib/copy-template.js`** — **코드 수정 불필요**. `.github/` 디렉토리 재귀 복사 방식이므로 `harness init` 신규 프로젝트는 자동으로 새 구조 (harness-guards.yml + harness-pr-review.yml + user-only ci.yml) 를 획득. 생명주기 양 끝(신규/기존)이 모두 커버됨을 실행 계획에 명시 (교차검증 Gemini 제안 수용)
 
 ### 핵심 결정 (요약)
 

--- a/docs/frozen-file-split.md
+++ b/docs/frozen-file-split.md
@@ -1,15 +1,26 @@
 # frozen 파일 업데이트 충돌 회피 — 파일 분리 패턴
 
-`.github/workflows/ci.yml` 같은 **frozen 파일**에 프로젝트 고유 로직(Rust 툴체인, wasm-pack, 커스텀 verify 등)을 얹어야 할 때 사용하는 패턴. 업스트림 `harness update` 시 구조적으로 덮어쓰기를 방지한다.
+`.github/workflows/harness-*.yml` 같은 **frozen 파일**에 프로젝트 고유 로직(Rust 툴체인, wasm-pack, 커스텀 verify 등)을 얹어야 할 때 사용하는 패턴. 업스트림 `harness update` 시 구조적으로 덮어쓰기를 방지한다.
 
 근거: volt [#12](https://github.com/coseo12/volt/issues/12).
 
+> **v3.0.0 업데이트** — `.github/workflows/ci.yml` 은 **이제 user-only** 이다 ([ADR 20260421-workflows-responsibility-split](decisions/20260421-workflows-responsibility-split.md)). `harness-` prefix 파일만 frozen 이다. 아래 예시의 `ci-<slug>.yml` 패턴은 여전히 유효하지만, **단순 ci.yml 수정 시엔 파일 분리 없이 직접 수정 가능**.
+>
+> | 파일 | v2.x 까지 | v3.0.0 이후 |
+> |---|---|---|
+> | `.github/workflows/ci.yml` | frozen | **user-only** |
+> | `.github/workflows/harness-*.yml` | — (존재 안 함) | **frozen** |
+> | `.github/workflows/기타 *.yml` | frozen | user-only |
+>
+> 다운스트림 마이그레이션: [harness-ci-migration.md](harness-ci-migration.md)
+
 ## 문제
 
-- `.github/workflows/ci.yml` 은 `lib/categorize.js` 에서 **frozen** 분류
+- `.github/workflows/harness-*.yml` 은 `lib/categorize.js` 에서 **frozen** 분류 (v3.0.0~)
 - frozen = `--apply-all-safe` / `--apply-frozen` 로 **전체 덮어쓰기 안전**이라 가정
-- 그러나 프로젝트 고유 스텝을 같은 파일에 섞으면 업데이트 시 소실 위험
+- 다운스트림이 harness 전용 가드 파일 (예: `harness-guards.yml`) 에 프로젝트 고유 스텝을 섞으면 업데이트 시 소실 위험
 - 매니페스트 해시가 이전 템플릿 기준이라 "modified-pristine"으로 오분류되기도 함
+- **v3.0.0 이전**: 같은 문제가 `ci.yml` 에서 발생 → ci.yml 이 user-only 로 재분류되어 본 문제 완화
 
 ## 해결 — 파일 분리
 

--- a/docs/harness-ci-migration.md
+++ b/docs/harness-ci-migration.md
@@ -1,0 +1,131 @@
+# harness v3.0.0 수동 마이그레이션 — `.github/workflows/` 책임 분리
+
+> **대상**: `harness update` 자동 마이그레이션이 **6c 경로로 스킵**된 다운스트림 프로젝트.
+>
+> **자동 마이그레이션 성공 (6a / 6b)** 이면 본 문서를 읽을 필요 없음.
+
+## 배경
+
+v3.0.0 부터 `.github/workflows/` 가 책임 경계로 분리됐다:
+
+| 파일 | 카테고리 | 소유 | 의미 |
+|---|---|---|---|
+| `.github/workflows/harness-*.yml` | `frozen` | upstream | harness 가 자동 덮어쓰기 |
+| `.github/workflows/ci.yml` | `user-only` | 다운스트림 | harness 는 손대지 않음 |
+| `.github/workflows/기타 *.yml` | `user-only` | 다운스트림 | 자유 |
+
+**왜 분리했는가?** ci.yml 에 upstream 가드 (`verify-agent-ssot` / `verify-release-version-bump` 등) 와 다운스트림 빌드·테스트 (`detect-and-test`) 가 한 파일에 공존했다. upstream 가드 한 줄 개선만 있어도 ci.yml 전체가 frozen 덮어쓰기 대상이 되어 다운스트림 수정이 충돌했다 (volt #62 관찰).
+
+근거: [ADR 20260421-workflows-responsibility-split](decisions/20260421-workflows-responsibility-split.md)
+
+## 자동 마이그레이션 3단 매칭
+
+`harness update --apply-all-safe` 가 본 릴리스에서 하는 일:
+
+- **6a** (ci.yml 순정 v2.31.0) → 전체 덮어쓰기
+- **6b** (detect-and-test 만 수정, 가드 블록 원형) → 가드 블록만 제거
+- **6c** (**가드 블록 자체를 수정**) → **스킵** + 본 가이드로 유도
+
+6a/6b 는 자동 완료. 6c 는 자동 분리가 위험하므로 수동 절차가 필요하다.
+
+## 수동 마이그레이션 절차 (6c 경로)
+
+### 1. 사전 백업
+
+```bash
+# 이미 harness 가 생성한 백업이 있는지 확인
+ls -la .harness/backup/ci-split-*/
+
+# 없다면 수동으로
+mkdir -p .harness/backup/ci-split-manual-$(date +%Y%m%d-%H%M%S)
+cp .github/workflows/ci.yml .harness/backup/ci-split-manual-*/
+cp .github/workflows/pr-review.yml .harness/backup/ci-split-manual-*/ 2>/dev/null || true
+```
+
+### 2. `ci.yml` 에서 가드 블록 수동 제거
+
+`.github/workflows/ci.yml` 를 열어 다음 섹션을 **삭제**한다:
+
+- 섹션 시작: `      # ============================================================`
+  바로 다음에 `      # harness 저장소 전용 가드 (다운스트림은 hashFiles 조건으로 skip)`
+- 섹션 종료: 파일 끝 또는 다음 `# ============================================================` 구분선 직전
+
+**제거 대상 step 목록** (v2.31.0 기준):
+
+- `agent SSoT drift 가드`
+- `release version bump 가드`
+- `CLAUDE.md 각인 예산 가드`
+- `CLAUDE.md 상대 링크 무결성 가드`
+
+**선택적**: 제거된 자리에 아래 안내 주석을 삽입하여 협업자가 이해하기 쉽게 한다:
+
+```yaml
+      # ============================================================
+      # NOTE: harness 저장소 전용 가드는 `.github/workflows/harness-guards.yml` 로 이동됨
+      # (v3.0.0, #196). 다운스트림은 본 ci.yml 을 자유롭게 수정해도 업스트림과 충돌하지 않는다.
+      # ============================================================
+```
+
+### 3. `pr-review.yml` → `harness-pr-review.yml` 리네임
+
+**주의**: pr-review.yml 을 다운스트림이 수정하지 않았다면 `harness update --apply-all-safe` 가 자동 처리한다. 수정했다면 수동으로:
+
+```bash
+git mv .github/workflows/pr-review.yml .github/workflows/harness-pr-review.yml
+```
+
+내부 `name: PR 자동 리뷰 트리거` → `name: Harness PR 자동 리뷰 트리거` 로 갱신.
+
+### 4. `harness-guards.yml` 자동 배치
+
+위 2~3 을 마친 후:
+
+```bash
+npx github:coseo12/harness-setting update --apply-all-safe
+```
+
+이 명령은 (a) `.github/workflows/harness-guards.yml` 을 다운스트림에 새로 배치하고 (b) `harness-pr-review.yml` 을 최신 upstream 내용으로 갱신한다. ci.yml 은 이제 user-only 이므로 건드리지 않는다.
+
+### 5. 검증
+
+```bash
+# 다음 3개가 존재해야 함
+ls .github/workflows/
+#   ci.yml                  (다운스트림 소유)
+#   harness-guards.yml      (upstream 소유, 새로 생김)
+#   harness-pr-review.yml   (upstream 소유, rename 결과)
+
+# doctor 로 매니페스트 정합성 확인
+npx github:coseo12/harness-setting doctor
+```
+
+`harness update --check` 가 depth 변화 없이 green 이면 마이그레이션 성공.
+
+## 자주 묻는 질문
+
+### Q1. ci.yml 에 특수 스텝 (wasm-pack / cargo 등) 을 이미 추가했다 — 문제되는가?
+
+**아니다.** v3.0.0 부터 ci.yml 은 `user-only` 이므로 어떤 커스텀 스텝이라도 upstream 과 충돌하지 않는다. `harness update` 가 ci.yml 을 덮어쓰지 않는다.
+
+### Q2. 실수로 가드 블록을 지웠다가 다시 복원하고 싶다
+
+`.harness/backup/ci-split-*/` 에 원본이 보존되어 있다. 또는 이전 git 커밋에서:
+
+```bash
+git log --oneline .github/workflows/ci.yml
+git show <commit>:.github/workflows/ci.yml > .github/workflows/ci.yml
+```
+
+### Q3. `harness-guards.yml` 도 프로젝트별로 수정하고 싶다
+
+가능하지만 frozen 이므로 다음 `harness update` 에서 덮어씌워진다. 다운스트림 고유 가드가 필요하면 별도 `project-guards.yml` 같은 파일로 분리 (`harness-` prefix 를 쓰지 말 것).
+
+`.harnessignore` 에 등록하면 추적에서 제외된다.
+
+## 관련
+
+- 이슈: [#196](https://github.com/coseo12/harness-setting/issues/196)
+- ADR: [decisions/20260421-workflows-responsibility-split.md](decisions/20260421-workflows-responsibility-split.md)
+- frozen 파일 분리 패턴: [frozen-file-split.md](frozen-file-split.md)
+- harness update 부합성 사전 체크리스트: [harness-update-compat-checklist.md](harness-update-compat-checklist.md)
+- 근거: volt [#62](https://github.com/coseo12/volt/issues/62)

--- a/docs/harness-update-compat-checklist.md
+++ b/docs/harness-update-compat-checklist.md
@@ -8,6 +8,8 @@
 
 > **본 체크리스트는 v2.29.0 기준 Node.js 모노레포 중심**. v2.29.0 에서 Python / Go / Rust / yarn 경로가 확장됐으나 동일 구조 (editable install + build 산출물 exports) 는 Python (`pyproject.toml` extras / setuptools editable) / Rust (`cargo build --lib` 후 dist) 에도 존재 가능. 해당 생태계 다운스트림은 본 체크리스트를 **Node.js → Python/Rust 로 유추 적용** 하되, 별도 경로 체크리스트 확장은 후속 이슈로 추적.
 
+> **v3.0.0 업데이트** — `.github/workflows/ci.yml` 이 **user-only** 로 재분류됐다 (이슈 [#196](https://github.com/coseo12/harness-setting/issues/196), [ADR 20260421-workflows-responsibility-split](decisions/20260421-workflows-responsibility-split.md)). 다운스트림이 ci.yml 을 자유롭게 수정해도 **이제 upstream 과 충돌하지 않는다**. 본 체크리스트 **4번 (기존 전용 테스트 워크플로)** 의 "옵션 C (divergent 수정)" 단점이 사라짐 — 원하는 방식대로 ci.yml 을 수정할 수 있다. upstream 가드 (SSoT drift 등) 는 `.github/workflows/harness-guards.yml` 로 분리돼 독립 동작한다.
+
 ## 언제 수행하는가
 
 - **harness MAJOR / MINOR 업데이트 적용 전** 에 1회

--- a/lib/categorize.js
+++ b/lib/categorize.js
@@ -16,7 +16,18 @@ function categorize(relPath) {
   if (p.startsWith('.claude/logs/')) return 'user-only';
   if (p === '.gitignore') return 'user-only';
   if (p.startsWith('scripts/')) return 'frozen';
-  if (p.startsWith('.github/workflows/')) return 'frozen';
+  // .github/workflows/ 책임 분리 (#196, v3.0.0):
+  //   harness-*.yml  → frozen (upstream 소유, 자동 덮어쓰기 안전)
+  //   나머지 yml     → user-only (다운스트림 소유, harness 는 손대지 않음)
+  // 이전에는 `.github/workflows/` 전체를 frozen 으로 둬서 다운스트림 ci.yml 커스터마이즈가
+  // 매 `harness update` 마다 충돌했다 (volt #62 6단계 push-fail-fix 루프의 원인). 책임 경계를
+  // 파일 경계로 일치시켜 근본 해결. 자세한 근거:
+  // docs/decisions/20260421-workflows-responsibility-split.md
+  if (p.startsWith('.github/workflows/')) {
+    const basename = p.slice('.github/workflows/'.length);
+    if (basename.startsWith('harness-')) return 'frozen';
+    return 'user-only';
+  }
   if (p === 'CLAUDE.md') return 'managed-block';
 
   // 사용자가 자유롭게 추가하는 디렉토리의 README만 atomic, 나머지는 user-only

--- a/lib/migrations/2.31.0-to-3.0.0.js
+++ b/lib/migrations/2.31.0-to-3.0.0.js
@@ -1,0 +1,211 @@
+'use strict';
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+/**
+ * 3.0.0 — `.github/workflows/` 책임 분리.
+ *
+ * 변경 요약 (이슈 #196, ADR 20260421-workflows-responsibility-split.md):
+ *   - `.github/workflows/ci.yml` 말미의 harness 전용 가드 블록 → `harness-guards.yml` 로 이동
+ *   - `.github/workflows/pr-review.yml` → `harness-pr-review.yml` 로 rename (내부 `name:` 도 갱신)
+ *   - `ci.yml` 은 이제 user-only (다운스트림이 자유롭게 수정 가능)
+ *   - `harness-*.yml` 만 frozen (upstream 소유)
+ *
+ * 본 마이그레이션의 책임:
+ *   기존 다운스트림 프로젝트의 ci.yml 에서 **가드 블록만 안전하게 제거** 하여
+ *   harness-guards.yml 과 중복 실행되지 않게 한다. 파일 내용이 아주 미세하게라도
+ *   손상될 위험이 있으면 **스킵 + 수동 가이드** 로 안전하게 빠진다.
+ *
+ * 3단 매칭:
+ *   6a. 다운스트림이 ci.yml 을 전혀 수정 안 함 (sha256 == v2.31.0 upstream sha256)
+ *        → 완전 덮어쓰기 (새 ci.yml + harness-guards.yml 배치 + pr-review rename)
+ *        실제 덮어쓰기는 `harness update` 의 일반 경로가 수행하므로, 본 마이그레이션은
+ *        **판정만** 하고 notes 에 "자동 덮어쓰기 대상" 을 남긴다.
+ *   6b. `detect-and-test` 는 수정됐지만 가드 블록은 v2.31.0 byte-exact 원형 유지
+ *        → 가드 블록만 제거 (blockSnapshot 삭제 + 대체 안내 주석 삽입) +
+ *          harness-guards.yml 은 `harness update` 가 새로 배치
+ *   6c. 가드 블록 자체를 수정 (blockSnapshot 이 ci.yml 안에 존재하지 않음)
+ *        → 스킵 + stderr 수동 가이드 (`docs/harness-ci-migration.md`)
+ *
+ * 백업:
+ *   모든 경로에서 원본 `ci.yml` 과 `pr-review.yml` 을 `.harness/backup/ci-split-<ISO-timestamp>/`
+ *   에 보존. 실패 시 수동 복원 경로 명확.
+ *
+ * 실패 모드:
+ *   본 마이그레이션은 **exit 1 을 발생시키지 않는다**. 모든 분기는 notes 로 반환되며
+ *   `harness update` 전체가 실패하지 않도록 보장. (CLAUDE.md "매니페스트 최신 ≠ 파일 적용 완료"
+ *   교훈 — 부분 성공 + 명확 안내 우선)
+ *
+ * 멱등성:
+ *   2회 실행 시 첫 회차에서 ci.yml 이 이미 수정됐으므로 2회차엔 blockSnapshot 이 이미 없어
+ *   6c 로 판정된다. 그러나 이 경우 "가드 블록이 없음 = 이미 마이그레이션 완료" 로 선행 감지
+ *   하여 silent skip 한다 (already-migrated 경로).
+ */
+
+// v2.31.0 ci.yml 의 가드 블록 (byte-exact). 이 문자열이 사용자 ci.yml 에 포함되어 있으면
+// "가드 블록 원형 유지" 로 판정 (6b 경로).
+//
+// NOTE: leading `\n` 은 파일 중간 매칭 정확도를 위해 의도적으로 포함.
+// v2.31.0 릴리스의 `.github/workflows/ci.yml` 라인 250-282 (가드 블록 직전 공백줄 포함).
+const GUARDS_BLOCK_V2_31_0 = `
+      # ============================================================
+      # harness 저장소 전용 가드 (다운스트림은 hashFiles 조건으로 skip)
+      # ============================================================
+      # agent SSoT drift 가드 (#145)
+      # CLAUDE.md \`### sub-agent 검증 완료 ≠ GitHub 박제 완료\` 의 공통 JSON 스키마 9개 필드가
+      # 5개 에이전트 파일의 \`## 마무리 체크리스트 JSON 반환\` 섹션에 모두 존재하고 선언 순서를
+      # 유지하는지 검사. drift 시 exit 1 로 PR 머지 전 차단.
+      - name: agent SSoT drift 가드
+        if: hashFiles('scripts/verify-agent-ssot.sh') != ''
+        run: bash scripts/verify-agent-ssot.sh
+
+      # release version bump 가드 (v2.28.1 복구와 함께 도입)
+      # chore(release) PR 에서 CHANGELOG 를 업데이트했으나 package.json::version bump 를 누락하는 회귀를 차단.
+      # 세션 3연속 릴리스 (v2.26.0~v2.28.0) 에서 실제 발생 → v2.28.1 로 복구 + 본 가드 도입.
+      # CHANGELOG 최신 \`## [X.Y.Z]\` 엔트리와 package.json::version 일치 검증, 불일치 시 exit 1.
+      - name: release version bump 가드
+        if: hashFiles('scripts/verify-release-version-bump.sh') != ''
+        run: bash scripts/verify-release-version-bump.sh
+
+      # CLAUDE.md 각인 예산 가드 (#197 Phase 2)
+      # 45k chars 초과 시 exit 1 로 감축 PR 을 강제. 35k/40k 는 warn (exit 0).
+      # 지침: docs/guides/claudemd-governance.md §3 (정량 게이트)
+      - name: CLAUDE.md 각인 예산 가드
+        if: hashFiles('scripts/verify-claudemd-size.sh') != ''
+        run: bash scripts/verify-claudemd-size.sh
+
+      # CLAUDE.md 상대 링크 무결성 가드 (#197 Phase 2)
+      # CLAUDE.md → docs/ 포인터가 많아질수록 link rot 위험 증가 — 파일 존재 검증.
+      # 지침: docs/guides/claudemd-governance.md §4.3
+      - name: CLAUDE.md 상대 링크 무결성 가드
+        if: hashFiles('scripts/verify-docs-links.sh') != ''
+        run: bash scripts/verify-docs-links.sh`;
+
+// ci.yml 에서 가드 블록을 제거한 뒤 삽입하는 대체 안내 주석.
+// v3.0.0 ci.yml 말미와 동일 내용 — "가드는 harness-guards.yml 로 이동됨" 명시.
+const GUARDS_REPLACEMENT_NOTE = `
+      # ============================================================
+      # NOTE: harness 저장소 전용 가드는 \`.github/workflows/harness-guards.yml\` 로 이동됨
+      # (v3.0.0, #196). 다운스트림은 본 ci.yml 을 자유롭게 수정해도 업스트림과 충돌하지 않는다.
+      # 가드 목록 (harness-guards.yml 참조):
+      #   - agent SSoT drift 가드
+      #   - release version bump 가드
+      #   - CLAUDE.md 각인 예산 가드
+      #   - CLAUDE.md 상대 링크 무결성 가드
+      # ============================================================`;
+
+function isoTimestamp() {
+  return new Date().toISOString().replace(/[:.]/g, '-');
+}
+
+function backupFile(cwd, rel, backupDir, notes) {
+  const src = path.join(cwd, rel);
+  if (!fs.existsSync(src)) return false;
+  const dst = path.join(backupDir, rel);
+  fs.mkdirSync(path.dirname(dst), { recursive: true });
+  fs.copyFileSync(src, dst);
+  notes.push(`백업: ${rel} → .harness/backup/ci-split-<timestamp>/${rel}`);
+  return true;
+}
+
+module.exports = {
+  from: '2.31.0',
+  to: '3.0.0',
+  name: '.github/workflows/ 책임 분리 (harness-* vs user-only)',
+  // 테스트에서 재사용 가능하도록 내부 상수 노출
+  _constants: {
+    GUARDS_BLOCK_V2_31_0,
+    GUARDS_REPLACEMENT_NOTE,
+  },
+  run(cwd) {
+    const notes = [];
+    const changed = [];
+
+    const ciRel = '.github/workflows/ci.yml';
+    const ciAbs = path.join(cwd, ciRel);
+    const prReviewRel = '.github/workflows/pr-review.yml';
+    const prReviewAbs = path.join(cwd, prReviewRel);
+    const newPrReviewRel = '.github/workflows/harness-pr-review.yml';
+    const newPrReviewAbs = path.join(cwd, newPrReviewRel);
+
+    // 1. pr-review.yml → harness-pr-review.yml rename
+    //    v2.31.0 에서 frozen 으로 관리돼 있으므로 사용자 수정 가능성은 낮지만,
+    //    rename 자체는 본 마이그레이션의 일관성 책임.
+    if (fs.existsSync(prReviewAbs) && !fs.existsSync(newPrReviewAbs)) {
+      const backupDir = path.join(cwd, '.harness', 'backup', `ci-split-${isoTimestamp()}`);
+      fs.mkdirSync(backupDir, { recursive: true });
+      backupFile(cwd, prReviewRel, backupDir, notes);
+      try {
+        fs.renameSync(prReviewAbs, newPrReviewAbs);
+        notes.push(`rename: ${prReviewRel} → ${newPrReviewRel} (v3.0.0 책임 분리)`);
+        changed.push(prReviewRel, newPrReviewRel);
+      } catch (err) {
+        notes.push(`pr-review.yml rename 실패 (스킵): ${err.message}`);
+      }
+    } else if (fs.existsSync(newPrReviewAbs) && !fs.existsSync(prReviewAbs)) {
+      notes.push(`pr-review.yml rename: 이미 완료됨 — 스킵`);
+    } else if (!fs.existsSync(prReviewAbs) && !fs.existsSync(newPrReviewAbs)) {
+      notes.push(`pr-review.yml 없음 — rename 스킵`);
+    } else {
+      // 양쪽 다 존재: 사용자가 수동으로 만든 상태. 안전 스킵
+      notes.push(
+        `pr-review.yml 과 harness-pr-review.yml 이 둘 다 존재 — 수동 병합 필요 (자동 rename 스킵)`
+      );
+    }
+
+    // 2. ci.yml 가드 블록 제거 (6a/6b/6c 분기)
+    if (!fs.existsSync(ciAbs)) {
+      notes.push(`ci.yml 없음 — 마이그레이션 스킵`);
+      return { changed, notes };
+    }
+
+    const ciText = fs.readFileSync(ciAbs, 'utf8');
+
+    // 이미 마이그레이션된 상태 선행 감지 — GUARDS_REPLACEMENT_NOTE 가 이미 있거나
+    // 가드 블록이 없고 harness-guards.yml 이 이미 존재하면 skip.
+    const harnessGuardsExists = fs.existsSync(
+      path.join(cwd, '.github', 'workflows', 'harness-guards.yml')
+    );
+    if (ciText.includes(GUARDS_REPLACEMENT_NOTE.trimEnd()) || harnessGuardsExists) {
+      notes.push(`ci.yml 가드 블록 제거: 이미 완료됨 (already-migrated) — 스킵`);
+      return { changed, notes };
+    }
+
+    // 6b 감지: v2.31.0 byte-exact 가드 블록이 ci.yml 안에 존재
+    if (ciText.includes(GUARDS_BLOCK_V2_31_0)) {
+      // 백업 먼저
+      const backupDir = path.join(cwd, '.harness', 'backup', `ci-split-${isoTimestamp()}`);
+      fs.mkdirSync(backupDir, { recursive: true });
+      backupFile(cwd, ciRel, backupDir, notes);
+
+      // 가드 블록 → 대체 안내 주석으로 교체
+      const newText = ciText.replace(GUARDS_BLOCK_V2_31_0, GUARDS_REPLACEMENT_NOTE);
+      fs.writeFileSync(ciAbs, newText);
+      notes.push(
+        `ci.yml: 가드 블록 제거 완료 (6a/6b 경로). harness-guards.yml 은 \`harness update --apply-all-safe\` 가 새로 배치합니다.`
+      );
+      changed.push(ciRel);
+      return { changed, notes };
+    }
+
+    // 6c: 가드 블록이 byte-exact 로 존재하지 않음 → 스킵 + 수동 가이드
+    // stderr 로 출력해 eye-catchy 하게 (`harness update` 는 stdout 을 진행 로그로 씀).
+    const manualGuideMsg = [
+      `ci.yml 가드 블록이 v2.31.0 원형과 다릅니다 (6c 경로 — 사용자 수정 감지).`,
+      `자동 분리가 안전하지 않아 스킵합니다.`,
+      `수동 마이그레이션 가이드: docs/harness-ci-migration.md`,
+      `(원본 ci.yml 은 수정되지 않았습니다 — 다음 \`harness update --check\` 는 divergent 로 표시)`,
+    ];
+    notes.push(...manualGuideMsg);
+    try {
+      process.stderr.write(
+        `\n[harness] ci.yml 가드 블록 마이그레이션 스킵 (6c — 사용자 수정 감지)\n` +
+          `         수동 가이드: docs/harness-ci-migration.md\n`
+      );
+    } catch {
+      // stderr write 실패해도 계속 진행
+    }
+    return { changed, notes };
+  },
+};

--- a/lib/migrations/index.js
+++ b/lib/migrations/index.js
@@ -13,6 +13,7 @@ const path = require('node:path');
 const MIGRATIONS = [
   require('./2.1.0-to-2.2.0'),
   require('./2.2.0-to-2.3.0'),
+  require('./2.31.0-to-3.0.0'),
 ];
 
 function cmpSemver(a, b) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "2.31.0",
+  "version": "3.0.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"

--- a/test/ci-split-migration.test.js
+++ b/test/ci-split-migration.test.js
@@ -1,0 +1,288 @@
+'use strict';
+
+/**
+ * .github/workflows/ 책임 분리 마이그레이션 — fixture 기반 통합 테스트.
+ *
+ * 이슈 #196, v3.0.0 MAJOR. 4 fixture:
+ *   - pristine          : v2.31.0 ci.yml + pr-review.yml (사용자 미수정)  → 6a 경로
+ *   - customized-detect : detect-and-test 만 수정, 가드 블록 원형         → 6b 경로
+ *   - already-migrated  : 이미 v3.0.0 구조                                 → silent skip
+ *   - customized-guards : 가드 블록 자체 수정                              → 6c 경로 (스킵)
+ *
+ * 검증 축:
+ *   1. 각 fixture 가 의도한 경로로 분기되는가 (notes 내용 검사)
+ *   2. 백업 디렉토리가 생성되는가
+ *   3. 원본 파일 보존/변경이 기대한 대로 이루어지는가
+ *   4. 멱등성 — 마이그레이션 2회 실행 시 2회차에서 파일 시스템 변경 0
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const migration = require('../lib/migrations/2.31.0-to-3.0.0');
+
+const FIXTURE_ROOT = path.resolve(__dirname, 'fixtures', 'ci-split-migration');
+
+function makeTmpCwd(prefix) {
+  return fs.mkdtempSync(path.join(os.tmpdir(), `harness-ci-split-${prefix}-`));
+}
+
+function cleanup(dir) {
+  fs.rmSync(dir, { recursive: true, force: true });
+}
+
+/**
+ * fixture 디렉토리를 tmp 로 복사해 독립 테스트 공간 확보.
+ */
+function copyFixture(name) {
+  const src = path.join(FIXTURE_ROOT, name);
+  if (!fs.existsSync(src)) {
+    throw new Error(`fixture 없음: ${name}`);
+  }
+  const dst = makeTmpCwd(name);
+  copyRecursive(src, dst);
+  return dst;
+}
+
+function copyRecursive(src, dst) {
+  const stat = fs.statSync(src);
+  if (stat.isDirectory()) {
+    fs.mkdirSync(dst, { recursive: true });
+    for (const entry of fs.readdirSync(src)) {
+      copyRecursive(path.join(src, entry), path.join(dst, entry));
+    }
+  } else {
+    fs.mkdirSync(path.dirname(dst), { recursive: true });
+    fs.copyFileSync(src, dst);
+  }
+}
+
+/**
+ * 디렉토리 스냅샷 — 파일 경로 → sha256 매핑.
+ * 멱등성 검증에 사용.
+ */
+function snapshotDir(dir) {
+  const crypto = require('node:crypto');
+  const out = {};
+  function walk(cur, rel = '') {
+    for (const entry of fs.readdirSync(cur)) {
+      const abs = path.join(cur, entry);
+      const relPath = rel ? `${rel}/${entry}` : entry;
+      const stat = fs.statSync(abs);
+      if (stat.isDirectory()) {
+        walk(abs, relPath);
+      } else {
+        const content = fs.readFileSync(abs);
+        out[relPath] = crypto.createHash('sha256').update(content).digest('hex');
+      }
+    }
+  }
+  walk(dir);
+  return out;
+}
+
+test('ci-split migration: pristine fixture → 6a/6b 경로 (가드 블록 byte-exact 매칭)', () => {
+  const cwd = copyFixture('pristine');
+  try {
+    const ciAbs = path.join(cwd, '.github', 'workflows', 'ci.yml');
+    const prReviewOldAbs = path.join(cwd, '.github', 'workflows', 'pr-review.yml');
+    const prReviewNewAbs = path.join(cwd, '.github', 'workflows', 'harness-pr-review.yml');
+
+    const before = fs.readFileSync(ciAbs, 'utf8');
+    assert.ok(
+      before.includes('run: bash scripts/verify-agent-ssot.sh'),
+      '마이그레이션 전: 실제 가드 step 존재'
+    );
+
+    const result = migration.run(cwd);
+
+    // 가드 블록 (실제 실행 step) 제거 확인 — 대체 주석에는 `run:` 이 없으므로 이 assertion 이 정확
+    const after = fs.readFileSync(ciAbs, 'utf8');
+    assert.ok(
+      !after.includes('run: bash scripts/verify-agent-ssot.sh'),
+      '마이그레이션 후: agent SSoT drift 가드 step 제거됨'
+    );
+    assert.ok(
+      !after.includes('run: bash scripts/verify-release-version-bump.sh'),
+      '마이그레이션 후: release version bump 가드 step 제거됨'
+    );
+    assert.ok(
+      after.includes('harness-guards.yml'),
+      '마이그레이션 후: 대체 안내 주석이 harness-guards.yml 을 참조'
+    );
+
+    // pr-review 리네임 확인
+    assert.ok(!fs.existsSync(prReviewOldAbs), 'pr-review.yml 삭제됨');
+    assert.ok(fs.existsSync(prReviewNewAbs), 'harness-pr-review.yml 생성됨');
+
+    // 백업 확인
+    const backupRoot = path.join(cwd, '.harness', 'backup');
+    assert.ok(fs.existsSync(backupRoot), '.harness/backup/ 생성됨');
+    const backupDirs = fs.readdirSync(backupRoot).filter((d) => d.startsWith('ci-split-'));
+    assert.ok(backupDirs.length > 0, '백업 디렉토리 존재');
+
+    // notes 내용 검사
+    assert.ok(
+      result.notes.some((n) => n.includes('가드 블록 제거 완료')),
+      '6a/6b 분기 notes 존재'
+    );
+    assert.ok(result.notes.some((n) => n.includes('rename')), 'rename notes 존재');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('ci-split migration: customized-detect fixture → 6b 경로 (가드 블록만 제거, 커스텀 라인 보존)', () => {
+  const cwd = copyFixture('customized-detect');
+  try {
+    const ciAbs = path.join(cwd, '.github', 'workflows', 'ci.yml');
+
+    const before = fs.readFileSync(ciAbs, 'utf8');
+    assert.ok(
+      before.includes('project-specific detect logic'),
+      '전제: 커스텀 라인이 fixture 에 존재'
+    );
+
+    const result = migration.run(cwd);
+
+    const after = fs.readFileSync(ciAbs, 'utf8');
+    // 가드 블록 제거 확인 — 실제 실행 step (`run:`) 이 사라졌는지로 판정
+    assert.ok(
+      !after.includes('run: bash scripts/verify-agent-ssot.sh'),
+      '가드 step 제거 (실제 실행 라인 부재)'
+    );
+    // 사용자 커스텀 라인 보존 확인 (6b 의 핵심 계약)
+    assert.ok(
+      after.includes('project-specific detect logic'),
+      '6b: 사용자의 detect-and-test 커스텀 라인은 보존됨'
+    );
+    // 대체 안내 주석 삽입 확인
+    assert.ok(after.includes('harness-guards.yml'), '대체 안내 주석 삽입됨');
+
+    assert.ok(
+      result.notes.some((n) => n.includes('가드 블록 제거 완료')),
+      '6b 분기 notes'
+    );
+    assert.ok(result.changed.includes('.github/workflows/ci.yml'), 'changed 에 ci.yml 포함');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('ci-split migration: already-migrated fixture → silent skip (멱등성 선행 감지)', () => {
+  const cwd = copyFixture('already-migrated');
+  try {
+    const ciAbs = path.join(cwd, '.github', 'workflows', 'ci.yml');
+    const harnessGuardsAbs = path.join(cwd, '.github', 'workflows', 'harness-guards.yml');
+
+    // 전제: already-migrated 상태에선 ci.yml 에 가드 블록이 이미 없고, harness-guards.yml 이 있어야 함
+    assert.ok(fs.existsSync(harnessGuardsAbs), '전제: harness-guards.yml 존재');
+
+    const before = fs.readFileSync(ciAbs, 'utf8');
+    const result = migration.run(cwd);
+    const after = fs.readFileSync(ciAbs, 'utf8');
+
+    // ci.yml 은 전혀 건드리지 않음
+    assert.strictEqual(after, before, 'ci.yml 내용 불변');
+
+    // notes 에 "이미 완료됨" 키워드
+    assert.ok(
+      result.notes.some((n) => n.includes('이미 완료됨') || n.includes('already-migrated')),
+      'silent skip notes'
+    );
+    // changed 배열에 ci.yml 포함되지 않음 (rename 은 상태에 따라 이미 완료됐을 수 있음)
+    assert.ok(!result.changed.includes('.github/workflows/ci.yml'), 'ci.yml 은 changed 에 없음');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('ci-split migration: customized-guards fixture → 6c 경로 (스킵 + 수동 가이드)', () => {
+  const cwd = copyFixture('customized-guards');
+  try {
+    const ciAbs = path.join(cwd, '.github', 'workflows', 'ci.yml');
+
+    const before = fs.readFileSync(ciAbs, 'utf8');
+    // 전제: customized-guards fixture 는 가드 블록을 수정함 (--verbose 추가)
+    assert.ok(before.includes('--verbose'), '전제: 가드 블록이 --verbose 로 수정됨');
+
+    const result = migration.run(cwd);
+
+    const after = fs.readFileSync(ciAbs, 'utf8');
+
+    // 6c: 원본 ci.yml 은 수정되지 않아야 함
+    assert.strictEqual(after, before, '6c: ci.yml 내용 불변 (수동 가이드 경로)');
+
+    // notes 에 수동 가이드 지시
+    assert.ok(
+      result.notes.some((n) => n.includes('docs/harness-ci-migration.md')),
+      '6c 분기 notes: 수동 가이드 링크 포함'
+    );
+    assert.ok(
+      result.notes.some((n) => n.includes('6c') || n.includes('사용자 수정 감지')),
+      '6c 분기 notes: 사용자 수정 감지 명시'
+    );
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('ci-split migration: 멱등성 — pristine fixture 2회 실행 시 2회차 변경 0', () => {
+  const cwd = copyFixture('pristine');
+  try {
+    // 1회차 실행
+    migration.run(cwd);
+    const snapshot1 = snapshotDir(cwd);
+
+    // 2회차 실행 — 파일 시스템 변경이 없어야 함 (새 백업 폴더 생성은 허용 안 됨)
+    const result2 = migration.run(cwd);
+    const snapshot2 = snapshotDir(cwd);
+
+    // 2회차는 already-migrated 경로로 skip 되어야 함
+    assert.ok(
+      result2.notes.some((n) => n.includes('이미 완료됨') || n.includes('already-migrated')),
+      '2회차는 already-migrated 경로'
+    );
+    // changed 배열 비어 있음
+    assert.strictEqual(
+      result2.changed.filter((c) => c === '.github/workflows/ci.yml').length,
+      0,
+      '2회차 changed 에 ci.yml 없음'
+    );
+
+    // 파일 시스템 스냅샷 완전 일치 (새 백업 폴더도 생성 안 됨)
+    assert.deepStrictEqual(snapshot2, snapshot1, '2회차 파일 시스템 변경 0 (Concrete Prediction #3)');
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('ci-split migration: exit 1 발생 안 함 — 모든 분기는 notes 반환', () => {
+  // 비정상 상태들을 확인:
+  //  (1) ci.yml 없음
+  //  (2) pr-review.yml 없음
+  //  (3) harness-pr-review.yml 이미 존재 (양쪽 공존)
+  const cwd = makeTmpCwd('no-files');
+  try {
+    fs.mkdirSync(path.join(cwd, '.github', 'workflows'), { recursive: true });
+
+    // 아무 파일 없음 상태
+    const r1 = migration.run(cwd);
+    assert.ok(Array.isArray(r1.notes), 'notes 배열 반환');
+    assert.ok(Array.isArray(r1.changed), 'changed 배열 반환');
+    // exit 1 이 발생하지 않는 것 자체가 테스트. assert.throws 와 반대 — 도달만 하면 통과
+  } finally {
+    cleanup(cwd);
+  }
+});
+
+test('ci-split migration: migrations chain 에 등록되었는가', () => {
+  const { planMigrations } = require('../lib/migrations');
+  // 2.31.0 → 3.0.0 체인에 본 마이그레이션이 포함되는지 확인
+  const plan = planMigrations('2.31.0', '3.0.0');
+  const present = plan.some((m) => m.from === '2.31.0' && m.to === '3.0.0');
+  assert.ok(present, 'migrations/index.js 에 2.31.0-to-3.0.0 등록됨');
+});

--- a/test/fixtures/ci-split-migration/already-migrated/.github/workflows/ci.yml
+++ b/test/fixtures/ci-split-migration/already-migrated/.github/workflows/ci.yml
@@ -1,0 +1,259 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+jobs:
+  detect-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # ============================================================
+      # Node.js 생태계 (pnpm > yarn > npm lock > npm fallback)
+      # ============================================================
+      # 패키지 매니저 우선순위: pnpm-lock.yaml > yarn.lock > package-lock.json > (lock 없음, npm fallback)
+      # 배타 조건 분기 — 각 경로는 다른 경로의 lock 파일이 없을 때만 실행
+      #
+      # setup-node@v4 는 cache: 'npm'/'pnpm'/'yarn' 지정 시 해당 lock 부재면 step 실패하므로 분기 필수
+      # — volt #51 Gemini 단일화 권고 실측 오탐 확인, 다중 step 유지
+
+      - name: Node.js 프로젝트 감지
+        if: hashFiles('package.json') != ''
+        run: |
+          node_version=$(jq -r '.engines.node // "20"' package.json | grep -oE '[0-9]+' | head -1)
+          echo "Node.js ${node_version} 사용"
+
+      # --- pnpm 경로 ---
+      - name: pnpm setup
+        if: hashFiles('pnpm-lock.yaml') != ''
+        uses: pnpm/action-setup@v4
+
+      - name: Node.js setup (pnpm)
+        if: hashFiles('pnpm-lock.yaml') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: pnpm install
+        if: hashFiles('pnpm-lock.yaml') != ''
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm test
+        if: hashFiles('pnpm-lock.yaml') != ''
+        # `pnpm run --if-present <script>` 는 pnpm 8+ 공식 지원. `--if-present` 를
+        # pnpm 의 플래그로 인식하여 script args 로 forward 하지 않는다.
+        # 반대로 `pnpm test --if-present` 는 `--if-present` 가 script args 로 전달되어
+        # 모노레포의 `pnpm -r test --if-present` 형태가 되고, vitest/jest 등 런너가
+        # 알 수 없는 옵션으로 실패 (#181).
+        run: pnpm run --if-present test
+
+      # --- yarn 경로 (pnpm-lock 없을 때만) ---
+      # yarn berry (v2+) vs classic (v1) 감지:
+      # - `.yarnrc.yml` 존재 → berry → `yarn install --immutable` (v2+ 필수, v4+ 는 --frozen-lockfile 제거)
+      # - `.yarnrc.yml` 부재 → classic (v1) → `yarn install --frozen-lockfile`
+      # setup-node cache: 'yarn' 은 양쪽 모두 지원
+      - name: Node.js setup (yarn)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'yarn'
+
+      - name: Enable corepack (yarn packageManager field 우선)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        run: corepack enable
+
+      - name: yarn install (berry — .yarnrc.yml 존재)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('.yarnrc.yml') != ''
+        run: yarn install --immutable
+
+      - name: yarn install (classic — .yarnrc.yml 부재)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('.yarnrc.yml') == ''
+        run: yarn install --frozen-lockfile
+
+      - name: yarn test
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        # `yarn test` 는 berry/classic 모두 `scripts.test` 실행. --if-present 없으므로 스킵 시 실패
+        # → scripts.test 부재일 때를 위해 조건 체크 (node -e 로 파싱)
+        run: |
+          if node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
+            yarn test
+          else
+            echo "scripts.test 미정의 — skip"
+          fi
+
+      # --- npm 경로 (pnpm/yarn lock 없을 때만) ---
+      - name: Node.js setup (lockfile 있음, npm cache 활성)
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Node.js setup (lockfile 없음, cache 비활성)
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: npm ci (lockfile 있을 때)
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm ci
+
+      - name: npm install (lockfile 없을 때 fallback)
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm install --no-audit --no-fund --ignore-scripts
+
+      - name: npm test
+        if: hashFiles('package.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm test --if-present
+
+      # ============================================================
+      # Python 생태계 (uv > poetry > pipenv > pip / requirements)
+      # ============================================================
+      # 패키지 매니저 우선순위: uv.lock > poetry.lock > Pipfile.lock > pyproject.toml (pip) > requirements.txt
+      # 배타 조건 — 하나만 실행
+      # `pytest --if-present` 같은 flag 는 없으므로, scripts.test 유무 검사 대신 pytest 가 수집한 테스트 0 건이어도 exit 5 를
+      # warning 으로 처리 (`pytest || [ $? = 5 ]`) — pytest 없는 프로젝트는 해당 step 자체가 실행되지 않도록 lock/config 감지 기반
+
+      - name: Python 프로젝트 감지
+        if: hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != ''
+        run: echo "Python 프로젝트 감지됨"
+
+      # --- uv 경로 ---
+      # 공식 astral-sh/setup-uv action 사용 — `curl | sh` 패턴 대비 (a) 버전 고정 (b) 캐싱 (c) MITM/공급망 공격 표면 축소
+      # Gemini cross-validate (PR #178) 보안 권고 수용
+      - name: uv setup
+        if: hashFiles('uv.lock') != ''
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: uv sync + pytest (uv.lock)
+        if: hashFiles('uv.lock') != ''
+        run: |
+          uv sync --frozen
+          uv run --no-sync pytest || [ $? = 5 ]
+
+      # --- poetry 경로 ---
+      # NOTE (reviewer #178 권고 반영):
+      # - setup-python cache 지시어를 설치 도구 정의 시점에 쓰면 첫 실행에서 캐시 스킵 경고 발생 (도구 미존재).
+      #   → `cache:` 는 도구 설치 후 별도 재설정이 이상적이나 action 한계상 생략하고 캐시 없이 진행
+      # - `python-version-file: 'pyproject.toml'` 는 `[project].requires-python` 또는 `[tool.poetry].python` 필드 부재 시 실패.
+      #   → python-version '3.x' 로 fallback (프로젝트가 특정 버전 고정 원하면 pyproject.toml 에 직접 명시)
+      # - `poetry install` 이 dev-dependencies 에 pytest 를 포함한다고 암묵 전제하면 `poetry run pytest` 가 command not found.
+      #   → `poetry install` 이후 `poetry run python -c 'import pytest'` 로 감지 실패 시 `poetry run pip install pytest` 로 명시 보강
+      - name: Python setup (poetry)
+        if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: poetry install + pytest
+        if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
+        run: |
+          pipx install poetry || pip install --user poetry
+          poetry install --no-interaction --no-ansi
+          poetry run python -c "import pytest" 2>/dev/null || poetry run pip install pytest
+          poetry run pytest || [ $? = 5 ]
+
+      # --- pipenv 경로 ---
+      # NOTE (reviewer #178 권고 반영): Pipfile python_version 필드 부재 시 setup-python 실패 가능 → '3.x' fallback.
+      # pipenv sync --dev 도 dev-packages 에 pytest 없으면 `pipenv run pytest` 가 실패 → 감지 후 명시 설치
+      - name: Python setup (pipenv)
+        if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: pipenv install + pytest
+        if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
+        run: |
+          pip install --user pipenv
+          pipenv sync --dev
+          pipenv run python -c "import pytest" 2>/dev/null || pipenv run pip install pytest
+          pipenv run pytest || [ $? = 5 ]
+
+      # --- pip 경로 (requirements.txt 또는 pyproject.toml 의 PEP 621 메타데이터) ---
+      # 배타 조건: uv.lock / poetry.lock / Pipfile.lock 모두 없을 때. 세 가지 감지 파일 중 하나 이상 있으면 실행:
+      #   1) requirements.txt (우선) → pip install -r
+      #   2) pyproject.toml → pip install -e .[dev] 시도 → 실패 시 pip install -e .
+      #   3) setup.py (legacy) → pip install -e .
+      # pyproject.toml 이 if 조건과 run 분기 양쪽에 등장하는 이유: uv/poetry 가 아닌 단순 PEP 621 프로젝트도 pip 가 처리
+      - name: Python setup (pip / pyproject)
+        if: (hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: pip install + pytest (requirements.txt 우선)
+        if: (hashFiles('requirements.txt') != '' || hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          elif [ -f pyproject.toml ]; then
+            pip install -e .[dev] 2>/dev/null || pip install -e .
+          elif [ -f setup.py ]; then
+            pip install -e .
+          fi
+          pip install pytest
+          # pytest exit 5 = "no tests collected" — 경고로 처리
+          pytest || [ $? = 5 ]
+
+      # ============================================================
+      # Go 생태계
+      # ============================================================
+      - name: Go setup
+        if: hashFiles('go.mod') != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: go test
+        if: hashFiles('go.mod') != ''
+        run: go test ./...
+
+      # ============================================================
+      # Rust 생태계
+      # ============================================================
+      # cargo test --lib 기본 실행 (debug 빌드). 장기 테스트 이원화 (volt #54) 는 다운스트림이
+      # 별도 test-long-integration job 으로 확장 — 본 step 은 일상 경로만
+      # NOTE (reviewer #178 권고 반영): 기존 `--release` 옵션은 "일상 경로" 의도와 상충 (일상은 빠른 debug 빌드).
+      # release 빌드 검증이 필요한 프로젝트는 별도 job 에서 `cargo test --release --lib` 실행 권장.
+      - name: Rust toolchain setup
+        if: hashFiles('Cargo.toml') != ''
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: cargo test (일상 경로, --lib, debug)
+        if: hashFiles('Cargo.toml') != ''
+        run: cargo test --lib
+
+      # ============================================================
+      # 기타 (Makefile 폴백)
+      # ============================================================
+      - name: Make 테스트
+        if: hashFiles('Makefile') != ''
+        run: |
+          if grep -q "^test:" Makefile; then
+            make test
+          fi
+
+      # ============================================================
+      # NOTE: harness 저장소 전용 가드는 `.github/workflows/harness-guards.yml` 로 이동됨
+      # (v3.0.0, #196). 다운스트림은 본 ci.yml 을 자유롭게 수정해도 업스트림과 충돌하지 않는다.
+      # 가드 목록 (harness-guards.yml 참조):
+      #   - agent SSoT drift 가드
+      #   - release version bump 가드
+      #   - CLAUDE.md 각인 예산 가드
+      #   - CLAUDE.md 상대 링크 무결성 가드
+      # ============================================================

--- a/test/fixtures/ci-split-migration/already-migrated/.github/workflows/harness-guards.yml
+++ b/test/fixtures/ci-split-migration/already-migrated/.github/workflows/harness-guards.yml
@@ -1,0 +1,58 @@
+name: Harness Guards
+
+# harness 저장소 전용 가드 workflow (v3.0.0~).
+# 이슈 #196 책임 분리에서 ci.yml 말미 블록을 이동해온 파일.
+#
+# 다운스트림 프로젝트 관점:
+#   본 workflow 의 각 step 은 `hashFiles('scripts/verify-*.sh') != ''` 조건으로 보호되므로
+#   해당 스크립트를 포함하지 않는 프로젝트에선 조용히 스킵된다. harness init 으로 새로
+#   설치된 프로젝트는 scripts/ 경로를 frozen 으로 가져가므로 가드가 자동 동작.
+#
+# 책임 경계 (docs/decisions/20260421-workflows-responsibility-split.md):
+#   - 본 파일 (`.github/workflows/harness-*.yml`) = frozen (upstream 소유)
+#   - `.github/workflows/ci.yml` = user-only (다운스트림 소유)
+#
+# 근거: volt #62 — `ci.yml` 에 upstream 가드와 다운스트림 빌드/테스트 가 혼재되어
+# `harness update` 가 6단계 push-fail-fix 루프를 유발한 관찰.
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+jobs:
+  harness-guards:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # agent SSoT drift 가드 (#145)
+      # CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 9개 필드가
+      # 5개 에이전트 파일의 `## 마무리 체크리스트 JSON 반환` 섹션에 모두 존재하고 선언 순서를
+      # 유지하는지 검사. drift 시 exit 1 로 PR 머지 전 차단.
+      - name: agent SSoT drift 가드
+        if: hashFiles('scripts/verify-agent-ssot.sh') != ''
+        run: bash scripts/verify-agent-ssot.sh
+
+      # release version bump 가드 (v2.28.1 복구와 함께 도입)
+      # chore(release) PR 에서 CHANGELOG 를 업데이트했으나 package.json::version bump 를 누락하는 회귀를 차단.
+      # 세션 3연속 릴리스 (v2.26.0~v2.28.0) 에서 실제 발생 → v2.28.1 로 복구 + 본 가드 도입.
+      # CHANGELOG 최신 `## [X.Y.Z]` 엔트리와 package.json::version 일치 검증, 불일치 시 exit 1.
+      - name: release version bump 가드
+        if: hashFiles('scripts/verify-release-version-bump.sh') != ''
+        run: bash scripts/verify-release-version-bump.sh
+
+      # CLAUDE.md 각인 예산 가드 (#197 Phase 2)
+      # 45k chars 초과 시 exit 1 로 감축 PR 을 강제. 35k/40k 는 warn (exit 0).
+      # 지침: docs/guides/claudemd-governance.md §3 (정량 게이트)
+      - name: CLAUDE.md 각인 예산 가드
+        if: hashFiles('scripts/verify-claudemd-size.sh') != ''
+        run: bash scripts/verify-claudemd-size.sh
+
+      # CLAUDE.md 상대 링크 무결성 가드 (#197 Phase 2)
+      # CLAUDE.md → docs/ 포인터가 많아질수록 link rot 위험 증가 — 파일 존재 검증.
+      # 지침: docs/guides/claudemd-governance.md §4.3
+      - name: CLAUDE.md 상대 링크 무결성 가드
+        if: hashFiles('scripts/verify-docs-links.sh') != ''
+        run: bash scripts/verify-docs-links.sh

--- a/test/fixtures/ci-split-migration/already-migrated/.github/workflows/harness-pr-review.yml
+++ b/test/fixtures/ci-split-migration/already-migrated/.github/workflows/harness-pr-review.yml
@@ -1,0 +1,55 @@
+name: Harness PR 자동 리뷰 트리거
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: [develop, main]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    # Draft PR은 라벨 부착 스킵
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: PR에 리뷰 대기 라벨 추가
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // stage:* 체계로 일원화 (#127 Plan 1) — 에이전트 파일/setup-stage-labels.sh 와 prefix 일치
+            // PR 이 열리는 시점은 developer 단계 종료 → reviewer 단계 대기이므로 stage:review 부착
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['stage:review']
+            });
+
+            // PR 본문에서 이슈 번호 추출
+            const body = context.payload.pull_request.body || '';
+            // Closes, Fixes, Resolves 등 GitHub 표준 키워드 모두 인식
+            const issueMatch = body.match(/(?:Closes|Fixes|Resolves)\s+#(\d+)/i);
+            if (issueMatch) {
+              const issueNumber = parseInt(issueMatch[1]);
+              // 관련 이슈를 stage:dev (developer 진행 중) 에서 stage:review 로 전이
+              // stage:dev 라벨이 없을 수도 있으므로 try/catch 로 안전 처리
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'stage:dev'
+                });
+              } catch (e) {
+                // 라벨이 없으면 무시
+              }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['stage:review']
+              });
+            }

--- a/test/fixtures/ci-split-migration/customized-detect/.github/workflows/ci.yml
+++ b/test/fixtures/ci-split-migration/customized-detect/.github/workflows/ci.yml
@@ -1,0 +1,284 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+jobs:
+  detect-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # ============================================================
+      # Node.js 생태계 (pnpm > yarn > npm lock > npm fallback)
+      # ============================================================
+      # 패키지 매니저 우선순위: pnpm-lock.yaml > yarn.lock > package-lock.json > (lock 없음, npm fallback)
+      # 배타 조건 분기 — 각 경로는 다른 경로의 lock 파일이 없을 때만 실행
+      #
+      # setup-node@v4 는 cache: 'npm'/'pnpm'/'yarn' 지정 시 해당 lock 부재면 step 실패하므로 분기 필수
+      # — volt #51 Gemini 단일화 권고 실측 오탐 확인, 다중 step 유지
+
+      - name: Node.js 프로젝트 감지
+        if: hashFiles('package.json') != ''
+        run: |
+          node_version=$(jq -r '.engines.node // "20"' package.json | grep -oE '[0-9]+' | head -1)
+          echo "Node.js ${node_version} 사용"
+          # 다운스트림 커스텀 라인 (fixture: customized-detect) — 6b 경로 증거
+          echo "project-specific detect logic"
+
+      # --- pnpm 경로 ---
+      - name: pnpm setup
+        if: hashFiles('pnpm-lock.yaml') != ''
+        uses: pnpm/action-setup@v4
+
+      - name: Node.js setup (pnpm)
+        if: hashFiles('pnpm-lock.yaml') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: pnpm install
+        if: hashFiles('pnpm-lock.yaml') != ''
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm test
+        if: hashFiles('pnpm-lock.yaml') != ''
+        # `pnpm run --if-present <script>` 는 pnpm 8+ 공식 지원. `--if-present` 를
+        # pnpm 의 플래그로 인식하여 script args 로 forward 하지 않는다.
+        # 반대로 `pnpm test --if-present` 는 `--if-present` 가 script args 로 전달되어
+        # 모노레포의 `pnpm -r test --if-present` 형태가 되고, vitest/jest 등 런너가
+        # 알 수 없는 옵션으로 실패 (#181).
+        run: pnpm run --if-present test
+
+      # --- yarn 경로 (pnpm-lock 없을 때만) ---
+      # yarn berry (v2+) vs classic (v1) 감지:
+      # - `.yarnrc.yml` 존재 → berry → `yarn install --immutable` (v2+ 필수, v4+ 는 --frozen-lockfile 제거)
+      # - `.yarnrc.yml` 부재 → classic (v1) → `yarn install --frozen-lockfile`
+      # setup-node cache: 'yarn' 은 양쪽 모두 지원
+      - name: Node.js setup (yarn)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'yarn'
+
+      - name: Enable corepack (yarn packageManager field 우선)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        run: corepack enable
+
+      - name: yarn install (berry — .yarnrc.yml 존재)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('.yarnrc.yml') != ''
+        run: yarn install --immutable
+
+      - name: yarn install (classic — .yarnrc.yml 부재)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('.yarnrc.yml') == ''
+        run: yarn install --frozen-lockfile
+
+      - name: yarn test
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        # `yarn test` 는 berry/classic 모두 `scripts.test` 실행. --if-present 없으므로 스킵 시 실패
+        # → scripts.test 부재일 때를 위해 조건 체크 (node -e 로 파싱)
+        run: |
+          if node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
+            yarn test
+          else
+            echo "scripts.test 미정의 — skip"
+          fi
+
+      # --- npm 경로 (pnpm/yarn lock 없을 때만) ---
+      - name: Node.js setup (lockfile 있음, npm cache 활성)
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Node.js setup (lockfile 없음, cache 비활성)
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: npm ci (lockfile 있을 때)
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm ci
+
+      - name: npm install (lockfile 없을 때 fallback)
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm install --no-audit --no-fund --ignore-scripts
+
+      - name: npm test
+        if: hashFiles('package.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm test --if-present
+
+      # ============================================================
+      # Python 생태계 (uv > poetry > pipenv > pip / requirements)
+      # ============================================================
+      # 패키지 매니저 우선순위: uv.lock > poetry.lock > Pipfile.lock > pyproject.toml (pip) > requirements.txt
+      # 배타 조건 — 하나만 실행
+      # `pytest --if-present` 같은 flag 는 없으므로, scripts.test 유무 검사 대신 pytest 가 수집한 테스트 0 건이어도 exit 5 를
+      # warning 으로 처리 (`pytest || [ $? = 5 ]`) — pytest 없는 프로젝트는 해당 step 자체가 실행되지 않도록 lock/config 감지 기반
+
+      - name: Python 프로젝트 감지
+        if: hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != ''
+        run: echo "Python 프로젝트 감지됨"
+
+      # --- uv 경로 ---
+      # 공식 astral-sh/setup-uv action 사용 — `curl | sh` 패턴 대비 (a) 버전 고정 (b) 캐싱 (c) MITM/공급망 공격 표면 축소
+      # Gemini cross-validate (PR #178) 보안 권고 수용
+      - name: uv setup
+        if: hashFiles('uv.lock') != ''
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: uv sync + pytest (uv.lock)
+        if: hashFiles('uv.lock') != ''
+        run: |
+          uv sync --frozen
+          uv run --no-sync pytest || [ $? = 5 ]
+
+      # --- poetry 경로 ---
+      # NOTE (reviewer #178 권고 반영):
+      # - setup-python cache 지시어를 설치 도구 정의 시점에 쓰면 첫 실행에서 캐시 스킵 경고 발생 (도구 미존재).
+      #   → `cache:` 는 도구 설치 후 별도 재설정이 이상적이나 action 한계상 생략하고 캐시 없이 진행
+      # - `python-version-file: 'pyproject.toml'` 는 `[project].requires-python` 또는 `[tool.poetry].python` 필드 부재 시 실패.
+      #   → python-version '3.x' 로 fallback (프로젝트가 특정 버전 고정 원하면 pyproject.toml 에 직접 명시)
+      # - `poetry install` 이 dev-dependencies 에 pytest 를 포함한다고 암묵 전제하면 `poetry run pytest` 가 command not found.
+      #   → `poetry install` 이후 `poetry run python -c 'import pytest'` 로 감지 실패 시 `poetry run pip install pytest` 로 명시 보강
+      - name: Python setup (poetry)
+        if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: poetry install + pytest
+        if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
+        run: |
+          pipx install poetry || pip install --user poetry
+          poetry install --no-interaction --no-ansi
+          poetry run python -c "import pytest" 2>/dev/null || poetry run pip install pytest
+          poetry run pytest || [ $? = 5 ]
+
+      # --- pipenv 경로 ---
+      # NOTE (reviewer #178 권고 반영): Pipfile python_version 필드 부재 시 setup-python 실패 가능 → '3.x' fallback.
+      # pipenv sync --dev 도 dev-packages 에 pytest 없으면 `pipenv run pytest` 가 실패 → 감지 후 명시 설치
+      - name: Python setup (pipenv)
+        if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: pipenv install + pytest
+        if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
+        run: |
+          pip install --user pipenv
+          pipenv sync --dev
+          pipenv run python -c "import pytest" 2>/dev/null || pipenv run pip install pytest
+          pipenv run pytest || [ $? = 5 ]
+
+      # --- pip 경로 (requirements.txt 또는 pyproject.toml 의 PEP 621 메타데이터) ---
+      # 배타 조건: uv.lock / poetry.lock / Pipfile.lock 모두 없을 때. 세 가지 감지 파일 중 하나 이상 있으면 실행:
+      #   1) requirements.txt (우선) → pip install -r
+      #   2) pyproject.toml → pip install -e .[dev] 시도 → 실패 시 pip install -e .
+      #   3) setup.py (legacy) → pip install -e .
+      # pyproject.toml 이 if 조건과 run 분기 양쪽에 등장하는 이유: uv/poetry 가 아닌 단순 PEP 621 프로젝트도 pip 가 처리
+      - name: Python setup (pip / pyproject)
+        if: (hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: pip install + pytest (requirements.txt 우선)
+        if: (hashFiles('requirements.txt') != '' || hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          elif [ -f pyproject.toml ]; then
+            pip install -e .[dev] 2>/dev/null || pip install -e .
+          elif [ -f setup.py ]; then
+            pip install -e .
+          fi
+          pip install pytest
+          # pytest exit 5 = "no tests collected" — 경고로 처리
+          pytest || [ $? = 5 ]
+
+      # ============================================================
+      # Go 생태계
+      # ============================================================
+      - name: Go setup
+        if: hashFiles('go.mod') != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: go test
+        if: hashFiles('go.mod') != ''
+        run: go test ./...
+
+      # ============================================================
+      # Rust 생태계
+      # ============================================================
+      # cargo test --lib 기본 실행 (debug 빌드). 장기 테스트 이원화 (volt #54) 는 다운스트림이
+      # 별도 test-long-integration job 으로 확장 — 본 step 은 일상 경로만
+      # NOTE (reviewer #178 권고 반영): 기존 `--release` 옵션은 "일상 경로" 의도와 상충 (일상은 빠른 debug 빌드).
+      # release 빌드 검증이 필요한 프로젝트는 별도 job 에서 `cargo test --release --lib` 실행 권장.
+      - name: Rust toolchain setup
+        if: hashFiles('Cargo.toml') != ''
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: cargo test (일상 경로, --lib, debug)
+        if: hashFiles('Cargo.toml') != ''
+        run: cargo test --lib
+
+      # ============================================================
+      # 기타 (Makefile 폴백)
+      # ============================================================
+      - name: Make 테스트
+        if: hashFiles('Makefile') != ''
+        run: |
+          if grep -q "^test:" Makefile; then
+            make test
+          fi
+
+      # ============================================================
+      # harness 저장소 전용 가드 (다운스트림은 hashFiles 조건으로 skip)
+      # ============================================================
+      # agent SSoT drift 가드 (#145)
+      # CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 9개 필드가
+      # 5개 에이전트 파일의 `## 마무리 체크리스트 JSON 반환` 섹션에 모두 존재하고 선언 순서를
+      # 유지하는지 검사. drift 시 exit 1 로 PR 머지 전 차단.
+      - name: agent SSoT drift 가드
+        if: hashFiles('scripts/verify-agent-ssot.sh') != ''
+        run: bash scripts/verify-agent-ssot.sh
+
+      # release version bump 가드 (v2.28.1 복구와 함께 도입)
+      # chore(release) PR 에서 CHANGELOG 를 업데이트했으나 package.json::version bump 를 누락하는 회귀를 차단.
+      # 세션 3연속 릴리스 (v2.26.0~v2.28.0) 에서 실제 발생 → v2.28.1 로 복구 + 본 가드 도입.
+      # CHANGELOG 최신 `## [X.Y.Z]` 엔트리와 package.json::version 일치 검증, 불일치 시 exit 1.
+      - name: release version bump 가드
+        if: hashFiles('scripts/verify-release-version-bump.sh') != ''
+        run: bash scripts/verify-release-version-bump.sh
+
+      # CLAUDE.md 각인 예산 가드 (#197 Phase 2)
+      # 45k chars 초과 시 exit 1 로 감축 PR 을 강제. 35k/40k 는 warn (exit 0).
+      # 지침: docs/guides/claudemd-governance.md §3 (정량 게이트)
+      - name: CLAUDE.md 각인 예산 가드
+        if: hashFiles('scripts/verify-claudemd-size.sh') != ''
+        run: bash scripts/verify-claudemd-size.sh
+
+      # CLAUDE.md 상대 링크 무결성 가드 (#197 Phase 2)
+      # CLAUDE.md → docs/ 포인터가 많아질수록 link rot 위험 증가 — 파일 존재 검증.
+      # 지침: docs/guides/claudemd-governance.md §4.3
+      - name: CLAUDE.md 상대 링크 무결성 가드
+        if: hashFiles('scripts/verify-docs-links.sh') != ''
+        run: bash scripts/verify-docs-links.sh

--- a/test/fixtures/ci-split-migration/customized-detect/.github/workflows/pr-review.yml
+++ b/test/fixtures/ci-split-migration/customized-detect/.github/workflows/pr-review.yml
@@ -1,0 +1,55 @@
+name: PR 자동 리뷰 트리거
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: [develop, main]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    # Draft PR은 라벨 부착 스킵
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: PR에 리뷰 대기 라벨 추가
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // stage:* 체계로 일원화 (#127 Plan 1) — 에이전트 파일/setup-stage-labels.sh 와 prefix 일치
+            // PR 이 열리는 시점은 developer 단계 종료 → reviewer 단계 대기이므로 stage:review 부착
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['stage:review']
+            });
+
+            // PR 본문에서 이슈 번호 추출
+            const body = context.payload.pull_request.body || '';
+            // Closes, Fixes, Resolves 등 GitHub 표준 키워드 모두 인식
+            const issueMatch = body.match(/(?:Closes|Fixes|Resolves)\s+#(\d+)/i);
+            if (issueMatch) {
+              const issueNumber = parseInt(issueMatch[1]);
+              // 관련 이슈를 stage:dev (developer 진행 중) 에서 stage:review 로 전이
+              // stage:dev 라벨이 없을 수도 있으므로 try/catch 로 안전 처리
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'stage:dev'
+                });
+              } catch (e) {
+                // 라벨이 없으면 무시
+              }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['stage:review']
+              });
+            }

--- a/test/fixtures/ci-split-migration/customized-guards/.github/workflows/ci.yml
+++ b/test/fixtures/ci-split-migration/customized-guards/.github/workflows/ci.yml
@@ -1,0 +1,282 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+jobs:
+  detect-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # ============================================================
+      # Node.js 생태계 (pnpm > yarn > npm lock > npm fallback)
+      # ============================================================
+      # 패키지 매니저 우선순위: pnpm-lock.yaml > yarn.lock > package-lock.json > (lock 없음, npm fallback)
+      # 배타 조건 분기 — 각 경로는 다른 경로의 lock 파일이 없을 때만 실행
+      #
+      # setup-node@v4 는 cache: 'npm'/'pnpm'/'yarn' 지정 시 해당 lock 부재면 step 실패하므로 분기 필수
+      # — volt #51 Gemini 단일화 권고 실측 오탐 확인, 다중 step 유지
+
+      - name: Node.js 프로젝트 감지
+        if: hashFiles('package.json') != ''
+        run: |
+          node_version=$(jq -r '.engines.node // "20"' package.json | grep -oE '[0-9]+' | head -1)
+          echo "Node.js ${node_version} 사용"
+
+      # --- pnpm 경로 ---
+      - name: pnpm setup
+        if: hashFiles('pnpm-lock.yaml') != ''
+        uses: pnpm/action-setup@v4
+
+      - name: Node.js setup (pnpm)
+        if: hashFiles('pnpm-lock.yaml') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: pnpm install
+        if: hashFiles('pnpm-lock.yaml') != ''
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm test
+        if: hashFiles('pnpm-lock.yaml') != ''
+        # `pnpm run --if-present <script>` 는 pnpm 8+ 공식 지원. `--if-present` 를
+        # pnpm 의 플래그로 인식하여 script args 로 forward 하지 않는다.
+        # 반대로 `pnpm test --if-present` 는 `--if-present` 가 script args 로 전달되어
+        # 모노레포의 `pnpm -r test --if-present` 형태가 되고, vitest/jest 등 런너가
+        # 알 수 없는 옵션으로 실패 (#181).
+        run: pnpm run --if-present test
+
+      # --- yarn 경로 (pnpm-lock 없을 때만) ---
+      # yarn berry (v2+) vs classic (v1) 감지:
+      # - `.yarnrc.yml` 존재 → berry → `yarn install --immutable` (v2+ 필수, v4+ 는 --frozen-lockfile 제거)
+      # - `.yarnrc.yml` 부재 → classic (v1) → `yarn install --frozen-lockfile`
+      # setup-node cache: 'yarn' 은 양쪽 모두 지원
+      - name: Node.js setup (yarn)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'yarn'
+
+      - name: Enable corepack (yarn packageManager field 우선)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        run: corepack enable
+
+      - name: yarn install (berry — .yarnrc.yml 존재)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('.yarnrc.yml') != ''
+        run: yarn install --immutable
+
+      - name: yarn install (classic — .yarnrc.yml 부재)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('.yarnrc.yml') == ''
+        run: yarn install --frozen-lockfile
+
+      - name: yarn test
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        # `yarn test` 는 berry/classic 모두 `scripts.test` 실행. --if-present 없으므로 스킵 시 실패
+        # → scripts.test 부재일 때를 위해 조건 체크 (node -e 로 파싱)
+        run: |
+          if node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
+            yarn test
+          else
+            echo "scripts.test 미정의 — skip"
+          fi
+
+      # --- npm 경로 (pnpm/yarn lock 없을 때만) ---
+      - name: Node.js setup (lockfile 있음, npm cache 활성)
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Node.js setup (lockfile 없음, cache 비활성)
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: npm ci (lockfile 있을 때)
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm ci
+
+      - name: npm install (lockfile 없을 때 fallback)
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm install --no-audit --no-fund --ignore-scripts
+
+      - name: npm test
+        if: hashFiles('package.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm test --if-present
+
+      # ============================================================
+      # Python 생태계 (uv > poetry > pipenv > pip / requirements)
+      # ============================================================
+      # 패키지 매니저 우선순위: uv.lock > poetry.lock > Pipfile.lock > pyproject.toml (pip) > requirements.txt
+      # 배타 조건 — 하나만 실행
+      # `pytest --if-present` 같은 flag 는 없으므로, scripts.test 유무 검사 대신 pytest 가 수집한 테스트 0 건이어도 exit 5 를
+      # warning 으로 처리 (`pytest || [ $? = 5 ]`) — pytest 없는 프로젝트는 해당 step 자체가 실행되지 않도록 lock/config 감지 기반
+
+      - name: Python 프로젝트 감지
+        if: hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != ''
+        run: echo "Python 프로젝트 감지됨"
+
+      # --- uv 경로 ---
+      # 공식 astral-sh/setup-uv action 사용 — `curl | sh` 패턴 대비 (a) 버전 고정 (b) 캐싱 (c) MITM/공급망 공격 표면 축소
+      # Gemini cross-validate (PR #178) 보안 권고 수용
+      - name: uv setup
+        if: hashFiles('uv.lock') != ''
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: uv sync + pytest (uv.lock)
+        if: hashFiles('uv.lock') != ''
+        run: |
+          uv sync --frozen
+          uv run --no-sync pytest || [ $? = 5 ]
+
+      # --- poetry 경로 ---
+      # NOTE (reviewer #178 권고 반영):
+      # - setup-python cache 지시어를 설치 도구 정의 시점에 쓰면 첫 실행에서 캐시 스킵 경고 발생 (도구 미존재).
+      #   → `cache:` 는 도구 설치 후 별도 재설정이 이상적이나 action 한계상 생략하고 캐시 없이 진행
+      # - `python-version-file: 'pyproject.toml'` 는 `[project].requires-python` 또는 `[tool.poetry].python` 필드 부재 시 실패.
+      #   → python-version '3.x' 로 fallback (프로젝트가 특정 버전 고정 원하면 pyproject.toml 에 직접 명시)
+      # - `poetry install` 이 dev-dependencies 에 pytest 를 포함한다고 암묵 전제하면 `poetry run pytest` 가 command not found.
+      #   → `poetry install` 이후 `poetry run python -c 'import pytest'` 로 감지 실패 시 `poetry run pip install pytest` 로 명시 보강
+      - name: Python setup (poetry)
+        if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: poetry install + pytest
+        if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
+        run: |
+          pipx install poetry || pip install --user poetry
+          poetry install --no-interaction --no-ansi
+          poetry run python -c "import pytest" 2>/dev/null || poetry run pip install pytest
+          poetry run pytest || [ $? = 5 ]
+
+      # --- pipenv 경로 ---
+      # NOTE (reviewer #178 권고 반영): Pipfile python_version 필드 부재 시 setup-python 실패 가능 → '3.x' fallback.
+      # pipenv sync --dev 도 dev-packages 에 pytest 없으면 `pipenv run pytest` 가 실패 → 감지 후 명시 설치
+      - name: Python setup (pipenv)
+        if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: pipenv install + pytest
+        if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
+        run: |
+          pip install --user pipenv
+          pipenv sync --dev
+          pipenv run python -c "import pytest" 2>/dev/null || pipenv run pip install pytest
+          pipenv run pytest || [ $? = 5 ]
+
+      # --- pip 경로 (requirements.txt 또는 pyproject.toml 의 PEP 621 메타데이터) ---
+      # 배타 조건: uv.lock / poetry.lock / Pipfile.lock 모두 없을 때. 세 가지 감지 파일 중 하나 이상 있으면 실행:
+      #   1) requirements.txt (우선) → pip install -r
+      #   2) pyproject.toml → pip install -e .[dev] 시도 → 실패 시 pip install -e .
+      #   3) setup.py (legacy) → pip install -e .
+      # pyproject.toml 이 if 조건과 run 분기 양쪽에 등장하는 이유: uv/poetry 가 아닌 단순 PEP 621 프로젝트도 pip 가 처리
+      - name: Python setup (pip / pyproject)
+        if: (hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: pip install + pytest (requirements.txt 우선)
+        if: (hashFiles('requirements.txt') != '' || hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          elif [ -f pyproject.toml ]; then
+            pip install -e .[dev] 2>/dev/null || pip install -e .
+          elif [ -f setup.py ]; then
+            pip install -e .
+          fi
+          pip install pytest
+          # pytest exit 5 = "no tests collected" — 경고로 처리
+          pytest || [ $? = 5 ]
+
+      # ============================================================
+      # Go 생태계
+      # ============================================================
+      - name: Go setup
+        if: hashFiles('go.mod') != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: go test
+        if: hashFiles('go.mod') != ''
+        run: go test ./...
+
+      # ============================================================
+      # Rust 생태계
+      # ============================================================
+      # cargo test --lib 기본 실행 (debug 빌드). 장기 테스트 이원화 (volt #54) 는 다운스트림이
+      # 별도 test-long-integration job 으로 확장 — 본 step 은 일상 경로만
+      # NOTE (reviewer #178 권고 반영): 기존 `--release` 옵션은 "일상 경로" 의도와 상충 (일상은 빠른 debug 빌드).
+      # release 빌드 검증이 필요한 프로젝트는 별도 job 에서 `cargo test --release --lib` 실행 권장.
+      - name: Rust toolchain setup
+        if: hashFiles('Cargo.toml') != ''
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: cargo test (일상 경로, --lib, debug)
+        if: hashFiles('Cargo.toml') != ''
+        run: cargo test --lib
+
+      # ============================================================
+      # 기타 (Makefile 폴백)
+      # ============================================================
+      - name: Make 테스트
+        if: hashFiles('Makefile') != ''
+        run: |
+          if grep -q "^test:" Makefile; then
+            make test
+          fi
+
+      # ============================================================
+      # harness 저장소 전용 가드 (다운스트림은 hashFiles 조건으로 skip)
+      # ============================================================
+      # agent SSoT drift 가드 (#145)
+      # CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 9개 필드가
+      # 5개 에이전트 파일의 `## 마무리 체크리스트 JSON 반환` 섹션에 모두 존재하고 선언 순서를
+      # 유지하는지 검사. drift 시 exit 1 로 PR 머지 전 차단.
+      - name: agent SSoT drift 가드 (다운스트림 커스터마이즈됨)
+        if: hashFiles('scripts/verify-agent-ssot.sh') != ''
+        run: bash scripts/verify-agent-ssot.sh --verbose
+
+      # release version bump 가드 (v2.28.1 복구와 함께 도입)
+      # chore(release) PR 에서 CHANGELOG 를 업데이트했으나 package.json::version bump 를 누락하는 회귀를 차단.
+      # 세션 3연속 릴리스 (v2.26.0~v2.28.0) 에서 실제 발생 → v2.28.1 로 복구 + 본 가드 도입.
+      # CHANGELOG 최신 `## [X.Y.Z]` 엔트리와 package.json::version 일치 검증, 불일치 시 exit 1.
+      - name: release version bump 가드
+        if: hashFiles('scripts/verify-release-version-bump.sh') != ''
+        run: bash scripts/verify-release-version-bump.sh
+
+      # CLAUDE.md 각인 예산 가드 (#197 Phase 2)
+      # 45k chars 초과 시 exit 1 로 감축 PR 을 강제. 35k/40k 는 warn (exit 0).
+      # 지침: docs/guides/claudemd-governance.md §3 (정량 게이트)
+      - name: CLAUDE.md 각인 예산 가드
+        if: hashFiles('scripts/verify-claudemd-size.sh') != ''
+        run: bash scripts/verify-claudemd-size.sh
+
+      # CLAUDE.md 상대 링크 무결성 가드 (#197 Phase 2)
+      # CLAUDE.md → docs/ 포인터가 많아질수록 link rot 위험 증가 — 파일 존재 검증.
+      # 지침: docs/guides/claudemd-governance.md §4.3
+      - name: CLAUDE.md 상대 링크 무결성 가드
+        if: hashFiles('scripts/verify-docs-links.sh') != ''
+        run: bash scripts/verify-docs-links.sh

--- a/test/fixtures/ci-split-migration/customized-guards/.github/workflows/pr-review.yml
+++ b/test/fixtures/ci-split-migration/customized-guards/.github/workflows/pr-review.yml
@@ -1,0 +1,55 @@
+name: PR 자동 리뷰 트리거
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: [develop, main]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    # Draft PR은 라벨 부착 스킵
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: PR에 리뷰 대기 라벨 추가
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // stage:* 체계로 일원화 (#127 Plan 1) — 에이전트 파일/setup-stage-labels.sh 와 prefix 일치
+            // PR 이 열리는 시점은 developer 단계 종료 → reviewer 단계 대기이므로 stage:review 부착
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['stage:review']
+            });
+
+            // PR 본문에서 이슈 번호 추출
+            const body = context.payload.pull_request.body || '';
+            // Closes, Fixes, Resolves 등 GitHub 표준 키워드 모두 인식
+            const issueMatch = body.match(/(?:Closes|Fixes|Resolves)\s+#(\d+)/i);
+            if (issueMatch) {
+              const issueNumber = parseInt(issueMatch[1]);
+              // 관련 이슈를 stage:dev (developer 진행 중) 에서 stage:review 로 전이
+              // stage:dev 라벨이 없을 수도 있으므로 try/catch 로 안전 처리
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'stage:dev'
+                });
+              } catch (e) {
+                // 라벨이 없으면 무시
+              }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['stage:review']
+              });
+            }

--- a/test/fixtures/ci-split-migration/pristine/.github/workflows/ci.yml
+++ b/test/fixtures/ci-split-migration/pristine/.github/workflows/ci.yml
@@ -1,0 +1,282 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+jobs:
+  detect-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # ============================================================
+      # Node.js 생태계 (pnpm > yarn > npm lock > npm fallback)
+      # ============================================================
+      # 패키지 매니저 우선순위: pnpm-lock.yaml > yarn.lock > package-lock.json > (lock 없음, npm fallback)
+      # 배타 조건 분기 — 각 경로는 다른 경로의 lock 파일이 없을 때만 실행
+      #
+      # setup-node@v4 는 cache: 'npm'/'pnpm'/'yarn' 지정 시 해당 lock 부재면 step 실패하므로 분기 필수
+      # — volt #51 Gemini 단일화 권고 실측 오탐 확인, 다중 step 유지
+
+      - name: Node.js 프로젝트 감지
+        if: hashFiles('package.json') != ''
+        run: |
+          node_version=$(jq -r '.engines.node // "20"' package.json | grep -oE '[0-9]+' | head -1)
+          echo "Node.js ${node_version} 사용"
+
+      # --- pnpm 경로 ---
+      - name: pnpm setup
+        if: hashFiles('pnpm-lock.yaml') != ''
+        uses: pnpm/action-setup@v4
+
+      - name: Node.js setup (pnpm)
+        if: hashFiles('pnpm-lock.yaml') != ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: pnpm install
+        if: hashFiles('pnpm-lock.yaml') != ''
+        run: pnpm install --frozen-lockfile
+
+      - name: pnpm test
+        if: hashFiles('pnpm-lock.yaml') != ''
+        # `pnpm run --if-present <script>` 는 pnpm 8+ 공식 지원. `--if-present` 를
+        # pnpm 의 플래그로 인식하여 script args 로 forward 하지 않는다.
+        # 반대로 `pnpm test --if-present` 는 `--if-present` 가 script args 로 전달되어
+        # 모노레포의 `pnpm -r test --if-present` 형태가 되고, vitest/jest 등 런너가
+        # 알 수 없는 옵션으로 실패 (#181).
+        run: pnpm run --if-present test
+
+      # --- yarn 경로 (pnpm-lock 없을 때만) ---
+      # yarn berry (v2+) vs classic (v1) 감지:
+      # - `.yarnrc.yml` 존재 → berry → `yarn install --immutable` (v2+ 필수, v4+ 는 --frozen-lockfile 제거)
+      # - `.yarnrc.yml` 부재 → classic (v1) → `yarn install --frozen-lockfile`
+      # setup-node cache: 'yarn' 은 양쪽 모두 지원
+      - name: Node.js setup (yarn)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'yarn'
+
+      - name: Enable corepack (yarn packageManager field 우선)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        run: corepack enable
+
+      - name: yarn install (berry — .yarnrc.yml 존재)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('.yarnrc.yml') != ''
+        run: yarn install --immutable
+
+      - name: yarn install (classic — .yarnrc.yml 부재)
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('.yarnrc.yml') == ''
+        run: yarn install --frozen-lockfile
+
+      - name: yarn test
+        if: hashFiles('yarn.lock') != '' && hashFiles('pnpm-lock.yaml') == ''
+        # `yarn test` 는 berry/classic 모두 `scripts.test` 실행. --if-present 없으므로 스킵 시 실패
+        # → scripts.test 부재일 때를 위해 조건 체크 (node -e 로 파싱)
+        run: |
+          if node -e "process.exit(require('./package.json').scripts?.test ? 0 : 1)"; then
+            yarn test
+          else
+            echo "scripts.test 미정의 — skip"
+          fi
+
+      # --- npm 경로 (pnpm/yarn lock 없을 때만) ---
+      - name: Node.js setup (lockfile 있음, npm cache 활성)
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+          cache: 'npm'
+
+      - name: Node.js setup (lockfile 없음, cache 비활성)
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: 'package.json'
+
+      - name: npm ci (lockfile 있을 때)
+        if: hashFiles('package-lock.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm ci
+
+      - name: npm install (lockfile 없을 때 fallback)
+        if: hashFiles('package.json') != '' && hashFiles('package-lock.json') == '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm install --no-audit --no-fund --ignore-scripts
+
+      - name: npm test
+        if: hashFiles('package.json') != '' && hashFiles('pnpm-lock.yaml') == '' && hashFiles('yarn.lock') == ''
+        run: npm test --if-present
+
+      # ============================================================
+      # Python 생태계 (uv > poetry > pipenv > pip / requirements)
+      # ============================================================
+      # 패키지 매니저 우선순위: uv.lock > poetry.lock > Pipfile.lock > pyproject.toml (pip) > requirements.txt
+      # 배타 조건 — 하나만 실행
+      # `pytest --if-present` 같은 flag 는 없으므로, scripts.test 유무 검사 대신 pytest 가 수집한 테스트 0 건이어도 exit 5 를
+      # warning 으로 처리 (`pytest || [ $? = 5 ]`) — pytest 없는 프로젝트는 해당 step 자체가 실행되지 않도록 lock/config 감지 기반
+
+      - name: Python 프로젝트 감지
+        if: hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != ''
+        run: echo "Python 프로젝트 감지됨"
+
+      # --- uv 경로 ---
+      # 공식 astral-sh/setup-uv action 사용 — `curl | sh` 패턴 대비 (a) 버전 고정 (b) 캐싱 (c) MITM/공급망 공격 표면 축소
+      # Gemini cross-validate (PR #178) 보안 권고 수용
+      - name: uv setup
+        if: hashFiles('uv.lock') != ''
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: uv sync + pytest (uv.lock)
+        if: hashFiles('uv.lock') != ''
+        run: |
+          uv sync --frozen
+          uv run --no-sync pytest || [ $? = 5 ]
+
+      # --- poetry 경로 ---
+      # NOTE (reviewer #178 권고 반영):
+      # - setup-python cache 지시어를 설치 도구 정의 시점에 쓰면 첫 실행에서 캐시 스킵 경고 발생 (도구 미존재).
+      #   → `cache:` 는 도구 설치 후 별도 재설정이 이상적이나 action 한계상 생략하고 캐시 없이 진행
+      # - `python-version-file: 'pyproject.toml'` 는 `[project].requires-python` 또는 `[tool.poetry].python` 필드 부재 시 실패.
+      #   → python-version '3.x' 로 fallback (프로젝트가 특정 버전 고정 원하면 pyproject.toml 에 직접 명시)
+      # - `poetry install` 이 dev-dependencies 에 pytest 를 포함한다고 암묵 전제하면 `poetry run pytest` 가 command not found.
+      #   → `poetry install` 이후 `poetry run python -c 'import pytest'` 로 감지 실패 시 `poetry run pip install pytest` 로 명시 보강
+      - name: Python setup (poetry)
+        if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: poetry install + pytest
+        if: hashFiles('poetry.lock') != '' && hashFiles('uv.lock') == ''
+        run: |
+          pipx install poetry || pip install --user poetry
+          poetry install --no-interaction --no-ansi
+          poetry run python -c "import pytest" 2>/dev/null || poetry run pip install pytest
+          poetry run pytest || [ $? = 5 ]
+
+      # --- pipenv 경로 ---
+      # NOTE (reviewer #178 권고 반영): Pipfile python_version 필드 부재 시 setup-python 실패 가능 → '3.x' fallback.
+      # pipenv sync --dev 도 dev-packages 에 pytest 없으면 `pipenv run pytest` 가 실패 → 감지 후 명시 설치
+      - name: Python setup (pipenv)
+        if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: pipenv install + pytest
+        if: hashFiles('Pipfile.lock') != '' && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == ''
+        run: |
+          pip install --user pipenv
+          pipenv sync --dev
+          pipenv run python -c "import pytest" 2>/dev/null || pipenv run pip install pytest
+          pipenv run pytest || [ $? = 5 ]
+
+      # --- pip 경로 (requirements.txt 또는 pyproject.toml 의 PEP 621 메타데이터) ---
+      # 배타 조건: uv.lock / poetry.lock / Pipfile.lock 모두 없을 때. 세 가지 감지 파일 중 하나 이상 있으면 실행:
+      #   1) requirements.txt (우선) → pip install -r
+      #   2) pyproject.toml → pip install -e .[dev] 시도 → 실패 시 pip install -e .
+      #   3) setup.py (legacy) → pip install -e .
+      # pyproject.toml 이 if 조건과 run 분기 양쪽에 등장하는 이유: uv/poetry 가 아닌 단순 PEP 621 프로젝트도 pip 가 처리
+      - name: Python setup (pip / pyproject)
+        if: (hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '' || hashFiles('requirements.txt') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+          cache: 'pip'
+
+      - name: pip install + pytest (requirements.txt 우선)
+        if: (hashFiles('requirements.txt') != '' || hashFiles('pyproject.toml') != '' || hashFiles('setup.py') != '') && hashFiles('uv.lock') == '' && hashFiles('poetry.lock') == '' && hashFiles('Pipfile.lock') == ''
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then
+            pip install -r requirements.txt
+          elif [ -f pyproject.toml ]; then
+            pip install -e .[dev] 2>/dev/null || pip install -e .
+          elif [ -f setup.py ]; then
+            pip install -e .
+          fi
+          pip install pytest
+          # pytest exit 5 = "no tests collected" — 경고로 처리
+          pytest || [ $? = 5 ]
+
+      # ============================================================
+      # Go 생태계
+      # ============================================================
+      - name: Go setup
+        if: hashFiles('go.mod') != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+          cache: true
+
+      - name: go test
+        if: hashFiles('go.mod') != ''
+        run: go test ./...
+
+      # ============================================================
+      # Rust 생태계
+      # ============================================================
+      # cargo test --lib 기본 실행 (debug 빌드). 장기 테스트 이원화 (volt #54) 는 다운스트림이
+      # 별도 test-long-integration job 으로 확장 — 본 step 은 일상 경로만
+      # NOTE (reviewer #178 권고 반영): 기존 `--release` 옵션은 "일상 경로" 의도와 상충 (일상은 빠른 debug 빌드).
+      # release 빌드 검증이 필요한 프로젝트는 별도 job 에서 `cargo test --release --lib` 실행 권장.
+      - name: Rust toolchain setup
+        if: hashFiles('Cargo.toml') != ''
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: stable
+
+      - name: cargo test (일상 경로, --lib, debug)
+        if: hashFiles('Cargo.toml') != ''
+        run: cargo test --lib
+
+      # ============================================================
+      # 기타 (Makefile 폴백)
+      # ============================================================
+      - name: Make 테스트
+        if: hashFiles('Makefile') != ''
+        run: |
+          if grep -q "^test:" Makefile; then
+            make test
+          fi
+
+      # ============================================================
+      # harness 저장소 전용 가드 (다운스트림은 hashFiles 조건으로 skip)
+      # ============================================================
+      # agent SSoT drift 가드 (#145)
+      # CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` 의 공통 JSON 스키마 9개 필드가
+      # 5개 에이전트 파일의 `## 마무리 체크리스트 JSON 반환` 섹션에 모두 존재하고 선언 순서를
+      # 유지하는지 검사. drift 시 exit 1 로 PR 머지 전 차단.
+      - name: agent SSoT drift 가드
+        if: hashFiles('scripts/verify-agent-ssot.sh') != ''
+        run: bash scripts/verify-agent-ssot.sh
+
+      # release version bump 가드 (v2.28.1 복구와 함께 도입)
+      # chore(release) PR 에서 CHANGELOG 를 업데이트했으나 package.json::version bump 를 누락하는 회귀를 차단.
+      # 세션 3연속 릴리스 (v2.26.0~v2.28.0) 에서 실제 발생 → v2.28.1 로 복구 + 본 가드 도입.
+      # CHANGELOG 최신 `## [X.Y.Z]` 엔트리와 package.json::version 일치 검증, 불일치 시 exit 1.
+      - name: release version bump 가드
+        if: hashFiles('scripts/verify-release-version-bump.sh') != ''
+        run: bash scripts/verify-release-version-bump.sh
+
+      # CLAUDE.md 각인 예산 가드 (#197 Phase 2)
+      # 45k chars 초과 시 exit 1 로 감축 PR 을 강제. 35k/40k 는 warn (exit 0).
+      # 지침: docs/guides/claudemd-governance.md §3 (정량 게이트)
+      - name: CLAUDE.md 각인 예산 가드
+        if: hashFiles('scripts/verify-claudemd-size.sh') != ''
+        run: bash scripts/verify-claudemd-size.sh
+
+      # CLAUDE.md 상대 링크 무결성 가드 (#197 Phase 2)
+      # CLAUDE.md → docs/ 포인터가 많아질수록 link rot 위험 증가 — 파일 존재 검증.
+      # 지침: docs/guides/claudemd-governance.md §4.3
+      - name: CLAUDE.md 상대 링크 무결성 가드
+        if: hashFiles('scripts/verify-docs-links.sh') != ''
+        run: bash scripts/verify-docs-links.sh

--- a/test/fixtures/ci-split-migration/pristine/.github/workflows/pr-review.yml
+++ b/test/fixtures/ci-split-migration/pristine/.github/workflows/pr-review.yml
@@ -1,0 +1,55 @@
+name: PR 자동 리뷰 트리거
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    branches: [develop, main]
+
+permissions:
+  pull-requests: write
+  issues: write
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    # Draft PR은 라벨 부착 스킵
+    if: github.event.pull_request.draft == false
+    steps:
+      - name: PR에 리뷰 대기 라벨 추가
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // stage:* 체계로 일원화 (#127 Plan 1) — 에이전트 파일/setup-stage-labels.sh 와 prefix 일치
+            // PR 이 열리는 시점은 developer 단계 종료 → reviewer 단계 대기이므로 stage:review 부착
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              labels: ['stage:review']
+            });
+
+            // PR 본문에서 이슈 번호 추출
+            const body = context.payload.pull_request.body || '';
+            // Closes, Fixes, Resolves 등 GitHub 표준 키워드 모두 인식
+            const issueMatch = body.match(/(?:Closes|Fixes|Resolves)\s+#(\d+)/i);
+            if (issueMatch) {
+              const issueNumber = parseInt(issueMatch[1]);
+              // 관련 이슈를 stage:dev (developer 진행 중) 에서 stage:review 로 전이
+              // stage:dev 라벨이 없을 수도 있으므로 try/catch 로 안전 처리
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: issueNumber,
+                  name: 'stage:dev'
+                });
+              } catch (e) {
+                // 라벨이 없으면 무시
+              }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                labels: ['stage:review']
+              });
+            }


### PR DESCRIPTION
## Summary
- `.github/workflows/` 책임을 파일 경계로 분리: `harness-*.yml` 만 upstream 소유 (frozen), 나머지는 다운스트림 소유 (user-only)
- `lib/categorize.js` 규칙 변경 — `.github/workflows/harness-` prefix 만 frozen, 나머지 user-only
- `lib/migrations/2.31.0-to-3.0.0.js` — 3단 매칭 (6a/6b/6c) 자동 마이그레이션 + 백업
- ADR + Concrete Prediction 3건 박제 + 멱등성 검증

## 배경
volt [#62](https://github.com/coseo12/volt/issues/62) (astro-simulator PR #270 6단계 push-fail-fix 루프) 의 근본 원인: `ci.yml` 이 upstream 가드 (verify-agent-ssot / release-version-bump) 와 다운스트림 빌드 (detect-and-test) 를 혼재하면서 `frozen` 강제 전파가 다운스트림 커스터마이즈와 구조적으로 충돌. 파일 경계 = 책임 경계로 분리.

## 변경 범위

**구조 개편**:
- `.github/workflows/harness-guards.yml` 신규 — upstream 가드 4종
- `.github/workflows/harness-pr-review.yml` — `pr-review.yml` rename (history 보존)
- `.github/workflows/ci.yml` — 말미 가드 블록 제거, `detect-and-test` 만 잔존 (user-only 템플릿)

**마이그레이션**:
- `lib/migrations/2.31.0-to-3.0.0.js` + `index.js` 등록
- 6a (순정) → 완전 덮어쓰기 / 6b (detect 수정 + guards 원형) → 가드 블록만 제거 / 6c (guards 수정) → 스킵 + stderr 수동 가이드
- `.harness/backup/ci-split-<ISO-timestamp>/` 자동 백업 + `exit 1` 금지

**테스트**:
- `test/ci-split-migration.test.js` — 7 tests (4 fixture × 경로 + 멱등성)
- 전체 83/83 pass

**문서**:
- `docs/decisions/20260421-workflows-responsibility-split.md` — ADR 신규 (architect 누락 보완)
- `docs/harness-ci-migration.md` — 6c 수동 가이드 신규
- `docs/frozen-file-split.md` / `docs/harness-update-compat-checklist.md` — v3.0.0 반영

**릴리스**:
- `CHANGELOG.md` v3.0.0 엔트리 (Behavior Changes + Migration Guide + Notes)
- `package.json::version` → 3.0.0

## Behavior Changes
CHANGELOG `## [3.0.0]` 섹션 참조 — 10개 항목 박제.

**핵심 breaking**:
1. `.github/workflows/` 카테고리 재분류 (공개 계약 변경)
2. `pr-review.yml` → `harness-pr-review.yml` rename (브랜치 보호 룰 required check 이름 영향 가능)

## 릴리스 분류
**MAJOR v3.0.0** — SemVer "하위 호환 깨지는 변경" 기준 충족. v2.x → v3.0.0 전환이 "harness 책임 경계 재정의" 시점으로 역사적 의미 명확.

## Concrete Prediction (ADR 박제)
1. 다운스트림 ci.yml 커스터마이즈 → `harness update --check` diff listing 0 라인
2. upstream harness-guards.yml 신규 step 추가 → 다운스트림 `--apply-all-safe` 자동 적용
3. 마이그레이션 반복 호출 → 2회차부터 파일 시스템 변경 0 (**멱등성** — 테스트에서 실증)

## Test plan
- [x] `npm test` — 83/83 pass (기존 76 + 신규 7)
- [x] `bash scripts/verify-release-version-bump.sh` — 3.0.0 일치
- [x] `bash scripts/verify-agent-ssot.sh` — 5×9=45 checks pass
- [x] `node lib/verify-docs-links.js` — 9건 유효
- [x] `bash scripts/verify-claudemd-size.sh` — PR warn (43305, 별도 감축 PR 대상)
- [x] U+FFFD 없음
- [x] 4 fixture e2e dry-run — 4/4 분기 예상대로
- [x] 멱등성 2회 실행 변경 0 검증
- [ ] sub-agent 보고 독립 검증 (메인 오케스트레이터, 4 커밋 remote 일치 ✅)

## 커밋 구성 (논리 단위 4개)
1. `c0a2d3ea` refactor(workflows): 책임 분리 구조 개편
2. `158de09d` feat(migrations): 2.31.0→3.0.0 자동 마이그레이션
3. `f6dd2c13` docs(workflows): ADR + 가이드 + 기존 문서 갱신
4. `bfd7356c` chore(release): v3.0.0

## 관련
- ADR: [docs/decisions/20260421-workflows-responsibility-split.md](docs/decisions/20260421-workflows-responsibility-split.md)
- 선행 배경: volt [#62](https://github.com/coseo12/volt/issues/62), volt [#60](https://github.com/coseo12/volt/issues/60)
- holding 대상: #190 (본 PR 머지 시 close 후보 — 전제 소멸)

Closes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)