### PR TITLE
chore(release): v3.2.0 — #190 CI fixture pnpm-workspace (MINOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
-## [Unreleased]
+## [3.2.0] — 2026-04-23
+
+v3.1.2 이후 **단일 PR MINOR 릴리스** — CI 자체 검증 경로 확장. upstream 3중 방어의 다운스트림 blindspot (pnpm workspace + dist-based exports) 을 fixture 로 영속 가드.
+
+**포함 범위**:
+
+- [#190](https://github.com/coseo12/harness-setting/issues/190) — CI fixture: pnpm workspace 스모크 테스트 (MINOR + ADR) — PR [#223](https://github.com/coseo12/harness-setting/pull/223)
 
 ### Behavior Changes
 
@@ -15,13 +21,22 @@
 - **`package.json::files` 누수 가드 영속화 (`test/package-files-no-test-leak.test.js`)** — `test/fixtures/*` 가 실수로 `files` 배열에 포함돼 다운스트림에 publish 되는 것을 유닛 테스트로 차단. Gemini 교차검증에서 "매우 중요한 보안 가드" 로 격상
 - **DX: 루트 `scripts.test:fixture` 추가** — 로컬에서 `npm run test:fixture` 로 fixture 독립 실행 가능 (`cd test/fixtures/pnpm-monorepo && pnpm install --frozen-lockfile && pnpm run --if-present test`)
 
+### 내부 변경 요약
+
+**#190 (PR #223)** — upstream self-coverage 확장
+- `test/fixtures/pnpm-monorepo/` 신규 — `@fixture/lib` (dist-based exports) + `@fixture/app` (`workspace:*` 소비) 최소 구조 13 파일 (`.gitignore` / `package.json` / `pnpm-workspace.yaml` / `pnpm-lock.yaml` / `packages/{lib,app}/*`)
+- `.github/workflows/ci.yml` — 신규 `fixture-smoke-test` job (matrix.fixture 확장 지점 + `package_json_file` 명시로 root `packageManager` 부재 대응)
+- `docs/decisions/20260423-ci-fixture-pnpm-workspace.md` 신규 — ADR 박제 (축 3개 비교)
+- `docs/harness-update-compat-checklist.md` — 체크리스트 1~2 항목 ↔ fixture 양방향 링크
+- `test/ci-fixture-smoke-test.test.js` / `test/package-files-no-test-leak.test.js` 신규 — 유닛 가드 2개 (CI job 선언 정규식 + `files` 누수 blacklist/whitelist 이중 방어)
+- `scripts.test:fixture` DX 스크립트
+
 ### Notes
 
-- 이 Unreleased 섹션은 **MINOR 릴리스 `v3.2.0`** 으로 통합 예정. 버전 bump 와 릴리스 노트 재구성은 별도 release PR 에서 처리
-- 신규 fixture: `test/fixtures/pnpm-monorepo/` — `@fixture/lib` (dist-based exports) + `@fixture/app` (workspace:* 소비) 최소 구조
-- 설계 ADR: [docs/decisions/20260423-ci-fixture-pnpm-workspace.md](docs/decisions/20260423-ci-fixture-pnpm-workspace.md) — 축 3개 (job 구조 β / 최소 fixture / 의도적 red + 유닛 가드) 비교
-- 범위 밖 (후속 이슈): WASM fixture, yarn/bun matrix 확장
-- 근거 이슈: [#190](https://github.com/coseo12/harness-setting/issues/190), 선행 관찰 volt [#62](https://github.com/coseo12/volt/issues/62) / [#64](https://github.com/coseo12/volt/issues/64)
+- regression signature 는 pnpm 9 에서 `--if-present` forwarding 이 재현되지 않아 **dist-based exports 의존 실패** 로 전환 (v2.29.1 의도를 더 정확히 표현). 실패 Actions 링크는 PR #223 에 박제
+- ADR §최종 CI job 구조 블록에 `package_json_file` 각주 추가 (reviewer non-blocking 제안 #1, footnote 로 Amendment 해결)
+- 범위 밖 (후속 이슈): WASM fixture (ADR 위험 #4), yarn/bun matrix 확장 (ADR 재검토 조건 #3)
+- 선행 관찰: volt [#62](https://github.com/coseo12/volt/issues/62) / [#64](https://github.com/coseo12/volt/issues/64)
 
 ---
 

--- a/docs/decisions/20260423-ci-fixture-pnpm-workspace.md
+++ b/docs/decisions/20260423-ci-fixture-pnpm-workspace.md
@@ -111,6 +111,8 @@ fixture-smoke-test:
         pnpm run --if-present test
 ```
 
+> **각주 (Amendment 2026-04-23, v3.2.0 릴리스 반영)**: upstream 루트 `package.json` 에 `packageManager` 필드가 없어 `pnpm/action-setup@v4` 가 자동 감지 실패. 실제 구현 (PR #223) 은 `pnpm/action-setup@v4` step 에 `with: package_json_file: test/fixtures/${{ matrix.fixture }}/package.json` 를 명시해 fixture 내부 `packageManager` 를 참조하게 했다. 위 블록은 원 설계 예시이며, 실제 적용본은 `.github/workflows/ci.yml` 을 기준으로 한다. 설계 결정 축 (β / 최소 fixture / 의도적 red + 유닛 가드) 은 불변.
+
 ### 스프린트 완료 기준 (측정 가능)
 
 - [ ] `test/fixtures/pnpm-monorepo/` 디렉토리 존재 + 최소 7 파일 (`package.json` / `pnpm-workspace.yaml` / `pnpm-lock.yaml` / `packages/lib/{package.json,src/index.ts}` / `packages/app/{package.json,src/index.test.ts}`)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## Summary

v3.2.0 MINOR release 준비 — `CHANGELOG.md` [Unreleased] → [3.2.0] 엔트리 확정 + `package.json` 3.1.2→3.2.0 bump + ADR footnote 추가.

## 포함 범위

- [#190](https://github.com/coseo12/harness-setting/issues/190) — CI fixture: pnpm workspace 스모크 테스트 (MINOR + ADR) — PR #223

## 릴리스 분류

**MINOR** — CI 자체 검증 경로 확장 + 신규 보안 가드 (`files` 누수 테스트) + DX 스크립트 (`test:fixture`). 다운스트림에 직접 영향은 없으나 harness 자체 릴리스 품질 향상으로 `harness update` 회귀 빈도 감소 기대.

## 포함 변경

- `CHANGELOG.md`: [Unreleased] → [3.2.0] — 2026-04-23 확정. `### Behavior Changes` / `### 내부 변경 요약` / `### Notes` 3 섹션
- `package.json::version` 3.1.2 → 3.2.0
- `docs/decisions/20260423-ci-fixture-pnpm-workspace.md`: §최종 CI job 구조 블록에 `package_json_file` 각주 추가 (reviewer non-blocking 제안 #1 — Amendment 를 별도 ADR 없이 footnote 로 해결)

## 검증

- [x] `bash scripts/verify-release-version-bump.sh` → ✅ 3.2.0 정합
- [x] `npm test` → 122/122 pass
- [x] U+FFFD 검증 통과 (CHANGELOG / package.json / ADR 3 파일)

## 자체 점검 (CRITICAL DIRECTIVES)

- [x] base=develop (feature/fix 규약)
- [x] 범위 명시 (#190 단일)
- [x] 파괴적 작업 없음
- [x] U+FFFD 검증 통과

## 다음 단계

머지 후 **develop → main release PR** 생성 (본문에 `Closes #190` 포함, `--merge` 방식 머지 → `git push origin main:develop` → `git tag v3.2.0` + `gh release create`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)