### PR TITLE
[#203] verify-docs-links 엣지케이스 + 상수 SSoT + locale 독립성 (PATCH)

### DIFF
--- a/docs/guides/claudemd-governance.md
+++ b/docs/guides/claudemd-governance.md
@@ -63,31 +63,35 @@
 
 ---
 
-## 3. 정량 게이트 (char 단위, 한글 UTF-8 보정)
+## 3. 정량 게이트 (char 단위, Unicode code point)
 
 | 임계 | 동작 | 도구 |
 |---|---|---|
 | **35k chars** | 경계 경보 | `harness doctor` warn |
 | **40k chars** | PR 체크 warn | `verify-claudemd-size.sh` (신규 인라인 블록 금지 안내) |
-| **45k chars** | CI fail | `verify-claudemd-size.sh` in `detect-and-test` |
+| **45k chars** | CI fail | `verify-claudemd-size.sh` in `harness-guards` |
+
+> **SSoT (#203)**: 위 임계값은 [`lib/claudemd-size-constants.js`](../../lib/claudemd-size-constants.js) 에서 단일 선언되며 `lib/verify-claudemd-size.js` / `lib/doctor.js` 가 이를 import 한다. 변경 시 SSoT 1곳만 수정하면 모든 가드가 자동 동기화.
 
 ### 3.1 절대불변 아님 (Gemini 제안 4)
 위 수치는 **현재 Claude Code 내부 경고(40k)와 본 저장소의 실측 기반(42.6k)** 을 근거로 설정한 실용적 경계이다.
 
 - 향후 에이전트 컨텍스트 크기 / 어텐션 특성 데이터가 축적되면 **재조정 가능**
 - 중요한 것은 임계값이 아니라 **임계를 통한 검토·제어 시스템** 그 자체
-- 재조정 시 본 가이드 + 검사 스크립트를 동일 PR 에서 갱신
+- 재조정 시 `lib/claudemd-size-constants.js` 한 곳만 수정 + 본 가이드 표 갱신 (동일 PR)
 
 ### 3.2 char 카운트 방법
-한글은 UTF-8 3바이트이므로 `wc -c` (바이트) 가 아닌 **문자 수** 기준:
+
+Node 기반 구현 (`lib/verify-claudemd-size.js`) 이 `[...str].length` 로 **Unicode code point 단위** 측정. locale 독립 (#203).
 
 ```bash
-# POSIX 환경
-wc -m CLAUDE.md
-
-# macOS (기본 wc 가 로케일 의존)
-LC_ALL=en_US.UTF-8 wc -m CLAUDE.md
+# 공식 게이트 실행 — locale 영향 없음
+bash scripts/verify-claudemd-size.sh
+# 또는 직접 Node 호출
+node lib/verify-claudemd-size.js
 ```
+
+> **이전 shell 구현의 한계 (#203 해소)**: `LC_ALL=en_US.UTF-8 wc -m` 은 self-hosted runner 에서 해당 locale 미설치 시 POSIX 로 폴백 → 바이트 수 (한글 62% 부풀림, 실측: 70,500 vs 실제 43,305) 오탐 유발. Node 포트로 완전 해소.
 
 ---
 

--- a/lib/claudemd-size-constants.js
+++ b/lib/claudemd-size-constants.js
@@ -1,0 +1,18 @@
+'use strict';
+
+// CLAUDE.md 각인 예산 정량 게이트 임계값 SSoT (#203).
+//
+// 과거에는 verify-claudemd-size.sh / lib/doctor.js / docs/guides/claudemd-governance.md §3
+// 세 위치에 독립 하드코딩되어 drift 위험. 본 모듈로 단일 선언 + 참조 통일.
+//
+// 지침: docs/guides/claudemd-governance.md §3 (정량 게이트)
+// 참조: harness #197 Phase 2 (가드 도입) + #203 (SSoT 추출)
+
+module.exports = {
+  // 경계 경보 — 가지치기 후보 탐색 권장 (exit 0 + stdout)
+  WARN_BOUNDARY: 35000,
+  // PR warn — 신규 인라인 블록 금지 안내 (exit 0 + stdout)
+  WARN_PR: 40000,
+  // fail — CI 머지 차단 (exit 1 + stderr)
+  FAIL_THRESHOLD: 45000,
+};

--- a/lib/doctor.js
+++ b/lib/doctor.js
@@ -134,12 +134,11 @@ function runDoctor(cwd = process.cwd()) {
   // 1b. CLAUDE.md 각인 예산 (#197 Phase 2)
   // 지침: docs/guides/claudemd-governance.md §3 정량 게이트 (35k/40k/45k)
   // 각인층은 매 세션 전량 어텐션 대상 — 크기가 커질수록 규칙의 상대적 비중 희석
+  // 임계값 SSoT: lib/claudemd-size-constants.js (#203)
   if (critical.content) {
     // 문자 수 (UTF-8 char 단위) — 한글 보정
     const charCount = [...critical.content].length;
-    const WARN_BOUNDARY = 35000;
-    const WARN_PR = 40000;
-    const FAIL_THRESHOLD = 45000;
+    const { WARN_BOUNDARY, WARN_PR, FAIL_THRESHOLD } = require('./claudemd-size-constants');
     let status, detail;
     if (charCount >= FAIL_THRESHOLD) {
       status = 'fail';

--- a/lib/verify-claudemd-size.js
+++ b/lib/verify-claudemd-size.js
@@ -1,0 +1,96 @@
+#!/usr/bin/env node
+'use strict';
+
+// CLAUDE.md 의 char 수 (Unicode code point 단위) 를 측정해 "각인 예산" 게이트를 강제한다.
+//
+// 3단 게이트:
+//   - 35k 미만            : pass (조용)
+//   - 35k ~ 40k           : 경계 경보 (stdout, exit 0)
+//   - 40k ~ 45k           : PR warn (신규 인라인 블록 금지 안내, exit 0)
+//   - 45k 이상            : fail (stderr + 가지치기 안내, exit 1)
+//
+// 본 파일은 기존 shell 스크립트 (scripts/verify-claudemd-size.sh) 를 Node 포트 한 구현.
+// 포트 근거 (#203):
+//   - `LC_ALL=en_US.UTF-8 wc -m` 가 self-hosted runner 에서 locale 미설치 시 POSIX 로 폴백 →
+//     바이트 수 (62% 부풀림, 실측: 70,500 vs 43,305) 로 오탐 발생
+//   - JS 의 `[...str].length` 는 Unicode code point 를 세며 locale 영향 없음 → 이식성 확보
+//   - 임계값 SSoT 연동 (lib/claudemd-size-constants.js) — 이전에는 shell 기본값 / doctor.js /
+//     가이드 문서 3곳에 독립 하드코딩되던 drift 위험 제거
+//
+// 환경변수 override (기존 shell 인터페이스와 호환):
+//   CLAUDEMD_FILE                     : 검사 대상 파일 (기본 PROJECT_ROOT/CLAUDE.md)
+//   CLAUDEMD_SIZE_LIMIT_WARN_BOUNDARY : 경계 경보 임계 (기본 SSoT WARN_BOUNDARY)
+//   CLAUDEMD_SIZE_LIMIT_WARN_PR       : PR warn 임계 (기본 SSoT WARN_PR)
+//   CLAUDEMD_SIZE_LIMIT_FAIL          : fail 임계 (기본 SSoT FAIL_THRESHOLD)
+
+const fs = require('node:fs');
+const path = require('node:path');
+
+const {
+  WARN_BOUNDARY: SSOT_WARN_BOUNDARY,
+  WARN_PR: SSOT_WARN_PR,
+  FAIL_THRESHOLD: SSOT_FAIL_THRESHOLD,
+} = require('./claudemd-size-constants');
+
+const PROJECT_ROOT = path.resolve(__dirname, '..');
+const CLAUDEMD_FILE = process.env.CLAUDEMD_FILE || path.join(PROJECT_ROOT, 'CLAUDE.md');
+
+function parsePositiveInt(value, fallback) {
+  if (value === undefined || value === null || value === '') return fallback;
+  const n = Number(value);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) {
+    console.error(`verify-claudemd-size: 잘못된 임계값 (양의 정수 기대): '${value}'`);
+    process.exit(1);
+  }
+  return n;
+}
+
+const WARN_BOUNDARY = parsePositiveInt(
+  process.env.CLAUDEMD_SIZE_LIMIT_WARN_BOUNDARY,
+  SSOT_WARN_BOUNDARY
+);
+const WARN_PR = parsePositiveInt(process.env.CLAUDEMD_SIZE_LIMIT_WARN_PR, SSOT_WARN_PR);
+const FAIL_THRESHOLD = parsePositiveInt(
+  process.env.CLAUDEMD_SIZE_LIMIT_FAIL,
+  SSOT_FAIL_THRESHOLD
+);
+
+if (!fs.existsSync(CLAUDEMD_FILE)) {
+  console.error(`verify-claudemd-size: 파일 없음: ${CLAUDEMD_FILE}`);
+  process.exit(1);
+}
+
+const content = fs.readFileSync(CLAUDEMD_FILE, 'utf8');
+// Unicode code point 단위 (한글 포함 locale-independent) — [...str] 은 surrogate pair 결합
+const charCount = [...content].length;
+
+if (charCount >= FAIL_THRESHOLD) {
+  console.error('❌ CLAUDE.md 각인 예산 초과');
+  console.error(`   현재: ${charCount} chars (fail 임계 ${FAIL_THRESHOLD})`);
+  console.error('');
+  console.error('   올바른 대응: 예외 박제가 아니라 기존 블록 가지치기');
+  console.error(
+    '   - 상위 섹션 bytes 측정: awk \'/^## /{if(n)print c"\\t"n; n=$0; c=0; next} {c+=length($0)+1} END{if(n)print c"\\t"n}\' CLAUDE.md | sort -rn'
+  );
+  console.error('   - 추출 기준: 매트릭스 3행+ / 코드 5라인+ / 프로토콜 3스텝+ / 근거 2+');
+  console.error('   - 상세: docs/guides/claudemd-governance.md §5 (가지치기 프로토콜)');
+  process.exit(1);
+}
+
+if (charCount >= WARN_PR) {
+  console.log('⚠️  CLAUDE.md 각인 예산 PR warn');
+  console.log(`   현재: ${charCount} chars (PR warn ${WARN_PR} / fail ${FAIL_THRESHOLD})`);
+  console.log('   신규 인라인 블록 금지 — 추가 규약은 docs/ 로 추출 후 포인터 1~3 줄만');
+  console.log('   상세: docs/guides/claudemd-governance.md §3');
+  process.exit(0);
+}
+
+if (charCount >= WARN_BOUNDARY) {
+  console.log('🟡 CLAUDE.md 각인 예산 경계 경보');
+  console.log(`   현재: ${charCount} chars (경계 ${WARN_BOUNDARY} / PR warn ${WARN_PR})`);
+  console.log('   가지치기 후보 탐색 권장 — 6개월 미수정 + 매트릭스/코드 블록 보유 섹션 우선');
+  process.exit(0);
+}
+
+console.log(`✅ CLAUDE.md 각인 예산 정상 (${charCount} / ${WARN_BOUNDARY} chars)`);
+process.exit(0);

--- a/lib/verify-docs-links.js
+++ b/lib/verify-docs-links.js
@@ -5,16 +5,19 @@
 // 비대화 방지 지침에 따라 추출이 많아질수록 link rot 위험 증가 — 본 스크립트로 구조적 방어.
 //
 // 검증 범위:
-//   - 코드펜스 (```...```) 블록 내부 스킵
+//   - 코드펜스 (```...``` / ~~~...~~~) 블록 내부 스킵 (#203)
+//   - 4-space 들여쓰기 코드블록 스킵 (#203)
+//   - HTML 주석 (<!-- ... -->) 내부 스킵 (#203)
 //   - 인라인 코드 (`...`) 내부 스킵 (placeholder 표기로 간주)
 //   - 외부 URL (http*, //, mailto:, ftp:, data:) 스킵
 //   - 앵커 전용 링크 (#section) 스킵
 //   - 파일#anchor 링크는 파일 부분만 존재 확인
+//   - reference-style 링크 정의 (`[ref]: path`) 도 검증 대상 (#203)
 //
 // 환경변수:
 //   CLAUDEMD_FILE : 검사 대상 파일 (기본 PROJECT_ROOT/CLAUDE.md)
 //
-// 근거: harness #197 Phase 2, docs/guides/claudemd-governance.md §4.3
+// 근거: harness #197 Phase 2 + #203 엣지케이스 확장, docs/guides/claudemd-governance.md §4.3
 
 const fs = require('node:fs');
 const path = require('node:path');
@@ -27,30 +30,74 @@ if (!fs.existsSync(TARGET_FILE)) {
   process.exit(1);
 }
 
-const content = fs.readFileSync(TARGET_FILE, 'utf8');
+let content = fs.readFileSync(TARGET_FILE, 'utf8');
+
+// HTML 주석 (<!-- ... -->) 제거 — multi-line 안전. 주석 내부 링크는 placeholder 이므로 검증 대상 아님.
+content = content.replace(/<!--[\s\S]*?-->/g, '');
+
 const lines = content.split('\n');
 
-// 마크다운 링크 매처 — `[text](url)` 의 url 부분 추출
-const LINK_PATTERN = /\]\(([^)]+)\)/g;
+// 인라인 마크다운 링크 매처 — `[text](url)` 의 url 부분 추출
+const INLINE_LINK_PATTERN = /\]\(([^)]+)\)/g;
+// reference-style 링크 정의 매처 — 라인 시작의 `[ref]: url "title"?` 형태
+// `  [ref]:` 같은 들여쓰기 정의도 허용 (최대 3 space, CommonMark)
+const REF_DEF_PATTERN = /^ {0,3}\[([^\]]+)\]:\s*(\S+)/;
 // 외부 URL 프리픽스
 const EXTERNAL_PREFIXES = [/^https?:\/\//, /^\/\//, /^mailto:/, /^ftp:/, /^data:/];
 
 let inFence = false;
+let fenceMarker = null; // '```' 또는 '~~~' — 열린 펜스와 동일 마커여야 닫힘
 const extracted = [];
 
+function looksLikeIndentedCodeBlock(line) {
+  // 4-space 또는 tab 으로 시작 + 리스트 마커 아님.
+  // markdown 규약: 4+ space 들여쓰기는 코드블록 (단, 리스트 내부는 아님).
+  // 간단한 휴리스틱 — 정확도는 낮지만 link rot 감지 목적에 충분.
+  if (!/^( {4,}|\t)/.test(line)) return false;
+  const trimmed = line.replace(/^( {4,}|\t+)/, '');
+  // `- item` / `* item` / `+ item` / `1. item` 형태는 리스트 continuation 가능성 → 코드 취급 안 함
+  if (/^[-*+]\s/.test(trimmed)) return false;
+  if (/^\d+[.)]\s/.test(trimmed)) return false;
+  return true;
+}
+
 for (const line of lines) {
-  if (line.startsWith('```')) {
-    inFence = !inFence;
+  // fenced code block 감지 — ``` 또는 ~~~ (최소 3개 연속, CommonMark)
+  const fenceMatch = line.match(/^(\s*)(`{3,}|~{3,})/);
+  if (fenceMatch) {
+    const marker = fenceMatch[2][0]; // '`' 또는 '~'
+    if (!inFence) {
+      inFence = true;
+      fenceMarker = marker;
+    } else if (marker === fenceMarker) {
+      inFence = false;
+      fenceMarker = null;
+    }
     continue;
   }
   if (inFence) continue;
 
+  // 4-space 들여쓰기 코드블록 — 링크 검증 대상 아님
+  if (looksLikeIndentedCodeBlock(line)) continue;
+
   // 인라인 코드 (단일 백틱 쌍) 제거 — 내부 예시 링크 표기 (예: `[foo](경로)`) 는 실제 링크 아님
   const stripped = line.replace(/`[^`]*`/g, '');
 
+  // reference-style 정의 라인 처리 — `[ref]: url` 형태의 url 부분 수집
+  const refMatch = stripped.match(REF_DEF_PATTERN);
+  if (refMatch) {
+    const url = refMatch[2].trim();
+    if (url && !url.startsWith('#') && !EXTERNAL_PREFIXES.some((re) => re.test(url))) {
+      extracted.push(url);
+    }
+    // 같은 라인에 인라인 링크가 섞인 경우는 거의 없으므로 continue (안전)
+    continue;
+  }
+
+  // 인라인 `[text](url)` 링크 수집
   let match;
-  LINK_PATTERN.lastIndex = 0;
-  while ((match = LINK_PATTERN.exec(stripped)) !== null) {
+  INLINE_LINK_PATTERN.lastIndex = 0;
+  while ((match = INLINE_LINK_PATTERN.exec(stripped)) !== null) {
     const url = match[1].trim();
     if (!url) continue;
     if (url.startsWith('#')) continue;

--- a/scripts/verify-claudemd-size.sh
+++ b/scripts/verify-claudemd-size.sh
@@ -1,22 +1,25 @@
 #!/usr/bin/env bash
 # verify-claudemd-size.sh
-# CLAUDE.md 의 char 수 (UTF-8 문자 단위) 를 측정하여 "각인 예산" 게이트를 강제한다.
+# CLAUDE.md 의 char 수를 측정하여 "각인 예산" 게이트를 강제한다.
+#
+# 본 스크립트는 #203 에서 Node 포트 (`lib/verify-claudemd-size.js`) 로 이동했고,
+# 호환성 유지를 위해 thin wrapper 로 잔존. shell 호출 인터페이스 + 환경변수 override 는 동일.
+#
+# 포트 근거 (#203):
+#   - `LC_ALL=en_US.UTF-8 wc -m` 가 self-hosted runner 에서 locale 미설치 시 POSIX 로 폴백 →
+#     바이트 수 (62% 부풀림, 실측: 70,500 vs 43,305) 로 오탐 발생
+#   - JS 의 `[...str].length` 는 locale 영향 없이 Unicode code point 단위 측정
+#   - 임계값 SSoT 추출 (lib/claudemd-size-constants.js) — shell / doctor.js / 가이드 문서
+#     3곳 drift 위험 제거
+#
 # 3단 게이트:
-#   - 35k 미만          : pass (조용)
-#   - 35k ~ 40k         : 경계 경보 (stdout 경보, exit 0)
-#   - 40k ~ 45k         : PR warn (신규 인라인 블록 금지 안내, exit 0)
-#   - 45k 이상          : fail (stderr + 가지치기 안내, exit 1)
+#   - 35k 미만    : pass (조용)
+#   - 35k ~ 40k   : 경계 경보 (stdout, exit 0)
+#   - 40k ~ 45k   : PR warn (exit 0)
+#   - 45k 이상    : fail (stderr, exit 1)
 #
-# 근거: harness #197 Phase 1 지침 (docs/guides/claudemd-governance.md §3)
-# CLAUDE.md 는 매 세션 전량 어텐션 대상이라 크기가 커질수록 각 규칙의 상대적 비중이 희석.
-#
-# 호출 예:
-#   bash scripts/verify-claudemd-size.sh
-#     → 통과: exit 0, 경계/경고 상황에서도 exit 0
-#     → 실패: 45k 초과 시 exit 1 + stderr 가이드 링크
-#
-# 환경변수 override (테스트/재조정 용이성):
-#   CLAUDEMD_FILE           : 검사 대상 파일 경로 (기본 $PROJECT_DIR/CLAUDE.md)
+# 환경변수 override (Node 구현이 그대로 인식):
+#   CLAUDEMD_FILE                     : 검사 대상 파일 (기본 PROJECT_ROOT/CLAUDE.md)
 #   CLAUDEMD_SIZE_LIMIT_WARN_BOUNDARY : 경계 경보 임계 (기본 35000)
 #   CLAUDEMD_SIZE_LIMIT_WARN_PR       : PR warn 임계 (기본 40000)
 #   CLAUDEMD_SIZE_LIMIT_FAIL          : fail 임계 (기본 45000)
@@ -26,52 +29,4 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 
-CLAUDEMD_FILE="${CLAUDEMD_FILE:-${PROJECT_DIR}/CLAUDE.md}"
-WARN_BOUNDARY="${CLAUDEMD_SIZE_LIMIT_WARN_BOUNDARY:-35000}"
-WARN_PR="${CLAUDEMD_SIZE_LIMIT_WARN_PR:-40000}"
-FAIL_THRESHOLD="${CLAUDEMD_SIZE_LIMIT_FAIL:-45000}"
-
-if [ ! -f "${CLAUDEMD_FILE}" ]; then
-  echo "verify-claudemd-size: 파일 없음: ${CLAUDEMD_FILE}" >&2
-  exit 1
-fi
-
-# 한글 UTF-8 보정 — `wc -c` (바이트) 가 아닌 `wc -m` (문자) 사용.
-# macOS 기본 wc 는 로케일 의존이라 LC_ALL 강제.
-char_count=$(LC_ALL=en_US.UTF-8 wc -m < "${CLAUDEMD_FILE}" | tr -d ' ')
-
-# 숫자 검증 (unexpected output 방어)
-if ! [[ "${char_count}" =~ ^[0-9]+$ ]]; then
-  echo "verify-claudemd-size: char 수 파싱 실패: '${char_count}'" >&2
-  exit 1
-fi
-
-# 정량 게이트 판정
-if [ "${char_count}" -ge "${FAIL_THRESHOLD}" ]; then
-  echo "❌ CLAUDE.md 각인 예산 초과" >&2
-  echo "   현재: ${char_count} chars (fail 임계 ${FAIL_THRESHOLD})" >&2
-  echo "" >&2
-  echo "   올바른 대응: 예외 박제가 아니라 기존 블록 가지치기" >&2
-  echo "   - 상위 섹션 bytes 측정: awk '/^## /{if(n)print c\"\\t\"n; n=\$0; c=0; next} {c+=length(\$0)+1} END{if(n)print c\"\\t\"n}' CLAUDE.md | sort -rn" >&2
-  echo "   - 추출 기준: 매트릭스 3행+ / 코드 5라인+ / 프로토콜 3스텝+ / 근거 2+" >&2
-  echo "   - 상세: docs/guides/claudemd-governance.md §5 (가지치기 프로토콜)" >&2
-  exit 1
-fi
-
-if [ "${char_count}" -ge "${WARN_PR}" ]; then
-  echo "⚠️  CLAUDE.md 각인 예산 PR warn"
-  echo "   현재: ${char_count} chars (PR warn ${WARN_PR} / fail ${FAIL_THRESHOLD})"
-  echo "   신규 인라인 블록 금지 — 추가 규약은 docs/ 로 추출 후 포인터 1~3 줄만"
-  echo "   상세: docs/guides/claudemd-governance.md §3"
-  exit 0
-fi
-
-if [ "${char_count}" -ge "${WARN_BOUNDARY}" ]; then
-  echo "🟡 CLAUDE.md 각인 예산 경계 경보"
-  echo "   현재: ${char_count} chars (경계 ${WARN_BOUNDARY} / PR warn ${WARN_PR})"
-  echo "   가지치기 후보 탐색 권장 — 6개월 미수정 + 매트릭스/코드 블록 보유 섹션 우선"
-  exit 0
-fi
-
-echo "✅ CLAUDE.md 각인 예산 정상 (${char_count} / ${WARN_BOUNDARY} chars)"
-exit 0
+exec node "${PROJECT_DIR}/lib/verify-claudemd-size.js" "$@"

--- a/test/verify-claudemd-size.test.js
+++ b/test/verify-claudemd-size.test.js
@@ -100,3 +100,56 @@ test('파일 없음 → exit 1', () => {
   assert.equal(result.code, 1);
   assert.match(result.stderr, /파일 없음/);
 });
+
+// ---- #203 locale 독립성 / SSoT 회귀 가드 ----
+
+test('한글 UTF-8 문자가 code point 단위로 측정 (byte 수 아님, #203)', () => {
+  // 한글 1 글자는 UTF-8 에서 3 bytes. "가" × 20000 = code point 20000 / byte 60000
+  // PR warn 임계(40000) 를 code point 로는 안 넘어야 정상, byte 로 세면 넘는다
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claudemd-size-unicode-'));
+  const file = path.join(dir, 'CLAUDE.md');
+  fs.writeFileSync(file, '가'.repeat(20000));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    // code point 20000 → 35k 미만 → 정상 pass
+    assert.match(result.stdout, /정상/);
+    assert.doesNotMatch(result.stdout, /PR warn/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('LC_ALL=POSIX 환경에서도 code point 수 정확 (self-hosted 오차 62% 재발 차단, #203)', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claudemd-size-posix-'));
+  const file = path.join(dir, 'CLAUDE.md');
+  fs.writeFileSync(file, '한'.repeat(10000));
+  try {
+    const result = run(file, { LC_ALL: 'POSIX', LANG: 'POSIX' });
+    // code point 10000 이어야 하며, byte 수 30000 으로 세지 않아야 한다
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /10000/);
+    assert.doesNotMatch(result.stdout, /30000/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('기본 임계값이 lib/claudemd-size-constants.js SSoT 와 일치 (#203)', () => {
+  const ssot = require('../lib/claudemd-size-constants');
+  assert.equal(ssot.WARN_BOUNDARY, 35000, 'SSoT WARN_BOUNDARY 가 35000 이어야 함');
+  assert.equal(ssot.WARN_PR, 40000, 'SSoT WARN_PR 가 40000 이어야 함');
+  assert.equal(ssot.FAIL_THRESHOLD, 45000, 'SSoT FAIL_THRESHOLD 가 45000 이어야 함');
+
+  // 스크립트가 실제로 SSoT 기본값을 사용하는지 — 34999 chars 파일은 pass (경계 미만)
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'claudemd-size-ssot-'));
+  const file = path.join(dir, 'CLAUDE.md');
+  fs.writeFileSync(file, 'a'.repeat(ssot.WARN_BOUNDARY - 1));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /정상/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/test/verify-docs-links.test.js
+++ b/test/verify-docs-links.test.js
@@ -174,3 +174,109 @@ test('leading slash 링크도 프로젝트 루트 기준으로 해석', () => {
     fs.rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// ---- #203 엣지케이스 추가 ----
+
+test('tilde 펜스 (~~~) 내부 링크는 스킵', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '~~~markdown',
+    '예시: [ghost](docs/this-file-does-not-exist.md)',
+    '~~~',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /0건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('HTML 주석 내부 링크는 스킵 (multi-line)', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '<!-- 주석 안의 placeholder: [ghost](docs/nonexistent.md) -->',
+    '실제 링크: [real](CLAUDE.md)',
+    '<!--',
+    '여러 줄',
+    '[also-ghost](docs/also-missing.md)',
+    '-->',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /1건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('4-space 들여쓰기 코드블록은 스킵', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '일반 링크: [real](CLAUDE.md)',
+    '',
+    '    예시: [ghost](docs/indented-block-missing.md)',
+    '    또다른: [ghost2](docs/also-missing.md)',
+    '',
+    '본문 복귀.',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /1건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('reference-style 링크 정의도 검증 대상 (깨진 ref → exit 1)', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '본문에서 [text][real-ref] + [other][ghost-ref] 참조.',
+    '',
+    '[real-ref]: CLAUDE.md',
+    '[ghost-ref]: docs/nonexistent-ref.md',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 1);
+    assert.match(result.stderr, /docs\/nonexistent-ref\.md/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('reference-style 링크 정의 (유효) 는 검증 통과', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '본문 [text][ref1] + [other][ref2].',
+    '',
+    '[ref1]: CLAUDE.md',
+    '[ref2]: scripts/verify-agent-ssot.sh',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /2건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('외부 URL 의 reference-style 정의는 스킵', () => {
+  const { dir, file } = makeTempClaudeMd([
+    '# 테스트',
+    '[github][gh-ref] 참조.',
+    '',
+    '[gh-ref]: https://github.com/coseo12/harness-setting',
+  ].join('\n'));
+  try {
+    const result = run(file);
+    assert.equal(result.code, 0);
+    assert.match(result.stdout, /0건/);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

#203 의 3개 독립 sub-goal 을 통합 PATCH 릴리스 (옵션 A). 모두 기존 동작 유지 + 엣지케이스/버그 해소.

## 3 Parts

### Part 1 — verify-docs-links.js 엣지케이스
- **tilde 펜스 (`~~~`) 내부 스킵** — 기존 ``` 만 인식하던 한계 해소
- **HTML 주석 (`<!-- ... -->`) 내부 스킵** — multi-line 안전 (content 레벨에서 일괄 제거)
- **4-space 들여쓰기 코드블록 스킵** — 리스트 continuation 휴리스틱으로 false positive 방어
- **reference-style 링크 정의 (`[ref]: path`) 검증 대상 포함** — 기존 인라인 `[text](url)` 만 잡던 한계
- **dead branch 정리** 는 PR #205 에서 선행 완료 (현재 코드에 `path.isAbsolute` 분기 없음 재확인)

### Part 2 — 정량 게이트 상수 SSoT 추출
- `lib/claudemd-size-constants.js` 신설 — `{WARN_BOUNDARY: 35000, WARN_PR: 40000, FAIL_THRESHOLD: 45000}` 단일 선언
- `lib/doctor.js` / `lib/verify-claudemd-size.js` 가 import 하여 하드코딩 제거
- `docs/guides/claudemd-governance.md §3` SSoT 위치 명시 + 재조정 절차 단순화

### Part 3 — verify-claudemd-size.sh locale 독립성
- `lib/verify-claudemd-size.js` 신설 (Node 포트) — `[...str].length` 로 Unicode code point 직접 카운팅
- `scripts/verify-claudemd-size.sh` → Node 호출 thin wrapper (shell 인터페이스 + 환경변수 100% 호환)
- self-hosted runner 에서 `LC_ALL=en_US.UTF-8` 미설치 시 POSIX 폴백으로 **62% 부풀림 오탐** 차단 (실측: 70,500 bytes vs 실제 43,305 chars)

## Test plan

- [x] `node --test test/verify-docs-links.test.js` → 16/16 (신규 6)
- [x] `node --test test/verify-claudemd-size.test.js` → 9/9 (신규 3)
- [x] `node --test test/doctor-claudemd-budget.test.js` → 4/4 (리팩토링 회귀 없음)
- [x] `npm test` → 94/94 pass
- [x] `bash scripts/verify-claudemd-size.sh` → Node 포트로 통과
- [x] `bash scripts/verify-docs-links.sh` / `verify-agent-ssot.sh` / `verify-release-version-bump.sh` 모두 pass
- [x] U+FFFD 검증 통과

## 릴리스 분류

**PATCH** — 모두 기존 동작 유지 + 엣지케이스 추가 탐지 + bug fix (locale). 에이전트 행동 변화 없음.

## 비목표 준수 (#203)

- [x] 현재 동작 중인 경로 수정 없음 (shell 인터페이스 + env 인터페이스 100% 호환)
- [x] 전면 리팩토링 없음 (최소 범위 Node 포트 + SSoT 추출만)

## 자체 점검 (CRITICAL DIRECTIVES)

- [x] `main` 직접 수정 없음 (base=develop)
- [x] 범위 명시 (3 Part 모두 #203 DoD 범위 내)
- [x] UI 변경 없음
- [x] U+FFFD 검증 통과
- [x] 파괴적 작업 없음 (기존 파일은 이관/축소, 삭제 없음)

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)