### PR TITLE
Release v3.1.2 — #184 sub-agent 런타임 variance 검증 (PATCH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,35 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [3.1.2] — 2026-04-23
+
+v3.1.1 이후 누적된 **단일 PR PATCH 릴리스**. 행동 변화 없음 (도구 + ADR 추가, 에이전트 파일 미수정).
+
+**포함 범위**:
+
+- [#184](https://github.com/coseo12/harness-setting/issues/184) — sub-agent 반환 JSON SSoT 런타임 variance 검증 (PATCH + ADR) — PR [#220](https://github.com/coseo12/harness-setting/pull/220)
+
+### Behavior Changes: None — 도구 + ADR 추가
+
+신규 `lib/verify-agent-return.js` / `scripts/verify-agent-return.sh` 는 메인 오케스트레이터 opt-in 호출 도구이며 에이전트 파일(`.claude/agents/*.md`)은 미수정. hook 자동화 없음 → 에이전트가 같은 입력에 다르게 동작하지 않음. 본 섹션 명시는 CLAUDE.md `### 릴리스` 규약 (PATCH 도 frozen 변경 시 `### Behavior Changes` 명시) 준수.
+
+### 내부 변경 요약
+
+**#184 (PR #220)** — 정적 `verify-agent-ssot.sh` 의 blindspot (sub-agent 런타임 반환 variance) 해소
+- `docs/decisions/20260422-subagent-runtime-variance-defense.md` 신규 — ADR 박제 (후보 A/B/C/D 비교, 채택 A: 메인 post-parse 헬퍼)
+- `lib/verify-agent-return.js` 신규 — 9 코어 필드 존재 + 타입 + enum 검증. `--json` / `--file` / `--stdin` 3 입력 모드
+- `scripts/verify-agent-return.sh` 신규 — Node 호출 thin wrapper (shell 호환)
+- `test/verify-agent-return.test.js` 신규 — 16 테스트 (3 variance 패턴 실측 재현: #167/#178 필드 누락, #170 null 이탈)
+
+### Notes
+
+- volt [#57](https://github.com/coseo12/volt/issues/57) "3회 박제 규약" 발동 근거 실측 — #167 / #170 / #178 3건에서 정적 45/45 pass + 런타임 variance 병존 관찰
+- 후보 B (jq schema) 는 ADR 20260420 (jq NO-OP) 와 상충하여 기각 — ADR 간 일관성 유지
+- 후보 C (LLM 자가 체크) 는 variance 원인 = 검증 주체의 논리적 약점으로 기각
+- 후보 D (3층 방어) 는 본 범위 외 — ADR "미래 확장 여지" 에 명시
+
+---
+
 ## [3.1.1] — 2026-04-22
 
 v3.1.0 이후 누적된 **2개 PR 통합 PATCH 릴리스**. 행동 변화 없음 (문서 + 가드 강화).

--- a/docs/decisions/20260422-subagent-runtime-variance-defense.md
+++ b/docs/decisions/20260422-subagent-runtime-variance-defense.md
@@ -1,0 +1,98 @@
+# ADR: sub-agent 반환 JSON 런타임 variance 방어 — 메인 오케스트레이터 post-parse 가드 채택
+
+- 날짜: 2026-04-22
+- 상태: Accepted
+- 관련 이슈/PR: [#184](https://github.com/coseo12/harness-setting/issues/184), v3.1.x PR (본 ADR)
+- 선행 가드: `scripts/verify-agent-ssot.sh` (v2.23.0 #145 / v2.26.0 9필드 확장) — 정적 파일 drift 가드
+
+## 배경
+
+`scripts/verify-agent-ssot.sh` 는 `.claude/agents/*.md` 의 `## 마무리 체크리스트 JSON 반환` 섹션이 9개 코어 필드를 선언 순서대로 포함하는지 **정적 검증**한다. 그러나 **sub-agent 가 런타임에 실제로 반환하는 JSON** 이 9필드를 준수한다는 보장은 없다. 2026-04-20 한 세션에서만 3회 관찰된 실측:
+
+| PR | 릴리스 | variance 패턴 |
+|---|---|---|
+| [#167](https://github.com/coseo12/harness-setting/pull/167) | v2.27.0 | 신규 2필드 (`spawned_bg_pids` / `bg_process_handoff`) 자체 누락 |
+| [#170](https://github.com/coseo12/harness-setting/pull/170) | v2.28.0 | `null` / `null` — 규약 합치지만 파일 기본값 (`[]` / `"none"`) 과 이탈 |
+| [#178](https://github.com/coseo12/harness-setting/pull/178) | v2.29.0 | 신규 2필드 자체 누락 (#167 패턴 재현) |
+
+정적 가드 45/45 통과 + 런타임 variance — **정적 검증의 blindspot**. volt #57 "3회 이상 관찰 시 박제" 발동.
+
+## 후보 비교
+
+| 후보 | 내용 | 장점 | 단점 | 판정 |
+|---|---|---|---|---|
+| **A** — 메인 post-parse 헬퍼 | Agent tool 반환 직후 메인이 JSON 파싱 후 9필드 존재/타입/enum 검증 | 즉시 구현, 메인이 어차피 JSON 을 커밋 SHA / PR URL 추출 위해 파싱함 | sub-agent 프로세스 수정 아닌 사후 점검 | **Accepted** |
+| B — jq schema + 헬퍼 스크립트 | `.claude/agents/schema/*.json` + `scripts/verify-agent-return-schema.sh` | 엄격한 타입·enum·required 검증 | **[ADR 20260420-jq-based-parsing-no-op](20260420-jq-based-parsing-no-op.md) 와 상충** — jq 의존성 재도입 | 기각 |
+| C — 에이전트 프롬프트 자가 체크 | 각 에이전트 파일에 "JSON 반환 전 9필드 자가 체크" 단계 추가 | 인프라 불필요, 자연어로 해결 | **variance 의 원인이 LLM → self-check 도 같은 variance 에 노출**. 논리적 약점 | 기각 |
+| D — A+B+C 3층 방어 | 3층 직교 방어 | 최고 robustness | 구현 비용 3배, jq NO-OP 상충 잔존 | 본 스프린트 범위 외 (필요 시 후속 이슈) |
+
+## 결정
+
+**후보 A 채택**. 근거:
+
+1. **메인이 이미 JSON 파싱** — 커밋 SHA / PR URL / auto-close 상태 추출을 위해. 9필드 검증 추가 비용 미미
+2. **ADR 20260420 정합성 유지** — jq 도입 회피, grep/sed/Node 파이프라인 연속성
+3. **후보 C 의 논리적 약점 배제** — variance 원인 (LLM) 이 self-check 검증 주체와 동일하면 방어 효율 불확실
+4. **즉시 가치 전달** — 실측 3회 variance 가 PATCH 수준 도구 1개로 재발 차단
+
+## 구현 개요
+
+### 도구
+- `lib/verify-agent-return.js` — JSON 문자열 또는 파일 입력 받아 9필드 + 타입 + enum 검증. 결과 stderr 리포팅 + exit code
+- `scripts/verify-agent-return.sh` — Node 호출 thin wrapper (shell 호출 호환)
+
+### 9 코어 필드 검증 규약 (SSoT: CLAUDE.md `### sub-agent 검증 완료 ≠ GitHub 박제 완료` → Phase 3-A 에서 `docs/lessons/` 로 이동 가능성 있음. 현 유효 선언 위치는 CLAUDE.md 동일 블록)
+
+| # | 필드 | 타입 | 허용 값 / 검증 |
+|---|---|---|---|
+| 1 | `commit_sha` | string\|null | SHA-ish (7+ hex) 또는 null |
+| 2 | `pr_url` | string\|null | GitHub PR URL 또는 null |
+| 3 | `pr_comment_url` | string\|null | URL 형식 또는 null |
+| 4 | `labels_applied_or_transitioned` | array | stage:* 등 label 문자열 배열 (빈 배열 허용) |
+| 5 | `auto_close_issue_states` | object | `{#N: "CLOSED"\|"OPEN"}` 맵 (빈 객체 허용) |
+| 6 | `blocking_issues` | array | 문자열 배열 |
+| 7 | `non_blocking_suggestions` | array | 문자열 배열 |
+| 8 | `spawned_bg_pids` | array | 정수 배열 (빈 배열 허용) |
+| 9 | `bg_process_handoff` | string | enum: `"main-cleanup"` / `"sub-agent-confirmed-done"` / `"none"` |
+
+### variance 패턴 3가지 모두 커버
+1. **필드 누락** → 해당 필드 stderr 에 명시 + exit 1
+2. **`null` 과 기본값 이탈** (array 에 `null` 등) → 타입 검증 실패 + exit 1
+3. **값 타입 불일치** (string 에 number 등) → exit 1
+
+### 에이전트 프로세스 vs 메인 책임
+- **에이전트 (sub-agent)**: 기존 `## 마무리 체크리스트 JSON 반환` 섹션 유지. 자가 체크 추가하지 않음 (후보 C 기각 이유)
+- **메인 오케스트레이터**: sub-agent 반환 직후 본 도구 호출 → variance 감지 시 경고 출력 + 누락 필드 **수동 보완 박제** (자동 재호출 금지 — reviewer/qa 는 커밋/코멘트 idempotent 하지 않음)
+
+### auto-recall 비목표 명시
+variance 감지 시 sub-agent 자동 재호출 **금지**. 이유:
+- reviewer 가 PR 코멘트를 생성하고 반환값에서 2필드 누락 시 재호출하면 코멘트 중복 박제
+- qa 도 동일 (QA 증거 코멘트 중복)
+- 메인이 **경고만 받고 수동 보완** (커밋 추가 / 코멘트 추가) 이 현실적 운영
+
+## 결과·재검토 조건
+
+### 즉시 기대
+- 3 variance 패턴 중 1건이라도 재관찰 시 본 도구로 탐지 + stderr 리포트
+- 기존 정적 가드 (`verify-agent-ssot.sh`) 역할 분리 — 파일 drift vs 런타임 반환
+
+### 재검토 조건
+다음 중 1건 이상 충족 시 본 ADR 재평가 + Amendment 박제:
+- A 가 variance 탐지를 3회 이상 놓침 (B 또는 D 필요성)
+- 메인 오케스트레이터가 도구 호출을 일관되게 수행하지 못함 (hook 자동화 필요 → 별도 infra 이슈)
+- extends 필드의 복잡도가 커져 엄격 schema 필요 (B)
+- jq 의 성능·생태계 여건 변화로 ADR 20260420 재평가
+
+### 미래 확장 여지 (비-범위)
+- **hook 기반 자동 트리거** — Claude Code PostToolUse hook 에 엮어 메인 수동 호출 부담 제거
+- **extends 필드 에이전트별 schema** — architect 의 `cross_validate_outcome`, qa 의 `test_results` 등
+- **감사 모드** — 과거 PR 의 merged sub-agent 반환값 소급 검증 + variance 통계
+
+## 관련
+
+- 원 이슈: [#184](https://github.com/coseo12/harness-setting/issues/184)
+- 정적 가드: [scripts/verify-agent-ssot.sh](../../scripts/verify-agent-ssot.sh), 이슈 [#145](https://github.com/coseo12/harness-setting/issues/145)
+- 선행 ADR: [20260420-jq-based-parsing-no-op.md](20260420-jq-based-parsing-no-op.md) (B 기각 근거)
+- 관련 아키텍처: [docs/architecture/state-atomicity-3-layer-defense.md](../architecture/state-atomicity-3-layer-defense.md) §6 "해석자가 자동화 주체일 때 4번째 자동 매핑 층"
+- 관찰 PR: [#167](https://github.com/coseo12/harness-setting/pull/167), [#170](https://github.com/coseo12/harness-setting/pull/170), [#178](https://github.com/coseo12/harness-setting/pull/178)
+- 선행 volt: [#24](https://github.com/coseo12/volt/issues/24) (sub-agent 신뢰 한계) / [#55](https://github.com/coseo12/volt/issues/55) (Claude 편향) / [#57](https://github.com/coseo12/volt/issues/57) (3회 박제 규약)

--- a/lib/verify-agent-return.js
+++ b/lib/verify-agent-return.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+'use strict';
+
+// sub-agent 반환 JSON 의 9 코어 필드 런타임 검증 (#184).
+//
+// 정적 가드 `scripts/verify-agent-ssot.sh` 는 에이전트 파일(.claude/agents/*.md) 의
+// JSON 블록 drift 만 잡고, sub-agent 가 실제 반환하는 JSON 의 variance 는 놓친다.
+// 본 도구는 메인 오케스트레이터가 Agent tool 반환 직후 호출하여 variance 탐지.
+//
+// 3 variance 패턴 모두 커버:
+//   1. 필드 누락 (object 에 key 자체 없음)
+//   2. `null` 과 기본값 이탈 (array 에 null 등) — 타입 검증에서 걸림
+//   3. 값 타입 불일치 (string 에 number 등)
+//
+// 호출:
+//   node lib/verify-agent-return.js --json '<JSON 문자열>'
+//   node lib/verify-agent-return.js --file path/to/return.json
+//   cat return.json | node lib/verify-agent-return.js --stdin
+//
+// Exit code:
+//   0 — 9필드 + 타입 정합
+//   1 — variance 감지 (stderr 에 누락/불일치 목록)
+//   2 — 입력 오류 (JSON 파싱 실패 / 파일 없음)
+//
+// 근거: harness #184, ADR docs/decisions/20260422-subagent-runtime-variance-defense.md
+
+const fs = require('node:fs');
+
+// 9 코어 필드 스펙 (CLAUDE.md SSoT 와 동기화).
+// 수정 시 반드시 에이전트 파일 `## 마무리 체크리스트 JSON 반환` 섹션 + ADR 표와 동반 갱신.
+const CORE_FIELDS = [
+  { name: 'commit_sha', check: isStringOrNull },
+  { name: 'pr_url', check: isStringOrNull },
+  { name: 'pr_comment_url', check: isStringOrNull },
+  { name: 'labels_applied_or_transitioned', check: isStringArray },
+  { name: 'auto_close_issue_states', check: isStringValueObject },
+  { name: 'blocking_issues', check: isStringArray },
+  { name: 'non_blocking_suggestions', check: isStringArray },
+  { name: 'spawned_bg_pids', check: isIntegerArray },
+  {
+    name: 'bg_process_handoff',
+    check: (v) => typeof v === 'string' && ['main-cleanup', 'sub-agent-confirmed-done', 'none'].includes(v),
+    hint: 'enum: "main-cleanup" | "sub-agent-confirmed-done" | "none"',
+  },
+];
+
+function isStringOrNull(v) {
+  return v === null || typeof v === 'string';
+}
+function isStringArray(v) {
+  return Array.isArray(v) && v.every((x) => typeof x === 'string');
+}
+function isIntegerArray(v) {
+  return Array.isArray(v) && v.every((x) => Number.isInteger(x));
+}
+function isStringValueObject(v) {
+  if (v === null || typeof v !== 'object' || Array.isArray(v)) return false;
+  return Object.values(v).every((x) => typeof x === 'string');
+}
+
+function parseArgs(argv) {
+  const args = { mode: null, value: null };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === '--json') {
+      args.mode = 'json';
+      args.value = argv[++i];
+    } else if (a === '--file') {
+      args.mode = 'file';
+      args.value = argv[++i];
+    } else if (a === '--stdin') {
+      args.mode = 'stdin';
+    } else if (a === '-h' || a === '--help') {
+      printUsage();
+      process.exit(0);
+    }
+  }
+  return args;
+}
+
+function printUsage() {
+  console.log('Usage:');
+  console.log('  node lib/verify-agent-return.js --json \'{"commit_sha":"abc1234",...}\'');
+  console.log('  node lib/verify-agent-return.js --file path/to/return.json');
+  console.log('  cat return.json | node lib/verify-agent-return.js --stdin');
+}
+
+function readStdin() {
+  return fs.readFileSync(0, 'utf8');
+}
+
+function loadInput(args) {
+  if (args.mode === 'json') return args.value;
+  if (args.mode === 'file') {
+    if (!fs.existsSync(args.value)) {
+      console.error(`verify-agent-return: 파일 없음: ${args.value}`);
+      process.exit(2);
+    }
+    return fs.readFileSync(args.value, 'utf8');
+  }
+  if (args.mode === 'stdin') return readStdin();
+  console.error('verify-agent-return: 입력 모드 필요 (--json / --file / --stdin)');
+  printUsage();
+  process.exit(2);
+}
+
+function validate(obj) {
+  const missing = [];
+  const typeErrors = [];
+  if (obj === null || typeof obj !== 'object' || Array.isArray(obj)) {
+    return { missing: [], typeErrors: [{ field: '(root)', reason: 'object 여야 함', actualType: Array.isArray(obj) ? 'array' : typeof obj }] };
+  }
+  for (const spec of CORE_FIELDS) {
+    if (!Object.prototype.hasOwnProperty.call(obj, spec.name)) {
+      missing.push(spec.name);
+      continue;
+    }
+    const value = obj[spec.name];
+    if (!spec.check(value)) {
+      typeErrors.push({
+        field: spec.name,
+        actualType: value === null ? 'null' : Array.isArray(value) ? 'array' : typeof value,
+        hint: spec.hint,
+      });
+    }
+  }
+  return { missing, typeErrors };
+}
+
+function report(result) {
+  const { missing, typeErrors } = result;
+  if (missing.length === 0 && typeErrors.length === 0) {
+    console.log('✅ sub-agent 반환 JSON 정합 (9 코어 필드 + 타입 준수)');
+    return 0;
+  }
+  console.error('❌ sub-agent 반환 JSON variance 감지');
+  if (missing.length > 0) {
+    console.error(`\n필드 누락 ${missing.length}건:`);
+    for (const f of missing) console.error(`   - ${f}`);
+  }
+  if (typeErrors.length > 0) {
+    console.error(`\n타입/값 불일치 ${typeErrors.length}건:`);
+    for (const e of typeErrors) {
+      const hint = e.hint ? ` (기대: ${e.hint})` : '';
+      console.error(`   - ${e.field}: 실제 타입 '${e.actualType}'${hint}`);
+    }
+  }
+  console.error('\n대응:');
+  console.error('   1. 메인 오케스트레이터가 누락 필드를 수동 보완 박제 (커밋/코멘트)');
+  console.error('   2. sub-agent 재호출은 idempotent 보장 안 되므로 금지 (reviewer/qa 중복 박제 위험)');
+  console.error('   3. 반복 관찰 시 ADR docs/decisions/20260422-subagent-runtime-variance-defense.md 재검토 조건 확인');
+  return 1;
+}
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const raw = loadInput(args);
+  let obj;
+  try {
+    obj = JSON.parse(raw);
+  } catch (err) {
+    console.error(`verify-agent-return: JSON 파싱 실패: ${err.message}`);
+    process.exit(2);
+  }
+  const result = validate(obj);
+  process.exit(report(result));
+}
+
+// 테스트에서 재사용 가능하도록 export
+if (require.main === module) {
+  main();
+} else {
+  module.exports = { validate, CORE_FIELDS };
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"

--- a/scripts/verify-agent-return.sh
+++ b/scripts/verify-agent-return.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# verify-agent-return.sh
+# sub-agent 반환 JSON 의 9 코어 필드 런타임 검증 (#184) — Node 포트의 thin wrapper.
+#
+# 정적 가드 `scripts/verify-agent-ssot.sh` 는 에이전트 파일 drift 만 감지한다.
+# 본 도구는 **런타임 반환값** variance (필드 누락 / null 기본값 이탈 / 타입 불일치) 를 감지.
+#
+# 호출:
+#   bash scripts/verify-agent-return.sh --json '<JSON>'
+#   bash scripts/verify-agent-return.sh --file path/to/return.json
+#   echo '<JSON>' | bash scripts/verify-agent-return.sh --stdin
+#
+# Exit: 0 정합 / 1 variance / 2 입력 오류.
+#
+# 근거: ADR docs/decisions/20260422-subagent-runtime-variance-defense.md
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+exec node "${PROJECT_DIR}/lib/verify-agent-return.js" "$@"

--- a/test/verify-agent-return.test.js
+++ b/test/verify-agent-return.test.js
@@ -1,0 +1,177 @@
+// verify-agent-return.js 회귀 테스트 (#184)
+//
+// 3 variance 패턴 커버 (ADR docs/decisions/20260422-subagent-runtime-variance-defense.md):
+//   1. 필드 누락 — #167 / #178 실측 재현 (spawned_bg_pids / bg_process_handoff 자체 부재)
+//   2. null 과 기본값 이탈 — #170 실측 재현 (array 필드에 null)
+//   3. 값 타입 불일치 — string 에 number 등
+//
+// 추가 검증:
+//   - 정상 9필드 JSON → exit 0
+//   - JSON 파싱 실패 → exit 2
+//   - 파일 입력 / stdin 입력 동등성
+
+'use strict';
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const os = require('node:os');
+
+const PROJECT_DIR = path.resolve(__dirname, '..');
+const SCRIPT = path.join(PROJECT_DIR, 'lib/verify-agent-return.js');
+
+const VALID = {
+  commit_sha: 'abc1234',
+  pr_url: 'https://github.com/coseo12/harness-setting/pull/1',
+  pr_comment_url: null,
+  labels_applied_or_transitioned: ['stage:qa'],
+  auto_close_issue_states: { '#118': 'CLOSED' },
+  blocking_issues: [],
+  non_blocking_suggestions: [],
+  spawned_bg_pids: [85117],
+  bg_process_handoff: 'main-cleanup',
+};
+
+function run(args, stdin) {
+  return spawnSync('node', [SCRIPT, ...args], {
+    cwd: PROJECT_DIR,
+    input: stdin,
+    encoding: 'utf8',
+    timeout: 30_000,
+  });
+}
+
+function runJson(obj) {
+  return run(['--json', JSON.stringify(obj)]);
+}
+
+test('정상 9필드 JSON → exit 0', () => {
+  const r = runJson(VALID);
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  assert.match(r.stdout, /정합/);
+});
+
+test('variance 1 — 필드 누락 (#167 / #178 재현)', () => {
+  const obj = { ...VALID };
+  delete obj.spawned_bg_pids;
+  delete obj.bg_process_handoff;
+  const r = runJson(obj);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /필드 누락 2건/);
+  assert.match(r.stderr, /spawned_bg_pids/);
+  assert.match(r.stderr, /bg_process_handoff/);
+});
+
+test('variance 2 — null 과 기본값 이탈 (#170 재현)', () => {
+  // spawned_bg_pids 는 array 기본값 [], bg_process_handoff 는 enum 기본값 "none"
+  // null 은 규약 위반 (array/enum 필드에 null 허용 안 함)
+  const obj = { ...VALID, spawned_bg_pids: null, bg_process_handoff: null };
+  const r = runJson(obj);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /타입\/값 불일치/);
+  assert.match(r.stderr, /spawned_bg_pids/);
+  assert.match(r.stderr, /bg_process_handoff/);
+});
+
+test('variance 3 — 값 타입 불일치 (string 에 number)', () => {
+  const obj = { ...VALID, commit_sha: 12345 };
+  const r = runJson(obj);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /commit_sha/);
+  assert.match(r.stderr, /'number'/);
+});
+
+test('bg_process_handoff enum 이탈', () => {
+  const obj = { ...VALID, bg_process_handoff: 'invalid-value' };
+  const r = runJson(obj);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /bg_process_handoff/);
+  assert.match(r.stderr, /enum/);
+});
+
+test('labels_applied_or_transitioned 에 non-string 혼입', () => {
+  const obj = { ...VALID, labels_applied_or_transitioned: ['stage:qa', 42] };
+  const r = runJson(obj);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /labels_applied_or_transitioned/);
+});
+
+test('auto_close_issue_states 에 non-string 값', () => {
+  const obj = { ...VALID, auto_close_issue_states: { '#1': 'CLOSED', '#2': 123 } };
+  const r = runJson(obj);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /auto_close_issue_states/);
+});
+
+test('spawned_bg_pids 에 non-integer', () => {
+  const obj = { ...VALID, spawned_bg_pids: [1.5, 2] };
+  const r = runJson(obj);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /spawned_bg_pids/);
+});
+
+test('빈 배열 / 빈 객체 허용 (pr_comment_url null 포함)', () => {
+  const r = runJson({
+    commit_sha: null,
+    pr_url: null,
+    pr_comment_url: null,
+    labels_applied_or_transitioned: [],
+    auto_close_issue_states: {},
+    blocking_issues: [],
+    non_blocking_suggestions: [],
+    spawned_bg_pids: [],
+    bg_process_handoff: 'none',
+  });
+  assert.equal(r.status, 0);
+});
+
+test('전체 9필드 모두 누락 (root empty object)', () => {
+  const r = runJson({});
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /필드 누락 9건/);
+});
+
+test('root 가 object 가 아닌 경우 (array)', () => {
+  const r = runJson([1, 2, 3]);
+  assert.equal(r.status, 1);
+  assert.match(r.stderr, /\(root\)/);
+});
+
+test('JSON 파싱 실패 → exit 2', () => {
+  const r = run(['--json', 'not-json-at-all{']);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /JSON 파싱 실패/);
+});
+
+test('--stdin 모드 동등성', () => {
+  const r = run(['--stdin'], JSON.stringify(VALID));
+  assert.equal(r.status, 0, `stderr: ${r.stderr}`);
+  assert.match(r.stdout, /정합/);
+});
+
+test('--file 모드 동등성', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'agent-return-'));
+  const file = path.join(tmp, 'return.json');
+  fs.writeFileSync(file, JSON.stringify(VALID));
+  try {
+    const r = run(['--file', file]);
+    assert.equal(r.status, 0);
+    assert.match(r.stdout, /정합/);
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test('--file 파일 없음 → exit 2', () => {
+  const r = run(['--file', '/tmp/does-not-exist-agent-return-xyz.json']);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /파일 없음/);
+});
+
+test('입력 모드 생략 → exit 2 + usage', () => {
+  const r = run([]);
+  assert.equal(r.status, 2);
+  assert.match(r.stderr, /입력 모드 필요/);
+});


