### PR TITLE
[#213] docs/lessons/ README 목차 + verify-lessons-readme 동기화 가드 (PATCH)

### DIFF
--- a/.github/workflows/harness-guards.yml
+++ b/.github/workflows/harness-guards.yml
@@ -56,3 +56,10 @@ jobs:
       - name: CLAUDE.md 상대 링크 무결성 가드
         if: hashFiles('scripts/verify-docs-links.sh') != ''
         run: bash scripts/verify-docs-links.sh
+
+      # docs/lessons/ README 동기화 가드 (#213)
+      # Phase 3-A 에서 신설된 docs/lessons/ 디렉토리의 목차 README 누락 방지.
+      # 신규 레슨 파일이 README "파일 목록" 표에 등록되지 않으면 exit 1 로 PR 머지 차단.
+      - name: docs/lessons README 동기화 가드
+        if: hashFiles('scripts/verify-lessons-readme.sh') != ''
+        run: bash scripts/verify-lessons-readme.sh

--- a/docs/lessons/README.md
+++ b/docs/lessons/README.md
@@ -1,0 +1,33 @@
+# docs/lessons/ — 실전 교훈 모음
+
+CLAUDE.md `## 실전 교훈` 섹션에서 추출된 상세 문서 디렉토리. CLAUDE.md 본문은 1~3 줄 포인터만 유지하고, 전문은 이 디렉토리의 개별 파일에 박제한다.
+
+## 디렉토리 원칙
+
+- **1 블록 = 1 파일** (kebab-case) — CLAUDE.md `### <제목>` 블록 당 `docs/lessons/<kebab>.md` 한 파일
+- **원본 출처 명시** — 각 파일 상단에 `> **근거**: harness #<PR 번호> Phase 3-X 에서 추출` 라인 필수
+- **볼트 이슈 ↔ 레슨 매핑** — 볼트 knowledge 이슈 (coseo12/volt) 가 본 파일의 근거 체인
+- **신규 파일 추가 시 본 README 동기화 필수** — `scripts/verify-lessons-readme.sh` 가 CI 에서 drift 차단
+
+## 파일 목록
+
+| 파일 | 요지 | 관련 볼트 이슈 |
+|---|---|---|
+| [ci-and-downstream-verification.md](ci-and-downstream-verification.md) | CI 초록 체크 ≠ 테스트 실행 + upstream 3중 방어의 다운스트림 blindspot. `[실측]` / `[가정]` 라벨 규약 + 박제 문턱 공식 | [#48](https://github.com/coseo12/volt/issues/48) / [#60](https://github.com/coseo12/volt/issues/60) |
+| [comment-implementation-drift.md](comment-implementation-drift.md) | 파일 상단 주석이 선언한 계약이 구현에 반영되지 않는 drift 는 default fallback 이 조용히 흡수하는 버그 생성원 | [#49](https://github.com/coseo12/volt/issues/49) |
+| [data-not-code-extension.md](data-not-code-extension.md) | 레이어/플러그인/스키마 구조에서 "데이터만 추가, 코드 변경 0" 을 ADR Concrete Prediction 으로 박제하여 추상화 건강성 실증 | [#47](https://github.com/coseo12/volt/issues/47) |
+| [headless-browser-verification.md](headless-browser-verification.md) | Playwright headless + swiftshader 는 3D/WebGPU 경로에서 부분 freeze false positive. 실 Chrome GUI 수동 검증 필수 | [#33](https://github.com/coseo12/volt/issues/33) |
+| [sub-agent-multiturn-drift.md](sub-agent-multiturn-drift.md) | sub-agent multi-turn 세션에서 세부 매트릭스가 라운드 간 이탈. SendMessage 로 이전 라운드 매트릭스 재첨부 필수 | [#34](https://github.com/coseo12/volt/issues/34) |
+| [workflow-dispatch-pitfalls.md](workflow-dispatch-pitfalls.md) | `workflow_dispatch` 는 default branch 반영 후에만 discover + PR 자동 생성 권한 기본 OFF 2단계 함정 | [#45](https://github.com/coseo12/volt/issues/45) |
+
+## 신규 파일 추가 루틴
+
+1. 새 블록이 CLAUDE.md 에서 추출 대상이 되면 `docs/guides/claudemd-governance.md` §5 가지치기 프로토콜 확인
+2. 파일명은 kebab-case (`<topic>.md`), `## <제목>` / `> **근거**: ...` / `## 근거` 섹션 포함
+3. **본 README 의 "파일 목록" 표에 한 줄 추가** — 파일 / 요지 / 관련 볼트 이슈
+4. `bash scripts/verify-lessons-readme.sh` 로 동기화 확인 후 커밋
+
+## 관련 가이드
+
+- [docs/guides/claudemd-governance.md](../guides/claudemd-governance.md) — CLAUDE.md 비대화 방지 9 섹션 지침 (임계 / 가지치기 / 예외 ADR 등)
+- [docs/plans/phase3-extraction-plan.md](../plans/phase3-extraction-plan.md) — 본 디렉토리를 도입한 Phase 3-A 설계 계획

--- a/scripts/verify-lessons-readme.sh
+++ b/scripts/verify-lessons-readme.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# verify-lessons-readme.sh
+# docs/lessons/*.md (README.md 제외) 전체가 docs/lessons/README.md 의 "파일 목록" 표에 등장하는지 검증.
+# 신규 레슨 파일 추가 시 README 동기화 누락을 구조적으로 차단 (드리프트 방지).
+#
+# 호출 예:
+#   ./scripts/verify-lessons-readme.sh
+#     → 동기화 정합: exit 0
+#     → 누락 (파일 존재 but README 미등록): exit 1, 누락 파일명 stderr 출력
+#
+# 관련 이슈: harness #213 (Phase 3-A 후속, Gemini cross-validate 고유 발견)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# LESSONS_DIR 환경변수로 오버라이드 가능 (테스트 격리용)
+LESSONS_DIR="${LESSONS_DIR:-${PROJECT_DIR}/docs/lessons}"
+README="${LESSONS_DIR}/README.md"
+
+# docs/lessons/ 자체가 없는 다운스트림은 본 가드 대상 외
+if [ ! -d "${LESSONS_DIR}" ]; then
+  echo "ℹ️  ${LESSONS_DIR} 부재 — 본 가드 대상 아님 (skip)"
+  exit 0
+fi
+
+if [ ! -f "${README}" ]; then
+  echo "❌ ${README} 부재 — 디렉토리에 레슨 파일이 있으면 README 가 있어야 한다" >&2
+  exit 1
+fi
+
+missing=()
+# README.md 제외한 모든 .md 파일을 순회
+while IFS= read -r f; do
+  base=$(basename "${f}")
+  [ "${base}" = "README.md" ] && continue
+  # README 내 링크 패턴 `(${base})` 또는 `](${base})` 존재 확인
+  # (상대 경로 기준 — README 와 같은 디렉토리이므로 basename 이 링크 타깃)
+  if ! grep -qF "(${base})" "${README}"; then
+    missing+=("${base}")
+  fi
+done < <(find "${LESSONS_DIR}" -maxdepth 1 -type f -name '*.md' | sort)
+
+if [ ${#missing[@]} -eq 0 ]; then
+  echo "✅ docs/lessons/ README 동기화 정합 (모든 .md 파일이 README 에 등록됨)"
+  exit 0
+fi
+
+cat <<EOF >&2
+❌ docs/lessons/README.md 에 누락된 파일 ${#missing[@]}건:
+EOF
+for m in "${missing[@]}"; do
+  echo "    - ${m}" >&2
+done
+cat <<EOF >&2
+
+수정 안내:
+  1. docs/lessons/README.md "파일 목록" 표에 위 파일들의 행을 추가 (파일 / 요지 / 관련 볼트 이슈)
+  2. 재실행: bash scripts/verify-lessons-readme.sh
+EOF
+exit 1

--- a/test/verify-lessons-readme.test.js
+++ b/test/verify-lessons-readme.test.js
@@ -1,0 +1,111 @@
+// verify-lessons-readme.sh 회귀 테스트 (#213)
+//
+// 검증 항목:
+// - 모든 파일이 README 에 등록된 상태 → exit 0
+// - 신규 파일 추가 but README 미등록 → exit 1 + stderr 누락 목록 출력
+// - README 부재 → exit 1
+// - 디렉토리 부재 → exit 0 (다운스트림 skip)
+// - README 만 있고 다른 .md 없음 → exit 0
+
+const { test } = require('node:test');
+const assert = require('node:assert');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const PROJECT_DIR = path.resolve(__dirname, '..');
+const SCRIPT_PATH = path.join(PROJECT_DIR, 'scripts/verify-lessons-readme.sh');
+
+function setupLessonsDir() {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'harness-lessons-'));
+}
+
+function writeReadme(dir, registeredFiles) {
+  const rows = registeredFiles
+    .map((f) => `| [${f}](${f}) | 요지 | [#1](https://example.com) |`)
+    .join('\n');
+  const content = `# docs/lessons/
+
+## 파일 목록
+
+| 파일 | 요지 | 관련 볼트 이슈 |
+|---|---|---|
+${rows}
+`;
+  fs.writeFileSync(path.join(dir, 'README.md'), content);
+}
+
+function runScript(lessonsDir) {
+  return spawnSync('bash', [SCRIPT_PATH], {
+    cwd: PROJECT_DIR,
+    env: { ...process.env, LESSONS_DIR: lessonsDir },
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+}
+
+test('verify-lessons-readme: 모든 파일 등록 → exit 0', () => {
+  const dir = setupLessonsDir();
+  try {
+    fs.writeFileSync(path.join(dir, 'foo.md'), '# foo');
+    fs.writeFileSync(path.join(dir, 'bar.md'), '# bar');
+    writeReadme(dir, ['foo.md', 'bar.md']);
+    const r = runScript(dir);
+    assert.strictEqual(r.status, 0, `expected exit 0, got ${r.status}\nstderr: ${r.stderr}`);
+    assert.match(r.stdout, /동기화 정합/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('verify-lessons-readme: 신규 파일 미등록 → exit 1', () => {
+  const dir = setupLessonsDir();
+  try {
+    fs.writeFileSync(path.join(dir, 'foo.md'), '# foo');
+    fs.writeFileSync(path.join(dir, 'bar.md'), '# bar');
+    fs.writeFileSync(path.join(dir, 'baz.md'), '# baz');
+    writeReadme(dir, ['foo.md', 'bar.md']); // baz 누락
+    const r = runScript(dir);
+    assert.strictEqual(r.status, 1);
+    assert.ok(r.stderr.includes('baz.md'), `stderr 에 누락 파일 포함 기대. 실제: ${r.stderr}`);
+    assert.ok(!r.stderr.includes('foo.md'), '등록된 파일은 stderr 에 없어야 함');
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('verify-lessons-readme: README 부재 → exit 1', () => {
+  const dir = setupLessonsDir();
+  try {
+    fs.writeFileSync(path.join(dir, 'foo.md'), '# foo');
+    const r = runScript(dir);
+    assert.strictEqual(r.status, 1);
+    assert.ok(r.stderr.includes('README.md 부재'), `stderr: ${r.stderr}`);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('verify-lessons-readme: 디렉토리 부재 → exit 0 (skip)', () => {
+  const dir = setupLessonsDir();
+  const nonexistent = path.join(dir, 'nope');
+  try {
+    const r = runScript(nonexistent);
+    assert.strictEqual(r.status, 0);
+    assert.match(r.stdout, /부재.*skip/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('verify-lessons-readme: README 만 있고 다른 .md 없음 → exit 0', () => {
+  const dir = setupLessonsDir();
+  try {
+    writeReadme(dir, []);
+    const r = runScript(dir);
+    assert.strictEqual(r.status, 0);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
PR #212 Phase 3-A cross-validate 에서 Gemini 가 제안한 고유 발견 (cross-validate 프로토콜 §9 후속 분리) 반영. `docs/lessons/` 디렉토리 목차 README + 동기화 검증 가드 구조적 도입.

## 변경
- `docs/lessons/README.md` 신규 — 6 파일 목차 (제목 / 요지 / 관련 볼트 이슈)
- `scripts/verify-lessons-readme.sh` 신규 — 모든 `.md` 파일이 README "파일 목록" 표에 등장하는지 검증 (drift 차단)
- `.github/workflows/harness-guards.yml` — 신규 가드 step 통합 (`hashFiles('scripts/verify-lessons-readme.sh') != ''` 조건으로 다운스트림 safe)
- `test/verify-lessons-readme.test.js` 신규 — 5 시나리오 검증

## 완료 기준 (#213 DoD)
- [x] `docs/lessons/README.md` 작성 — 파일별 제목 + 1줄 요지 + 볼트 이슈
- [x] 신규 파일 추가 시 README 동기화 규약 — `scripts/verify-lessons-readme.sh` 로 구조적 강제
- [x] 릴리스 분류: **PATCH** (문서 보강 + 구조적 가드, 에이전트 행동 변화 없음)

## Test plan
- [x] `node --test test/verify-lessons-readme.test.js` → 5/5 pass
- [x] `npm test` → 90/90 pass (신규 5 포함)
- [x] `bash scripts/verify-lessons-readme.sh` → 동기화 정합
- [x] `bash scripts/verify-claudemd-size.sh` / `verify-docs-links.sh` / `verify-agent-ssot.sh` → 모두 pass
- [x] U+FFFD 검증 통과

## 릴리스 분류
**PATCH** — 문서 보강 + 구조적 가드 추가. 에이전트가 다르게 동작하지 않음 (drift 자동 차단).

## 자체 점검 (CRITICAL DIRECTIVES)
- [x] `main` 직접 수정 없음 (base=develop)
- [x] 범위 명시 (DoD 기반)
- [x] UI 변경 없음
- [x] U+FFFD 검증 통과
- [x] 파괴적 작업 없음

Closes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)