### PR TITLE
[#196] v3.0.0 CHANGELOG 엔트리 drift 보완 (#197 #200 MINOR 통합) (PATCH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,17 @@
 
 ## [3.0.0] — 2026-04-22
 
-[#196](https://github.com/coseo12/harness-setting/issues/196) — `.github/workflows/` 책임 분리 (**MAJOR** — breaking: 파일 rename + 카테고리 재분류). volt [#62](https://github.com/coseo12/volt/issues/62) 실측 (astro-simulator PR #270 6단계 push-fail-fix 루프) 근거.
+v2.31.0 이후 누적된 **5개 PR 통합 릴리스**. MAJOR 분류는 [#196](https://github.com/coseo12/harness-setting/issues/196) 의 breaking change (파일 rename + 카테고리 재분류) 에 의해 결정. 포함된 MINOR 2건 (#197 / #200) 의 Behavior Changes 도 본 엔트리에 수록.
 
-### Behavior Changes
+**포함 범위**:
+
+- [#196](https://github.com/coseo12/harness-setting/issues/196) — `.github/workflows/` 책임 분리 (**MAJOR**, breaking: 파일 rename + 카테고리 재분류). volt [#62](https://github.com/coseo12/volt/issues/62) 실측 (astro-simulator PR #270 6단계 push-fail-fix 루프) 근거
+- [#197](https://github.com/coseo12/harness-setting/issues/197) — CLAUDE.md 비대화 방지 근본 지침 박제 (**MINOR**, Phase 1)
+- [#200](https://github.com/coseo12/harness-setting/issues/200) — CLAUDE.md 각인 예산 강제 메커니즘 (**MINOR**, Phase 2)
+- [#199](https://github.com/coseo12/harness-setting/issues/199) — Phase 3 추출 실행 계획 박제 (PATCH, 설계 전용 — 행동 변화 없음)
+- [#202](https://github.com/coseo12/harness-setting/issues/202) — verify-docs-links 삼항 단순화 + leading slash 회귀 가드 (PATCH, 행동 변화 없음)
+
+### Behavior Changes — #196 `.github/workflows/` 책임 분리 (MAJOR)
 
 - **`.github/workflows/harness-*.yml` 만 frozen (upstream 소유)** — `lib/categorize.js` 규칙 변경. 이전에는 `.github/workflows/` 디렉토리 전체가 frozen 이었음. **다운스트림 ci.yml 을 이제 자유롭게 수정 가능** — upstream `harness update --apply-all-safe` 가 더 이상 ci.yml 을 덮어쓰지 않는다. 근거: volt #62 에서 관찰된 "upstream 가드 vs 다운스트림 빌드 혼재" 구조 문제 해소
 - **`.github/workflows/ci.yml` → user-only 로 재분류** — 말미 harness 전용 가드 블록 (agent SSoT / release version bump / CLAUDE.md 각인 / CLAUDE.md 링크) 4개가 신규 `harness-guards.yml` 로 이동. ci.yml 에는 `detect-and-test` (다언어 자동 감지/실행) 만 잔존
@@ -25,6 +33,22 @@
 - **마이그레이션 실패 시 `exit 1` 금지** — 6c 경로는 notes + stderr 경고 반환, `harness update` 전체가 실패하지 않도록 보장 (CLAUDE.md "매니페스트 최신 ≠ 파일 적용 완료" 교훈)
 - **`docs/frozen-file-split.md` / `docs/harness-update-compat-checklist.md` 갱신** — v3.0.0 책임 경계 명문화. 기존 "옵션 C (divergent 수정)" 의 단점이 해소됐음을 명시
 - **`docs/harness-ci-migration.md` 신설** — 6c 경로 발동 시 수동 마이그레이션 가이드 (단계별 체크리스트 + 제거 대상 step 목록)
+
+### Behavior Changes — #197 CLAUDE.md 비대화 방지 (MINOR, Phase 1)
+
+- **새 실전 교훈/프로토콜 블록 추가 시 기본 경로 변경** — `docs/lessons/<topic>.md` (또는 유사 위치) 생성 + CLAUDE.md 는 1~3 줄 포인터만. 매트릭스(3행+)·코드블록(5라인+)·프로토콜(3스텝+)·근거 체인(이슈 2+) 은 `docs/` 로 추출 대상
+- **인라인 유지 예외 절차** — 예외는 ADR 로만 박제 (`docs/decisions/<YYYYMMDD>-claudemd-exception-<topic>.md`). 사유·대체 불가 근거·재검토 조건 필수
+- **정량 게이트 선언** — 35k chars warn / 40k PR warn (신규 인라인 금지 안내) / 45k CI fail. 강제 메커니즘은 #200 에서 구현
+- **40k/45k 임계 접근 시 대응 원칙** — "예외 박제" 가 아니라 **기존 블록 가지치기 (각인층 → 참조층 이동)**
+- **상세 프로토콜 위치** — `docs/guides/claudemd-governance.md` 9 섹션 (임계 조정 여지 / 동적 운영 지표 / 가지치기 프로세스 / 링크 무결성 CI / 1인 개발자 환경 ADR 대체 등)
+
+### Behavior Changes — #200 CLAUDE.md 각인 예산 강제 (MINOR, Phase 2)
+
+- **CLAUDE.md 가 45k chars 초과 시 CI fail** — `scripts/verify-claudemd-size.sh` 가 `detect-and-test` 에서 exit 1 반환 → PR 머지 차단. 환경변수 override: `CLAUDEMD_SIZE_LIMIT_FAIL` / `CLAUDEMD_SIZE_LIMIT_WARN_PR` / `CLAUDEMD_SIZE_LIMIT_WARN_BOUNDARY`
+- **40k 초과 시 PR 체크 로그 경고** — exit 0 유지 (머지 차단 없음), 신규 인라인 금지 안내 노출
+- **`harness doctor` "CLAUDE.md 각인 예산" 항목 추가** — 로컬 charCount 기반 pass/warn/fail 3단 가시화
+- **CLAUDE.md 상대 링크 rot 방어** — `scripts/verify-docs-links.sh` + `lib/verify-docs-links.js` 가 깨진 상대 링크 감지 시 CI fail. 코드펜스/인라인 코드/외부 URL/앵커 전용 링크 스킵
+- **현재 실측**: CLAUDE.md = **43,305 chars** (PR warn 구간, exit 0). Phase 3 (#199 설계 박제 → 후속 세션 Phase 3-A PR 실행) 에서 35k 이하 복귀 예정
 
 ### Migration Guide (다운스트림)
 
@@ -49,6 +73,10 @@ npx github:coseo12/harness-setting doctor
 - **Concrete Prediction 실증** — (1) 다운스트림 ci.yml 커스터마이즈 유지 확인 / (2) upstream harness-guards.yml 자동 전파 / (3) 멱등성 (2회차 변경 0) 3건 모두 테스트로 검증 완료 (`test/ci-split-migration.test.js` 7 테스트 통과)
 - **Phase 분리 고려** — 본 릴리스는 카테고리 변경 + 파일 rename + 마이그레이션을 한 번에 묶었다. Phase 1 (categorize 수정) + Phase 2 (마이그레이션) 분리도 검토했으나, Phase 1 단독 배포 시 기존 다운스트림에서 "가드 블록이 ci.yml 과 harness-guards.yml 양쪽에서 실행" 되는 상태가 발생해 backward-compat 조건 불만족 → 단일 릴리스로 통합. CLAUDE.md `### 릴리스` "Phase 분리 리듬" 판정 기준 적용
 - **upstream 3중 방어 blindspot 인지** — 다운스트림 실 적용이 최종 가드 (CLAUDE.md 교훈). 본 PR 머지 후 대표 다운스트림 (astro-simulator) 에서 `harness update` 실행 결과를 1차 모니터링 대상. 6c 경로 발동 빈도가 재검토 트리거
+- **추가 수록 PR (행동 변화 없음)**:
+  - [#199](https://github.com/coseo12/harness-setting/issues/199) Phase 3 실행 계획 박제 (PATCH) — Tier 분류 + Phase 3-A (~27k chars 감축 예상) / 3-B 분할. CLAUDE.md 본문 무수정. 실제 추출 실행은 후속 세션의 Phase 3-A PR 에서 수행
+  - [#202](https://github.com/coseo12/harness-setting/issues/202) verify-docs-links 청결성 (PATCH) — 삼항 연산자 무의미 단순화 + leading slash 회귀 가드 테스트. `path.resolve` 전환 제안은 파일 시스템 루트 이탈 버그 유발로 반려 (PR #201 cross-validate 재시도 결과)
+- **drift 보완 경위** — 본 v3.0.0 엔트리는 최초 #196 만 담고 있었으나, v2.31.0 이후 develop 에 누적된 #197/#200 MINOR Behavior Changes 와 #199/#202 PATCH 가 누락된 상태였음. release PR (develop → main) 생성 직전 drift 감지 → CHANGELOG 보강 커밋으로 통합. CLAUDE.md 릴리스 규약 "MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션 필수 포함" 준수
 
 ### Breaking Changes Summary
 


### PR DESCRIPTION
## Summary

v3.0.0 release PR (develop → main) 생성 **직전** drift 감지:
- v2.31.0 이후 develop 에 누적된 5개 PR 중 **#196 (MAJOR) 만** v3.0.0 CHANGELOG 엔트리에 박제돼 있었음
- **#197 / #200 MINOR 의 Behavior Changes 누락** — CLAUDE.md 릴리스 규약 "MINOR/MAJOR 릴리스는 \`### Behavior Changes\` 섹션 필수 포함" 위반
- #199 / #202 PATCH 는 행동 변화 없으나 누락 경위 박제 필요

## 변경 범위
- `CHANGELOG.md` 만 +30 / -2
- 코드 변경 없음

## 변경 세부

### 서두 확장
v3.0.0 엔트리 첫 문단을 "5개 PR 통합 릴리스" 로 재정의 + 포함 범위 5개 bullet 나열

### 신규 섹션 2개 추가
- `### Behavior Changes — #197 CLAUDE.md 비대화 방지 (MINOR, Phase 1)` — 5 bullet
- `### Behavior Changes — #200 CLAUDE.md 각인 예산 강제 (MINOR, Phase 2)` — 5 bullet

(기존 Behavior Changes 섹션은 `### Behavior Changes — #196 \`.github/workflows/\` 책임 분리 (MAJOR)` 로 명시적 제목 부여)

### Notes 보강
- 추가 수록 PR 2건 (#199 설계 박제 PATCH / #202 verify-docs-links 청결성 PATCH) 언급
- drift 보완 경위 투명 박제 (미래 관찰자가 "왜 CHANGELOG 에 이런 보강 커밋이 있었나" 이해 가능하도록)

## 릴리스 분류
**PATCH** — 행동 변화 없음. CHANGELOG 는 문서이고, 보강된 Behavior Changes 항목들의 실제 코드 구현은 이미 develop 에 존재 (이 PR 은 기록만 일치시킴).

## 배경 — drift 발생 메커니즘
v2.31.0 → v3.0.0 사이 각 PR 이 **개별 중간 버전 릴리스 없이** develop 에 누적됐고, #196 PR 이 v3.0.0 chore(release) 를 포함할 때 자신의 Behavior Changes 만 엔트리에 기록. v3.0.0 이 MAJOR 점프라 "다른 MINOR 도 자동 흡수" 의도가 암묵적이었으나 엔트리 자체는 미흡수 상태로 머지됨.

## Test plan
- [x] `grep -rn '�' CHANGELOG.md` — U+FFFD 0건
- [x] `bash scripts/verify-release-version-bump.sh` — package.json 3.0.0 ↔ CHANGELOG 3.0.0 일치
- [x] `bash scripts/verify-docs-links.sh` — CLAUDE.md 상대 링크 9건 유효
- [x] `bash scripts/verify-claudemd-size.sh` — PR warn 유지 (본 PR 은 CLAUDE.md 미수정, 선행 상태)
- [x] diff 검토 — +30 / -2, 섹션 경계 깨짐 없음

## 비목표
- 코드 변경 — 본 PR 은 기록 보완만
- CLAUDE.md 감축 — Phase 3-A 후속 PR 에서
- #199 / #202 PATCH 를 별도 버전 엔트리 (v2.32.x 등) 로 역산 박제 — v3.0.0 통합으로 흡수

## 자체 점검 (CRITICAL DIRECTIVES)
- [x] \`main\` 직접 수정 없음 (base=develop)
- [x] 범위 명시 (CHANGELOG.md 만)
- [x] UI 변경 없음 — 3단계 검증 해당 없음
- [x] U+FFFD 검증 통과
- [x] 파괴적 작업 없음
- [x] 스프린트 계약 — "v3.0.0 엔트리가 포함된 모든 PR 의 Behavior Changes 를 수록한다"

Refs #196 #197 #200

🤖 Generated with [Claude Code](https://claude.com/claude-code)