### PR DESCRIPTION
## Summary

v3.1.1 → v3.1.2 PATCH 릴리스. **단일 PR 통합** — `#184` (PR #220).

## 포함 범위

- [#184](https://github.com/coseo12/harness-setting/issues/184) — sub-agent 반환 JSON SSoT 런타임 variance 검증 (PATCH + ADR) — PR #220

## 태그 계획

`v3.1.2` — merge 직후 생성

## Behavior Changes: None — 도구 + ADR 추가

신규 `lib/verify-agent-return.js` / `scripts/verify-agent-return.sh` 는 메인 오케스트레이터 opt-in 호출 도구이며 에이전트 파일(`.claude/agents/*.md`)은 미수정. hook 자동화 없음 → 에이전트가 같은 입력에 다르게 동작하지 않음.

## 내부 변경 요약

**#184 (PR #220)** — 정적 `verify-agent-ssot.sh` 의 blindspot (sub-agent 런타임 반환 variance) 해소
- `docs/decisions/20260422-subagent-runtime-variance-defense.md` 신규 — ADR 박제 (후보 A/B/C/D 비교, 채택 A: 메인 post-parse 헬퍼)
- `lib/verify-agent-return.js` 신규 — 9 코어 필드 존재 + 타입 + enum 검증
- `scripts/verify-agent-return.sh` 신규 — Node 호출 thin wrapper
- `test/verify-agent-return.test.js` 신규 — 16 테스트 (3 variance 패턴 실측 재현)

## 검증

- [x] `bash scripts/verify-release-version-bump.sh` → ✅ 3.1.2 정합
- [x] `npm test` → 115/115 pass
- [x] U+FFFD 검증 통과

## 머지 방식 (중요)

**`--merge` (merge commit) 방식으로 머지** — squash 금지. merge commit 이 main tip 에 develop tip 을 직계 조상으로 포함시켜 merge-back PR 이 불필요. 머지 직후 `git push origin main:develop` fast-forward 로 doctor warn 즉시 해소.

## 자체 점검 (CRITICAL DIRECTIVES)

- [x] base=main, head=develop (release PR 예외)
- [x] 범위 명시 (#184 단일)
- [x] 파괴적 작업 없음
- [x] U+FFFD 검증 통과

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)