### PR TITLE
Release v3.2.0 — #190 CI fixture pnpm-workspace (MINOR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,3 +257,37 @@ jobs:
       #   - CLAUDE.md 각인 예산 가드
       #   - CLAUDE.md 상대 링크 무결성 가드
       # ============================================================
+
+  # ============================================================
+  # fixture-smoke-test — 다운스트림 pnpm workspace 경로 실측 가드
+  # (issue #190, ADR: docs/decisions/20260423-ci-fixture-pnpm-workspace.md)
+  #
+  # 배경: upstream 저장소는 npm 단일 프로젝트라 detect-and-test 의 pnpm 분기가
+  # 평상시 실행되지 않는다 → v2.28.2 / v2.29.1 부류 regression 이 upstream 에서
+  # 초록, 다운스트림에서만 빨강으로 드러나는 blindspot 발생.
+  # 본 job 은 test/fixtures/pnpm-monorepo 로 pnpm workspace + dist-based exports
+  # 실측 경로를 확보해 PR 머지 전에 차단한다.
+  # matrix.fixture 는 향후 확장 지점 (예: yarn-monorepo, pnpm-wasm-monorepo).
+  # ============================================================
+  fixture-smoke-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        fixture: [pnpm-monorepo]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        # pnpm/action-setup@v4 는 기본적으로 root package.json::packageManager 를 참조하나
+        # upstream 은 npm 프로젝트라 packageManager 필드가 없다. fixture 의 package.json 명시 필수.
+        with:
+          package_json_file: test/fixtures/${{ matrix.fixture }}/package.json
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: test/fixtures/${{ matrix.fixture }}/pnpm-lock.yaml
+      - name: fixture install + test
+        working-directory: test/fixtures/${{ matrix.fixture }}
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm run --if-present test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
+## [Unreleased]
+
+### Behavior Changes
+
+- **CI `fixture-smoke-test` job 추가 (`.github/workflows/ci.yml`)** — pnpm workspace + dist-based exports 경로를 upstream PR 단계에서 실측 검증. v2.28.2 (`pnpm: not found`) / v2.29.1 (`--if-present` forwarding) 부류 regression 이 upstream 에서는 초록이고 다운스트림에서만 빨강으로 드러나던 blindspot 차단. 다운스트림에 직접 영향 없으나, harness 자체 릴리스 품질 향상으로 `harness update` 회귀 빈도 감소 기대
+- **`package.json::files` 누수 가드 영속화 (`test/package-files-no-test-leak.test.js`)** — `test/fixtures/*` 가 실수로 `files` 배열에 포함돼 다운스트림에 publish 되는 것을 유닛 테스트로 차단. Gemini 교차검증에서 "매우 중요한 보안 가드" 로 격상
+- **DX: 루트 `scripts.test:fixture` 추가** — 로컬에서 `npm run test:fixture` 로 fixture 독립 실행 가능 (`cd test/fixtures/pnpm-monorepo && pnpm install --frozen-lockfile && pnpm run --if-present test`)
+
+### Notes
+
+- 이 Unreleased 섹션은 **MINOR 릴리스 `v3.2.0`** 으로 통합 예정. 버전 bump 와 릴리스 노트 재구성은 별도 release PR 에서 처리
+- 신규 fixture: `test/fixtures/pnpm-monorepo/` — `@fixture/lib` (dist-based exports) + `@fixture/app` (workspace:* 소비) 최소 구조
+- 설계 ADR: [docs/decisions/20260423-ci-fixture-pnpm-workspace.md](docs/decisions/20260423-ci-fixture-pnpm-workspace.md) — 축 3개 (job 구조 β / 최소 fixture / 의도적 red + 유닛 가드) 비교
+- 범위 밖 (후속 이슈): WASM fixture, yarn/bun matrix 확장
+- 근거 이슈: [#190](https://github.com/coseo12/harness-setting/issues/190), 선행 관찰 volt [#62](https://github.com/coseo12/volt/issues/62) / [#64](https://github.com/coseo12/volt/issues/64)
+
+---
+
 ## [3.1.2] — 2026-04-23
 
 v3.1.1 이후 누적된 **단일 PR PATCH 릴리스**. 행동 변화 없음 (도구 + ADR 추가, 에이전트 파일 미수정).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
-## [Unreleased]
+## [3.2.0] — 2026-04-23
+
+v3.1.2 이후 **단일 PR MINOR 릴리스** — CI 자체 검증 경로 확장. upstream 3중 방어의 다운스트림 blindspot (pnpm workspace + dist-based exports) 을 fixture 로 영속 가드.
+
+**포함 범위**:
+
+- [#190](https://github.com/coseo12/harness-setting/issues/190) — CI fixture: pnpm workspace 스모크 테스트 (MINOR + ADR) — PR [#223](https://github.com/coseo12/harness-setting/pull/223)
 
 ### Behavior Changes
 
@@ -15,13 +21,22 @@
 - **`package.json::files` 누수 가드 영속화 (`test/package-files-no-test-leak.test.js`)** — `test/fixtures/*` 가 실수로 `files` 배열에 포함돼 다운스트림에 publish 되는 것을 유닛 테스트로 차단. Gemini 교차검증에서 "매우 중요한 보안 가드" 로 격상
 - **DX: 루트 `scripts.test:fixture` 추가** — 로컬에서 `npm run test:fixture` 로 fixture 독립 실행 가능 (`cd test/fixtures/pnpm-monorepo && pnpm install --frozen-lockfile && pnpm run --if-present test`)
 
+### 내부 변경 요약
+
+**#190 (PR #223)** — upstream self-coverage 확장
+- `test/fixtures/pnpm-monorepo/` 신규 — `@fixture/lib` (dist-based exports) + `@fixture/app` (`workspace:*` 소비) 최소 구조 13 파일 (`.gitignore` / `package.json` / `pnpm-workspace.yaml` / `pnpm-lock.yaml` / `packages/{lib,app}/*`)
+- `.github/workflows/ci.yml` — 신규 `fixture-smoke-test` job (matrix.fixture 확장 지점 + `package_json_file` 명시로 root `packageManager` 부재 대응)
+- `docs/decisions/20260423-ci-fixture-pnpm-workspace.md` 신규 — ADR 박제 (축 3개 비교)
+- `docs/harness-update-compat-checklist.md` — 체크리스트 1~2 항목 ↔ fixture 양방향 링크
+- `test/ci-fixture-smoke-test.test.js` / `test/package-files-no-test-leak.test.js` 신규 — 유닛 가드 2개 (CI job 선언 정규식 + `files` 누수 blacklist/whitelist 이중 방어)
+- `scripts.test:fixture` DX 스크립트
+
 ### Notes
 
-- 이 Unreleased 섹션은 **MINOR 릴리스 `v3.2.0`** 으로 통합 예정. 버전 bump 와 릴리스 노트 재구성은 별도 release PR 에서 처리
-- 신규 fixture: `test/fixtures/pnpm-monorepo/` — `@fixture/lib` (dist-based exports) + `@fixture/app` (workspace:* 소비) 최소 구조
-- 설계 ADR: [docs/decisions/20260423-ci-fixture-pnpm-workspace.md](docs/decisions/20260423-ci-fixture-pnpm-workspace.md) — 축 3개 (job 구조 β / 최소 fixture / 의도적 red + 유닛 가드) 비교
-- 범위 밖 (후속 이슈): WASM fixture, yarn/bun matrix 확장
-- 근거 이슈: [#190](https://github.com/coseo12/harness-setting/issues/190), 선행 관찰 volt [#62](https://github.com/coseo12/volt/issues/62) / [#64](https://github.com/coseo12/volt/issues/64)
+- regression signature 는 pnpm 9 에서 `--if-present` forwarding 이 재현되지 않아 **dist-based exports 의존 실패** 로 전환 (v2.29.1 의도를 더 정확히 표현). 실패 Actions 링크는 PR #223 에 박제
+- ADR §최종 CI job 구조 블록에 `package_json_file` 각주 추가 (reviewer non-blocking 제안 #1, footnote 로 Amendment 해결)
+- 범위 밖 (후속 이슈): WASM fixture (ADR 위험 #4), yarn/bun matrix 확장 (ADR 재검토 조건 #3)
+- 선행 관찰: volt [#62](https://github.com/coseo12/volt/issues/62) / [#64](https://github.com/coseo12/volt/issues/64)
 
 ---
 

--- a/docs/decisions/20260423-ci-fixture-pnpm-workspace.md
+++ b/docs/decisions/20260423-ci-fixture-pnpm-workspace.md
@@ -1,0 +1,215 @@
+# ADR: CI fixture `pnpm-monorepo` — 별도 job β + 의도적 regression + 최소 fixture 채택
+
+- 날짜: 2026-04-23
+- 상태: Accepted
+- 관련 이슈/PR: [#190](https://github.com/coseo12/harness-setting/issues/190), 본 PR (설계 단계)
+- 선행 ADR: [20260421-workflows-responsibility-split](20260421-workflows-responsibility-split.md) (`ci.yml` user-only 분류 / `harness-guards.yml` 분리)
+- 스프린트 범위 제외: **WASM 확장 fixture** (이슈 본문 완료 기준 4번) — 후속 이슈로 분리
+
+## 배경
+
+harness-setting 자체는 **npm 단일 프로젝트**. CI `.github/workflows/ci.yml::detect-and-test` 가 pnpm / yarn / Python / Rust 경로를 **선언적으로 포함** 하지만, upstream 저장소의 구조상 해당 경로는 **평상시 실행되지 않음** (lock 파일 부재). 2026-04-20 세션에서 **upstream 에서는 초록, 다운스트림 astro-simulator#270 에서만 실패** 하는 연쇄 버그 3건이 관찰됨:
+
+| 버전 | 버그 | upstream 감지 실패 원인 |
+|---|---|---|
+| v2.28.2 도입 시점 | `sh: 1: pnpm: not found` — pnpm 경로 부재 | upstream 에 `pnpm-lock.yaml` 없음 → pnpm step 건너뜀 |
+| v2.28.2 직후 | `pnpm test --if-present` forwarding → vitest `Unknown option: --if-present` | 동일 — pnpm step 자체가 실행 안 됨 |
+| v2.29.1 이후 | 범용 CI 가 WASM 모노레포 (core → physics-wasm 타입 의존) 처리 불가 | fixture 0건 |
+
+공통 원인: **선언적 CI 경로가 fixture 없이 존재** — 3중 방어 (단위 테스트 / reviewer / cross-validate) 를 모두 통과해도 실측 환경이 없어 blindspot. `docs/lessons/ci-and-downstream-verification.md` 에서 "다운스트림 실측이 최종 가드" 로 일반화된 패턴의 직접 치료 대상.
+
+### 문제 선언
+
+**upstream CI 에 pnpm 경로를 실제로 실행하는 fixture 가 필요** — 최소 구조 (`@fixture/lib` dist-based exports + `@fixture/app` 소비) 로 v2.28.2 / v2.29.1 부류 regression 을 upstream PR 단계에서 차단.
+
+## 후보 비교
+
+축 3개 (CI job 구조 / fixture 유지 전략 / regression 실증 방식) 를 독립적으로 평가. 각 축 채택안 조합이 최종 결정.
+
+### 축 (a) — CI job 구조
+
+| 후보 | 내용 | 장점 | 단점 | 판정 |
+|---|---|---|---|---|
+| α — 단일 job 내 통합 | 기존 `detect-and-test` 에 fixture step 추가 | 구현 최소, 단일 job | (1) fixture 실패가 upstream 자체 테스트와 뒤섞여 원인 분리 어려움 (2) fixture 가 lock 파일 없는 repo 에서 pnpm 호출 → 기존 분기 조건 (`hashFiles('pnpm-lock.yaml') != ''`) 와 충돌 | 기각 |
+| **β — 별도 `fixture-smoke-test` job** | 독립 job 으로 fixture 디렉토리 진입 후 pnpm install + test | (1) 격리 — 실패 로그가 "fixture regression" 으로 즉시 분류 (2) 향후 yarn / bun fixture 추가 시 같은 패턴 확장 (3) 실행 시간 병렬화 | job 하나 추가 (Actions 분 과금 소폭 증가) | **Accepted** |
+| γ — matrix 전략 (pnpm × Node 버전) | `strategy.matrix` 로 다중 실행 | 매트릭스 확장성 | 현 시점 요구 (pnpm 단일 경로) 대비 overkill + 분 과금 N배 증가 | 기각 (후속 확장 여지로만) |
+
+**결정 (a): β — 별도 job.** 이슈 본문 권장안과 일치. 기각된 α 의 근본 문제는 **실패 원인 분류 신호 소실** — fixture 가 upstream repo 테스트와 섞이면 다운스트림 관점 regression 을 "harness 자체 버그" 로 오진할 위험. β 는 job 이름 자체가 진단 신호 (`fixture-smoke-test (pnpm-monorepo)` 실패 = 다운스트림 경로 regression).
+
+### 축 (b) — fixture 유지 전략
+
+| 후보 | 내용 | 장점 | 단점 | 판정 |
+|---|---|---|---|---|
+| **최소 fixture (1개)** | `test/fixtures/pnpm-monorepo/` 만. lib (dist exports) + app 2 패키지 | (1) 유지 비용 최소 (2) 핵심 regression 3건 (`pnpm not found` / `--if-present` forwarding / dist-based exports 의존) 전부 커버 | 넓은 매트릭스 부재 (Node 버전별 / pnpm 버전별) | **Accepted** |
+| 포괄 matrix (N개) | pnpm / yarn berry / yarn classic / npm workspaces × Node LTS 2~3개 | 광범위 coverage | (1) 유지 비용 N배 (pnpm/vitest 업그레이드 시 N개 동기화) (2) fixture 자체 버그 표면적 증가 (3) CI 분 과금 | 기각 |
+
+**결정 (b): 최소 fixture.** 근거:
+- **실측 3건 regression 전부 최소 구조에서 재현** — pnpm workspace + dist-based exports + vitest 가 공통분모. 매트릭스는 추가 커버리지 ≈ 0 대비 비용 N배
+- 이슈 본문 비-범위 선언 ("Node.js pnpm 만 우선, 모든 매니저 매트릭스 금지") 과 일치
+- 매트릭스 확장은 후속 이슈로 분리 (재검토 조건 참조)
+
+### 축 (c) — regression 실증 방식
+
+| 후보 | 내용 | 장점 | 단점 | 판정 |
+|---|---|---|---|---|
+| 의도적 red 커밋만 | 개발 PR 중 의도적 `pnpm test --if-present` 도입 → fixture job red 확인 → revert | 실제 CI 가 실패하는 live 증거 | red 증거가 PR 본문 링크에만 남음 → 미래 회귀 시 재실행 불가 | 기각 (단독으로는) |
+| 유닛 테스트 가드만 | `test/ci-split-migration` 류로 ci.yml 의 fixture-smoke-test job 정의 존재 / script 명령 정규식 가드 | 영속적 / 빠름 | fixture **구조** 만 검증, **실행 자체 정상성** 은 미검증 | 기각 (단독으로는) |
+| **의도적 red 커밋 + 유닛 테스트 가드 (둘 다)** | 개발 시 red 1회 실증 + 유닛 테스트로 fixture 파일 구조 / CI job 선언 영속 가드 | (1) 실행 정상성: red 커밋으로 증명 (2) 구조 영속성: 유닛 테스트로 ci.yml / fixture 디렉토리 drift 차단 (3) 서로의 blindspot 을 커버 | 구현 비용 소폭 증가 (유닛 테스트 1개 추가) | **Accepted** |
+
+**결정 (c): 둘 다.** 이유: 두 방식은 **서로 다른 실패 모드** 를 방어. red 커밋은 "파이프라인 자체가 regression 감지 가능한가" (dynamic), 유닛 테스트는 "ci.yml / fixture 파일이 미래에 조용히 사라지지 않는가" (static). volt [#57](https://github.com/coseo12/volt/issues/57) "3회 이상 관찰 패턴 박제" + volt [#34](https://github.com/coseo12/volt/issues/34) "정적 가드의 blindspot" 의 결합 대응.
+
+## 결정 (종합)
+
+| 축 | 채택 |
+|---|---|
+| (a) CI job 구조 | **옵션 β** — 별도 `fixture-smoke-test` job |
+| (b) fixture 유지 전략 | **최소 fixture** — `test/fixtures/pnpm-monorepo/` 1개 |
+| (c) regression 실증 | **의도적 red 커밋 + 유닛 테스트 가드** 둘 다 |
+
+### 최종 fixture 구조 (developer 인계)
+
+```
+test/fixtures/pnpm-monorepo/
+├── .gitignore                # node_modules / dist (구조도 명시 — Gemini 교차검증 반영)
+├── package.json              # packageManager: "pnpm@X", scripts.test: "pnpm -r build && pnpm -r test"
+├── pnpm-workspace.yaml       # packages: ["packages/*"]
+├── pnpm-lock.yaml            # fixture 전용 lockfile (frozen-lockfile 실행용)
+└── packages/
+    ├── lib/
+    │   ├── package.json      # name: "@fixture/lib", main: "./dist/index.js", exports: { ".": "./dist/index.js" }
+    │   ├── src/index.ts
+    │   ├── tsconfig.json     # outDir: "./dist"
+    │   └── vitest.config.ts  # 간단한 합산 함수 1개 테스트
+    └── app/
+        ├── package.json      # dependencies: { "@fixture/lib": "workspace:*" }, scripts.test: "vitest run"
+        ├── src/index.ts
+        ├── src/index.test.ts # import { fn } from "@fixture/lib" — dist 기반
+        └── vitest.config.ts
+```
+
+### 최종 CI job 구조
+
+```yaml
+# .github/workflows/ci.yml 에 추가 (detect-and-test job 과 별도)
+fixture-smoke-test:
+  runs-on: ubuntu-latest
+  strategy:
+    matrix:
+      fixture: [pnpm-monorepo]  # 향후 확장 지점 (yarn-monorepo 등)
+  steps:
+    - uses: actions/checkout@v4
+    - uses: pnpm/action-setup@v4
+    - uses: actions/setup-node@v4
+      with:
+        node-version: 20
+        cache: 'pnpm'
+        cache-dependency-path: test/fixtures/${{ matrix.fixture }}/pnpm-lock.yaml
+    - name: fixture install + test
+      working-directory: test/fixtures/${{ matrix.fixture }}
+      run: |
+        pnpm install --frozen-lockfile
+        pnpm run --if-present test
+```
+
+### 스프린트 완료 기준 (측정 가능)
+
+- [ ] `test/fixtures/pnpm-monorepo/` 디렉토리 존재 + 최소 7 파일 (`package.json` / `pnpm-workspace.yaml` / `pnpm-lock.yaml` / `packages/lib/{package.json,src/index.ts}` / `packages/app/{package.json,src/index.test.ts}`)
+- [ ] `@fixture/lib` dist-based exports 로 `@fixture/app` 에서 import 가능 — fixture 디렉토리에서 로컬 `pnpm install && pnpm run test` 통과 (developer 검증)
+- [ ] `.github/workflows/ci.yml` 에 신규 `fixture-smoke-test` job 추가 — `pnpm install` + `pnpm run --if-present test` 실행
+- [ ] 의도적 regression 커밋으로 job red 증명 (예: fixture root `scripts.test` 를 `pnpm -r test --if-present` 로 변경 → vitest `Unknown option` 실패 → revert). PR 본문에 실패 Actions 링크 박제
+- [ ] 유닛 테스트 1개 추가 — `test/ci-split-migration/fixture-smoke-test.test.js` (이름 예시). ci.yml 에 `fixture-smoke-test` job 선언 + 최소 fixture 파일 존재 정규식 가드
+- [ ] `docs/harness-update-compat-checklist.md` 체크리스트 1~2 항목 (모노레포 재귀 호출 / dist-based exports) 이 fixture 로 실측 검증됨을 상호 참조 추가 (양방향 링크)
+- [ ] **(필수 보안 가드)** `package.json::files` 에 `test/` 가 포함되지 않음을 실측 확인 + **유닛 테스트 1개 추가** (`package.json::files` 배열에 `test` / `test/` 접두어 문자열 부재 검증). 현재 `bin/`, `lib/`, `.claude/`, `.github/`, `docs/`, `scripts/`, `CLAUDE.md`, `README.md` 만 — fixture 유출 없음. 재발 방지를 위해 자동 테스트로 영속 가드 (Gemini 교차검증 권고 격상)
+- [ ] (DX) 루트 `package.json::scripts` 에 `test:fixture` 추가 (`cd test/fixtures/pnpm-monorepo && pnpm install && pnpm test` 류) — 로컬 개발자가 fixture 단독 실행 가능 (Gemini 교차검증 반영)
+- [ ] CHANGELOG `v3.2.0` 엔트리 추가 — `### Behavior Changes` 섹션 포함 (MINOR 분류 근거 박제)
+
+### 테스트 ROI 5문 체크 (CLAUDE.md 스프린트 계약 §6)
+
+| 질문 | 답변 |
+|---|---|
+| fixture 구축 비용이 검증 대상 코드 라인의 5배 이상? | fixture ~50 라인 / ci.yml ~15 라인 = 보호 대상 **ci.yml 분기 4~5개 (pnpm 경로 전체) + downstream 부합 보장** → ROI 충분 |
+| 몇 줄을 보호하는가? | pnpm step 4개 (setup / install / test 분기) + 하위 7개 축의 부합성 (lock fingerprint 경로 / frozen-lockfile / dist exports 의존). 조용한 퇴행 시 **다운스트림 전체 부서짐** (v2.28.2 사례) |
+| 회귀 시 조용히 퇴행 vs 빌드 실패? | **조용한 퇴행** — fixture 없으면 upstream 은 초록이고 다운스트림만 빨강. 전형적 감지 지연 패턴 → fixture 필수 |
+| 인접 유닛 테스트 / 타입 가드로 간접 보증 가능? | 부분적만 — `test/ci-split-migration/` 류 유닛 테스트는 **파일 존재 / 명령 정규식** 만 가드. **실제 pnpm 실행 여부** 는 실행 환경 없이 검증 불가. 결정 (c) 에서 **둘 다 채택** 으로 해소 |
+| 미래 인프라 구축 후 저렴해지는가? | 반대 — **지금 박제가 최저 비용**. 다운스트림 버그가 1건 더 발생할 때마다 fixture 없이 디버깅하는 비용이 fixture 유지 비용을 수 배 상회 |
+
+결론: **fixture + 의도적 regression + 유닛 가드 3중 박제가 ROI 정당화**. 단, matrix 확장은 ROI 미달 (현 시점).
+
+## 결과·재검토 조건
+
+### 즉시 기대
+
+- v2.28.2 / v2.29.1 부류 regression 이 upstream PR 단계에서 차단 (fixture job red = 머지 차단)
+- `docs/harness-update-compat-checklist.md` 체크 항목 1~2 가 fixture 로 **실측 연결** — 문서와 실행 간 drift 차단
+- 다운스트림 (astro-simulator / 추후 Node.js 모노레포 프로젝트) 에서 upstream 의 pnpm 경로에 대한 신뢰도 증가
+
+### 재검토 조건 (다음 중 1건 이상 충족 시 본 ADR Amendment 또는 후속 ADR)
+
+1. **fixture 유지 비용 정량화 실패** — pnpm / vitest / TypeScript 업그레이드마다 fixture 동기화 비용이 월 3시간 이상 (= 유지 실패 신호. matrix 축소 또는 fixture 자동 생성 도구 검토)
+2. **fixture 자체 버그로 false negative** — regression 발생했는데 fixture 가 초록이었던 사례 관찰 시 즉시 재평가 (축 c 의 유닛 가드 실패 모드)
+3. **다운스트림에 yarn / bun / npm workspaces 프로젝트 출현** — 당시 해당 fixture 추가를 후속 이슈로 분리 (축 b 매트릭스 확장 트리거). 단, **동일 구조 3회 이상 관찰** 기준 적용 (volt #57)
+4. **WASM 후속 이슈 완결** — 이슈 본문 완료 기준 4번 (WASM fixture) 이 별도 이슈로 처리됐는지 확인 후 본 ADR 과 상호 링크
+5. **`ci.yml` 의 pnpm 경로 분기 로직 대규모 변경** — 본 fixture 가 가드하는 대상 코드 자체가 구조 변경되면 fixture 도 동기 재설계 필요
+6. **Actions 분 과금 증가가 허용 기준 초과** — 현재 예상 job 실행 시간 ~2분 (install 90s + test 30s). 5분 초과 지속 시 matrix 축소 / cache 전략 강화 검토
+
+### 비-범위 (후속 이슈 여지)
+
+- **WASM 확장 fixture** — 이슈 본문 완료 기준 4번. 본 ADR 에서 분리. draft 이슈로 분리 검토 (위험 섹션 참조)
+- **matrix 확장 (yarn / bun / npm workspaces)** — 재검토 조건 #3 트리거 시
+- **hook 자동화** — 다운스트림 clone 직후 fixture 동작 검증 스크립트
+- **fixture 자체의 유닛 테스트** — fixture 안의 lib 함수 자체 회귀 테스트 (fixture 안정성 ≠ fixture 검증 대상)
+
+## 위험 / 미해결 항목
+
+### 1. fixture 유지 비용 (정량화 시도)
+
+- pnpm major 업그레이드: 6~12개월에 1회 (최근 pnpm 9 → 10 전환 주기)
+- vitest major: 12~24개월에 1회
+- TypeScript major: 12~24개월에 1회
+- **예상 유지 비용**: 연 1~2회 fixture 업그레이드 (각 30분 ~ 2시간). 허용 범위 내로 판단하나 **재검토 조건 #1** 로 정량 모니터링
+
+### 2. `package.json::files` 누수 가드 (중요)
+
+- 현재 `package.json::files` = `["bin/", "lib/", ".claude/", ".github/", "docs/", "scripts/", "CLAUDE.md", "README.md"]` — `test/` **미포함**. 다운스트림 `harness update` 에 fixture 유출 없음 (확인 완료)
+- developer 구현 시 이 필드를 **절대 수정 금지** (스프린트 비-범위). 유닛 테스트 가드에 `test/` 가 `files` 에 **포함되지 않음** 을 검증하는 항목 추가 권장
+
+### 3. harness 저장소 크기 증가
+
+- 예상 증가: fixture 디렉토리 ~50 KB (소스) + `pnpm-lock.yaml` ~200~500 KB = **최대 550 KB**
+- `node_modules` 는 `.gitignore` 로 제외 (fixture 디렉토리의 `.gitignore` 필요 — developer 단계 체크)
+- 허용 기준: **저장소 tarball 크기 10 MB 미만 유지** (현재 ~2 MB → 2.5 MB 예상). 수용 가능
+
+### 4. WASM fixture 분리 이슈 드래프트
+
+- 제목: "CI fixture: WASM 모노레포 opt-out 검증 fixture 추가"
+- 본문 요약: `test/fixtures/pnpm-wasm-monorepo/` 추가 — `wasm-pack` 미지원을 명시적 skip 경로로 검증 (`docs/harness-update-compat-checklist.md` 옵션 A). WASM 빌드 도구가 CI 에 없을 때 **조용히 skip** 이 정상 동작임을 fixture 로 실측
+- 드래프트 생성 여부: **본 sub-agent 에서 생성 보류** (메인 오케스트레이터 판단 대기). 이슈 #190 comment 에 draft 템플릿 포함 (사용자가 별도 sprint 로 분리할 때 즉시 사용)
+
+### 5. fixture 내 lockfile frozen 운영
+
+- `pnpm install --frozen-lockfile` 이 실패하면 CI red. fixture 의 `package.json` 의존성을 바꾸면 lockfile 도 동기 업데이트 필수
+- developer 체크리스트에 "fixture 의존성 변경 시 lockfile 재생성 + 커밋" 명시
+
+### 교차검증 반영 사항
+
+박제 직후 Gemini 1회 교차검증 수행 (`cross_validate.sh architecture <본 ADR>`). outcome=applied, exit 0. Claude 편향 4종 셀프 체크 통과 (낙관적 일정: 재검토 #1 정량 모니터링 / 결합 간과: 5개 위험 명시 / 폐기 프레이밍: 없음 / 순수주의: 의도적 red + 유닛 가드 실용 결합).
+
+- **합의 (즉시 반영)**:
+  - `.gitignore` 를 최종 fixture 구조도에 명시 (기존 위험 #3 만 언급 → 구조도에도 박제해 구현 누락 차단)
+  - 루트 `package.json::scripts` 에 `test:fixture` 추가 — 로컬 DX 개선 (완료 기준에 추가)
+- **이견 수용 (권고 격상)**:
+  - 원안: "유닛 테스트 가드에 `test/` 가 `files` 에 포함되지 않음 검증 항목 추가 **권장**"
+  - 수정: "**필수 보안 가드**" 로 격상 + 자동 테스트 영속 가드 명시. 근거: 다운스트림 `harness update` 로 fixture 가 유출되면 다운스트림 저장소 크기 급증 + 선언되지 않은 경로 포함 리스크. Gemini "매우 중요한 가드, 실수로라도 발생해서는 안 될 문제" 지적 수용
+- **Claude 재분석으로 기각한 Gemini 제안**:
+  - `CONTRIBUTING.md` 에 lockfile 재생성 규칙 추가 — 현 저장소에 `CONTRIBUTING.md` 부재. 위험 #5 박제 위치 (ADR 본문) 로 충분 + ADR 이 곧 SSoT. 별도 기여 문서 신설은 범위 밖
+- **고유 발견 (후속 분리)**:
+  - 없음 (Gemini 제안 모두 본 ADR 스프린트 범위 내에서 처리 가능)
+
+## 관련
+
+- 원 이슈: [#190](https://github.com/coseo12/harness-setting/issues/190)
+- 상위 원칙 교훈: [docs/lessons/ci-and-downstream-verification.md](../lessons/ci-and-downstream-verification.md) — "다운스트림 실측이 최종 가드"
+- 다운스트림 사전 체크리스트: [docs/harness-update-compat-checklist.md](../harness-update-compat-checklist.md) — 본 fixture 의 쌍둥이 (사전 체크 ↔ 사후 실증)
+- 선행 ADR: [20260421-workflows-responsibility-split](20260421-workflows-responsibility-split.md) — `ci.yml` user-only 분리로 본 fixture job 추가가 upstream 단독 결정 가능
+- 관찰 release: [v2.28.2 ~ v2.29.1](https://github.com/coseo12/harness-setting/releases) — 본 fixture 가 사전 감지했어야 할 연쇄 버그
+- 선행 volt: [#64](https://github.com/coseo12/volt/issues/64) (원안) / [#62](https://github.com/coseo12/volt/issues/62) (체크리스트 쌍둥이) / [#59](https://github.com/coseo12/volt/issues/59) (셀프 위반 실증) / [#60](https://github.com/coseo12/volt/issues/60) (상위 원칙)

--- a/docs/decisions/20260423-ci-fixture-pnpm-workspace.md
+++ b/docs/decisions/20260423-ci-fixture-pnpm-workspace.md
@@ -111,6 +111,8 @@ fixture-smoke-test:
         pnpm run --if-present test
 ```
 
+> **각주 (Amendment 2026-04-23, v3.2.0 릴리스 반영)**: upstream 루트 `package.json` 에 `packageManager` 필드가 없어 `pnpm/action-setup@v4` 가 자동 감지 실패. 실제 구현 (PR #223) 은 `pnpm/action-setup@v4` step 에 `with: package_json_file: test/fixtures/${{ matrix.fixture }}/package.json` 를 명시해 fixture 내부 `packageManager` 를 참조하게 했다. 위 블록은 원 설계 예시이며, 실제 적용본은 `.github/workflows/ci.yml` 을 기준으로 한다. 설계 결정 축 (β / 최소 fixture / 의도적 red + 유닛 가드) 은 불변.
+
 ### 스프린트 완료 기준 (측정 가능)
 
 - [ ] `test/fixtures/pnpm-monorepo/` 디렉토리 존재 + 최소 7 파일 (`package.json` / `pnpm-workspace.yaml` / `pnpm-lock.yaml` / `packages/lib/{package.json,src/index.ts}` / `packages/app/{package.json,src/index.test.ts}`)

--- a/docs/harness-update-compat-checklist.md
+++ b/docs/harness-update-compat-checklist.md
@@ -24,6 +24,8 @@
 
 **Yes** 이면 CI 의 `npm test` / `pnpm test` 호출 시 **모든 workspace 가 빌드·테스트에 참여**. 각 workspace 가 CI 환경에서 정상 동작하는지 개별 확인 필요. 특히 빌드 산출물 의존이 있으면 다음 항목으로.
 
+> **실측 fixture 쌍둥이** — 본 체크 항목은 [`test/fixtures/pnpm-monorepo/`](../test/fixtures/pnpm-monorepo/) 로 upstream CI 에서 실측 검증된다 (issue [#190](https://github.com/coseo12/harness-setting/issues/190), [ADR 20260423-ci-fixture-pnpm-workspace](decisions/20260423-ci-fixture-pnpm-workspace.md)). fixture root `scripts.test` 가 `pnpm -r --filter ./packages/lib run build && pnpm -r run test` 로 재귀 호출 + 빌드 선행을 재현. 다운스트림에서 동일 구조라면 upstream `fixture-smoke-test` job 초록 = 해당 경로가 CI 에서 동작함이 보증.
+
 ### 2. 빌드 산출물 기반 exports 의존
 
 - [ ] 워크스페이스 중 `package.json::exports` / `main` / `module` 이 `dist/...` / `build/...` / `lib/...` 을 가리키는 항목이 있는가?
@@ -31,6 +33,8 @@
 **Yes** 이면 `pnpm install` / `npm ci` 직후 **import 불가 상태**. 빌드 선행 필요 → harness 의 detect-and-test 단순 `install → test` 파이프라인 **부적합**. 선택:
 - 사전 `build` step 추가 (`pnpm -r build && pnpm -r test`) — 다운스트림 전용 ci.yml 수정 필요
 - 또는 `scripts.test` 를 빌드 포함 명령으로 (`pnpm -r build && pnpm -r --stream test`)
+
+> **실측 fixture 쌍둥이** — [`test/fixtures/pnpm-monorepo/packages/lib/`](../test/fixtures/pnpm-monorepo/packages/lib/) 의 `package.json` 이 `main: ./dist/index.js` + `exports["."]` dist 경로를 유지하고, [`packages/app/`](../test/fixtures/pnpm-monorepo/packages/app/) 이 `workspace:*` 로 이를 소비한다. fixture root `scripts.test` 가 lib build 를 선행 실행하여 v2.28.2 / v2.29.1 부류 dist-based exports 의존 regression 을 upstream PR 단계에서 차단. 상세: [ADR 20260423](decisions/20260423-ci-fixture-pnpm-workspace.md).
 
 ### 3. 특수 빌드 도구 의존
 
@@ -77,6 +81,8 @@ harness v2.15.0 → v2.29.1 적용 시 6회 연속 push-fail-fix 루프:
 
 ## 관련
 
+- [`test/fixtures/pnpm-monorepo/`](../test/fixtures/pnpm-monorepo/) — 본 체크리스트 1~2 항목의 **실측 쌍둥이 fixture** (issue [#190](https://github.com/coseo12/harness-setting/issues/190))
+- [ADR 20260423-ci-fixture-pnpm-workspace](decisions/20260423-ci-fixture-pnpm-workspace.md) — fixture 설계 (축 3개 비교)
 - volt [#62](https://github.com/coseo12/volt/issues/62) — 본 체크리스트 원안
 - volt [#64](https://github.com/coseo12/volt/issues/64) — upstream CI 에 pnpm/WASM 스모크 fixture 추가 제안 (별도 실행 이슈)
 - volt [#60](https://github.com/coseo12/volt/issues/60) — "다운스트림 실측이 최종 가드" (본 체크리스트의 상위 원칙)

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "harness": "./bin/harness.js"
   },
   "scripts": {
-    "test": "node --test \"test/**/*.test.js\""
+    "test": "node --test \"test/**/*.test.js\"",
+    "test:fixture": "cd test/fixtures/pnpm-monorepo && pnpm install --frozen-lockfile && pnpm run --if-present test"
   },
   "files": [
     "bin/",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "3.1.2",
+  "version": "3.2.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"

--- a/test/ci-fixture-smoke-test.test.js
+++ b/test/ci-fixture-smoke-test.test.js
@@ -1,0 +1,138 @@
+'use strict';
+
+/**
+ * CI fixture-smoke-test 영속 가드 (issue #190).
+ *
+ * 의도: ADR 20260423-ci-fixture-pnpm-workspace 의 축 (c) — "유닛 테스트 가드" 축.
+ * 의도적 red 커밋 (dynamic 검증) 과 짝을 이루는 static 검증. 두 축은 서로 다른 실패 모드를 방어:
+ *   - dynamic: 파이프라인 자체가 regression 감지 가능한가
+ *   - static (본 테스트): ci.yml / fixture 파일이 미래에 조용히 사라지지 않는가
+ *
+ * 검증 대상:
+ *   1. .github/workflows/ci.yml 에 fixture-smoke-test job 이 선언되어 있다
+ *   2. job 이 pnpm/action-setup + setup-node + frozen-lockfile + --if-present 패턴을 유지한다
+ *   3. test/fixtures/pnpm-monorepo/ 디렉토리의 최소 7 파일이 존재한다
+ *   4. fixture 내 @fixture/lib 는 dist 기반 exports 를 유지한다 (main/exports 필드 형태)
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const ROOT = path.resolve(__dirname, '..');
+const CI_YML = path.join(ROOT, '.github', 'workflows', 'ci.yml');
+const FIXTURE_ROOT = path.join(ROOT, 'test', 'fixtures', 'pnpm-monorepo');
+
+test('ci.yml 에 fixture-smoke-test job 이 선언되어 있다', () => {
+  assert.ok(fs.existsSync(CI_YML), 'ci.yml 존재');
+  const content = fs.readFileSync(CI_YML, 'utf8');
+  // job key 형식: 들여쓰기 2칸 + 'fixture-smoke-test:'
+  assert.match(
+    content,
+    /^ {2}fixture-smoke-test:\s*$/m,
+    'fixture-smoke-test job 선언 존재',
+  );
+});
+
+test('fixture-smoke-test job 이 핵심 step 패턴을 유지한다', () => {
+  const content = fs.readFileSync(CI_YML, 'utf8');
+  // job 블록 추출 — 들여쓰기 2칸 job key 다음 줄부터, 다음 2칸 key (또는 EOF) 까지.
+  // YAML 에서 `jobs:` 하위 job 들은 모두 2칸 들여쓰기이므로 이 경계로 분리.
+  const lines = content.split('\n');
+  const startIdx = lines.findIndex((line) => /^ {2}fixture-smoke-test:\s*$/.test(line));
+  assert.ok(startIdx >= 0, 'fixture-smoke-test job 시작 라인 존재');
+  let endIdx = lines.length;
+  for (let i = startIdx + 1; i < lines.length; i += 1) {
+    // 다음 2칸 들여쓰기 key (단, 주석/빈 줄 제외) 를 발견하면 종료
+    if (/^ {2}[A-Za-z_][\w-]*:\s*(#.*)?$/.test(lines[i])) {
+      endIdx = i;
+      break;
+    }
+  }
+  const block = lines.slice(startIdx, endIdx).join('\n');
+  assert.ok(block.length > 0, 'fixture-smoke-test job 블록 추출 성공');
+
+  // 필수 step 패턴
+  assert.match(block, /pnpm\/action-setup@v\d+/, 'pnpm/action-setup@v4 사용');
+  // pnpm/action-setup 은 upstream 이 npm 프로젝트 (root package.json 에 packageManager 없음)
+  // 이므로 fixture package.json 을 명시적으로 가리켜야 한다. 이 파라미터 누락은 CI 에서
+  // "Error: No pnpm version is specified" 로 즉시 실패 (관찰 완료). 영속 가드 필요.
+  assert.match(
+    block,
+    /package_json_file:\s*test\/fixtures\/\$\{\{\s*matrix\.fixture\s*\}\}\/package\.json/,
+    'pnpm/action-setup 에 package_json_file 명시 (upstream packageManager 부재 보호)',
+  );
+  assert.match(block, /actions\/setup-node@v\d+/, 'actions/setup-node 사용');
+  assert.match(block, /node-version:\s*20/, 'node-version 20 고정');
+  assert.match(block, /cache:\s*['"]pnpm['"]/, 'pnpm cache 활성');
+  assert.match(
+    block,
+    /cache-dependency-path:\s*test\/fixtures\/\$\{\{\s*matrix\.fixture\s*\}\}\/pnpm-lock\.yaml/,
+    'lock 경로 matrix.fixture 치환',
+  );
+  assert.match(block, /pnpm install --frozen-lockfile/, 'frozen-lockfile 설치');
+  // --if-present 는 pnpm 의 플래그로 사용 (script args 앞). `pnpm test --if-present` 는 금지 패턴 (#181)
+  assert.match(
+    block,
+    /pnpm run --if-present test/,
+    'pnpm run --if-present test 패턴 (pnpm 플래그)',
+  );
+  assert.doesNotMatch(
+    block,
+    /pnpm test --if-present/,
+    'pnpm test --if-present 금지 패턴 (v2.28.2 regression 재발 방지)',
+  );
+
+  // matrix.fixture 확장 지점
+  assert.match(block, /matrix:\s*\n\s*fixture:\s*\[/, 'matrix.fixture 선언');
+  assert.match(block, /fixture:\s*\[pnpm-monorepo\]/, 'pnpm-monorepo 포함');
+});
+
+test('test/fixtures/pnpm-monorepo 최소 파일 집합이 존재한다', () => {
+  const required = [
+    '.gitignore',
+    'package.json',
+    'pnpm-workspace.yaml',
+    'pnpm-lock.yaml',
+    'packages/lib/package.json',
+    'packages/lib/src/index.ts',
+    'packages/app/package.json',
+    'packages/app/src/index.test.ts',
+  ];
+  for (const rel of required) {
+    const abs = path.join(FIXTURE_ROOT, rel);
+    assert.ok(fs.existsSync(abs), `fixture 필수 파일 존재: ${rel}`);
+  }
+});
+
+test('@fixture/lib 는 dist-based exports 를 유지한다 (v2.29.1 regression 가드)', () => {
+  const libPkgPath = path.join(FIXTURE_ROOT, 'packages', 'lib', 'package.json');
+  const libPkg = JSON.parse(fs.readFileSync(libPkgPath, 'utf8'));
+
+  assert.strictEqual(
+    libPkg.main,
+    './dist/index.js',
+    'lib.main 이 dist 경로 유지',
+  );
+  assert.ok(libPkg.exports, 'lib.exports 필드 존재');
+  // exports 의 "." 엔트리가 dist 로 향하는지
+  const dotExport = libPkg.exports['.'];
+  const defaultPath =
+    typeof dotExport === 'string' ? dotExport : dotExport?.default;
+  assert.match(
+    defaultPath,
+    /^\.\/dist\//,
+    'exports["."].default 가 dist 경로 유지',
+  );
+});
+
+test('@fixture/app 는 workspace:* 로 @fixture/lib 를 소비한다', () => {
+  const appPkgPath = path.join(FIXTURE_ROOT, 'packages', 'app', 'package.json');
+  const appPkg = JSON.parse(fs.readFileSync(appPkgPath, 'utf8'));
+  assert.strictEqual(
+    appPkg.dependencies?.['@fixture/lib'],
+    'workspace:*',
+    'app 이 @fixture/lib workspace:* 의존',
+  );
+});

--- a/test/fixtures/pnpm-monorepo/.gitignore
+++ b/test/fixtures/pnpm-monorepo/.gitignore
@@ -1,0 +1,5 @@
+# fixture 안에 설치되는 런타임 산출물은 커밋하지 않는다
+# (CI 는 frozen-lockfile 로 매번 재설치, 로컬 개발자도 동일)
+node_modules/
+packages/*/node_modules/
+packages/*/dist/

--- a/test/fixtures/pnpm-monorepo/package.json
+++ b/test/fixtures/pnpm-monorepo/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@fixture/pnpm-monorepo",
+  "version": "0.0.0",
+  "private": true,
+  "description": "harness CI fixture — pnpm workspace + dist-based exports regression guard (issue #190)",
+  "packageManager": "pnpm@9.15.4",
+  "scripts": {
+    "build": "pnpm -r --filter ./packages/lib run build",
+    "test": "pnpm -r --filter ./packages/lib run build && pnpm -r run test"
+  },
+  "engines": {
+    "node": ">=20"
+  }
+}

--- a/test/fixtures/pnpm-monorepo/packages/app/package.json
+++ b/test/fixtures/pnpm-monorepo/packages/app/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@fixture/app",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run"
+  },
+  "dependencies": {
+    "@fixture/lib": "workspace:*"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
+  }
+}

--- a/test/fixtures/pnpm-monorepo/packages/app/src/index.test.ts
+++ b/test/fixtures/pnpm-monorepo/packages/app/src/index.test.ts
@@ -1,0 +1,11 @@
+import { describe, it, expect } from "vitest";
+import { sum } from "@fixture/lib";
+
+describe("@fixture/app — dist-based exports 소비", () => {
+  it("@fixture/lib 의 sum 을 dist 경로로 import 할 수 있다", () => {
+    // 이 테스트의 진짜 의도는 결과값 자체가 아니라,
+    // lib 의 dist/index.js 가 정상 빌드되어 app 이 workspace:* 로 import 할 수 있음을 검증.
+    // v2.28.2 / v2.29.1 부류 regression 이 여기서 실패로 드러난다.
+    expect(sum(2, 3)).toBe(5);
+  });
+});

--- a/test/fixtures/pnpm-monorepo/packages/app/src/index.ts
+++ b/test/fixtures/pnpm-monorepo/packages/app/src/index.ts
@@ -1,0 +1,5 @@
+import { sum } from "@fixture/lib";
+
+export function add(a: number, b: number): number {
+  return sum(a, b);
+}

--- a/test/fixtures/pnpm-monorepo/packages/app/vitest.config.ts
+++ b/test/fixtures/pnpm-monorepo/packages/app/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/test/fixtures/pnpm-monorepo/packages/lib/package.json
+++ b/test/fixtures/pnpm-monorepo/packages/lib/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@fixture/lib",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "vitest": "^2.1.8"
+  }
+}

--- a/test/fixtures/pnpm-monorepo/packages/lib/src/index.test.ts
+++ b/test/fixtures/pnpm-monorepo/packages/lib/src/index.test.ts
@@ -1,0 +1,8 @@
+import { describe, it, expect } from "vitest";
+import { sum } from "./index.js";
+
+describe("@fixture/lib — sum", () => {
+  it("sum(1, 2) === 3", () => {
+    expect(sum(1, 2)).toBe(3);
+  });
+});

--- a/test/fixtures/pnpm-monorepo/packages/lib/src/index.ts
+++ b/test/fixtures/pnpm-monorepo/packages/lib/src/index.ts
@@ -1,0 +1,7 @@
+/**
+ * fixture 용 단순 함수. 실제 로직 정확성이 아니라 dist 산출물이
+ * `@fixture/app` 에서 import 가능한지를 확인하기 위한 최소 공개 API.
+ */
+export function sum(a: number, b: number): number {
+  return a + b;
+}

--- a/test/fixtures/pnpm-monorepo/packages/lib/tsconfig.json
+++ b/test/fixtures/pnpm-monorepo/packages/lib/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*"]
+}

--- a/test/fixtures/pnpm-monorepo/packages/lib/vitest.config.ts
+++ b/test/fixtures/pnpm-monorepo/packages/lib/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    include: ["src/**/*.test.ts"],
+  },
+});

--- a/test/fixtures/pnpm-monorepo/pnpm-lock.yaml
+++ b/test/fixtures/pnpm-monorepo/pnpm-lock.yaml
@@ -1,0 +1,896 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}
+
+  packages/app:
+    dependencies:
+      '@fixture/lib':
+        specifier: workspace:*
+        version: link:../lib
+    devDependencies:
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9
+
+  packages/lib:
+    devDependencies:
+      typescript:
+        specifier: ^5.6.3
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9
+
+packages:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    resolution: {integrity: sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    resolution: {integrity: sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    resolution: {integrity: sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    resolution: {integrity: sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    resolution: {integrity: sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    resolution: {integrity: sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    resolution: {integrity: sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    resolution: {integrity: sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    resolution: {integrity: sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    resolution: {integrity: sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    resolution: {integrity: sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    resolution: {integrity: sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    resolution: {integrity: sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    resolution: {integrity: sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    resolution: {integrity: sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    resolution: {integrity: sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    resolution: {integrity: sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    resolution: {integrity: sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    resolution: {integrity: sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    resolution: {integrity: sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    resolution: {integrity: sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    resolution: {integrity: sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    resolution: {integrity: sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  postcss@8.5.10:
+    resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  rollup@4.60.2:
+    resolution: {integrity: sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+snapshots:
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@rollup/rollup-android-arm-eabi@4.60.2':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.2':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.2':
+    optional: true
+
+  '@types/estree@1.0.8': {}
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21)':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  assertion-error@2.0.1: {}
+
+  cac@6.7.14: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  deep-eql@5.0.2: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  loupe@3.2.1: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  pathe@1.1.2: {}
+
+  pathval@2.0.1: {}
+
+  picocolors@1.1.1: {}
+
+  postcss@8.5.10:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  rollup@4.60.2:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.2
+      '@rollup/rollup-android-arm64': 4.60.2
+      '@rollup/rollup-darwin-arm64': 4.60.2
+      '@rollup/rollup-darwin-x64': 4.60.2
+      '@rollup/rollup-freebsd-arm64': 4.60.2
+      '@rollup/rollup-freebsd-x64': 4.60.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.2
+      '@rollup/rollup-linux-arm64-gnu': 4.60.2
+      '@rollup/rollup-linux-arm64-musl': 4.60.2
+      '@rollup/rollup-linux-loong64-gnu': 4.60.2
+      '@rollup/rollup-linux-loong64-musl': 4.60.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.2
+      '@rollup/rollup-linux-ppc64-musl': 4.60.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.2
+      '@rollup/rollup-linux-riscv64-musl': 4.60.2
+      '@rollup/rollup-linux-s390x-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-gnu': 4.60.2
+      '@rollup/rollup-linux-x64-musl': 4.60.2
+      '@rollup/rollup-openbsd-x64': 4.60.2
+      '@rollup/rollup-openharmony-arm64': 4.60.2
+      '@rollup/rollup-win32-arm64-msvc': 4.60.2
+      '@rollup/rollup-win32-ia32-msvc': 4.60.2
+      '@rollup/rollup-win32-x64-gnu': 4.60.2
+      '@rollup/rollup-win32-x64-msvc': 4.60.2
+      fsevents: 2.3.3
+
+  siginfo@2.0.0: {}
+
+  source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  typescript@5.9.3: {}
+
+  vite-node@2.1.9:
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21:
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.10
+      rollup: 4.60.2
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@2.1.9:
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21)
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21
+      vite-node: 2.1.9
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2

--- a/test/fixtures/pnpm-monorepo/pnpm-workspace.yaml
+++ b/test/fixtures/pnpm-monorepo/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - "packages/*"

--- a/test/package-files-no-test-leak.test.js
+++ b/test/package-files-no-test-leak.test.js
@@ -1,0 +1,64 @@
+'use strict';
+
+/**
+ * package.json::files 누수 방지 가드 (issue #190, 필수 보안 가드).
+ *
+ * 의도: `test/fixtures/pnpm-monorepo/` 가 `npm publish` 를 통해 다운스트림 `harness update`
+ * 로 유출되면 (a) 다운스트림 저장소 크기 급증 (b) 선언되지 않은 경로 포함 리스크.
+ * `package.json::files` 배열에 `test` 또는 `test/` 접두어가 포함되지 않음을 영속 가드.
+ *
+ * ADR 20260423-ci-fixture-pnpm-workspace §2 (필수 보안 가드, Gemini 교차검증 격상).
+ */
+
+const test = require('node:test');
+const assert = require('node:assert');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const PKG_PATH = path.resolve(__dirname, '..', 'package.json');
+
+test('package.json::files 에 test / test/ 가 포함되지 않는다 (fixture 유출 방지)', () => {
+  const pkg = JSON.parse(fs.readFileSync(PKG_PATH, 'utf8'));
+  assert.ok(Array.isArray(pkg.files), 'files 배열 존재');
+
+  for (const entry of pkg.files) {
+    // 허용 안 되는 패턴: 'test', 'test/', 'test/**', 'test/fixtures', '**/test' 등
+    // 정규식: 정확히 "test" 이거나, "test/" 로 시작, 또는 와일드카드 내 test/ 경로
+    const normalized = String(entry).trim();
+    assert.ok(
+      normalized !== 'test',
+      `files 에 'test' 항목 금지 (발견: ${entry})`,
+    );
+    assert.ok(
+      !normalized.startsWith('test/'),
+      `files 에 'test/' 접두어 금지 (발견: ${entry})`,
+    );
+    // glob 패턴에도 test 경로가 끼어들지 못하게
+    assert.ok(
+      !/\btest\/fixtures\b/.test(normalized),
+      `files 에 'test/fixtures' 경로 금지 (발견: ${entry})`,
+    );
+  }
+});
+
+test('package.json::files 가 알려진 허용 경로만 포함한다 (화이트리스트)', () => {
+  const pkg = JSON.parse(fs.readFileSync(PKG_PATH, 'utf8'));
+  // 화이트리스트 — 현 시점 합의된 배포 대상. 신규 경로 추가 시 본 테스트 업데이트 필수.
+  // 테스트 fixture 가 실수로 추가되면 첫 assertion 이 차단, 그 외 비정상 경로는 본 assertion 이 차단.
+  const allowed = new Set([
+    'bin/',
+    'lib/',
+    '.claude/',
+    '.github/',
+    'docs/',
+    'scripts/',
+    'CLAUDE.md',
+    'README.md',
+  ]);
+  for (const entry of pkg.files) {
+    assert.ok(
+      allowed.has(entry),
+      `files 에 허용되지 않은 경로: ${entry} (화이트리스트 업데이트 필요 시 본 테스트도 함께 수정)`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

v3.1.2 → v3.2.0 MINOR 릴리스. **단일 이슈 통합** — `#190` (PR #223 + chore(release) #225).

## 포함 범위

- [#190](https://github.com/coseo12/harness-setting/issues/190) — CI fixture: pnpm workspace 스모크 테스트 (MINOR + ADR) — PR [#223](https://github.com/coseo12/harness-setting/pull/223)

## 태그 계획

`v3.2.0` — merge 직후 생성

## Behavior Changes

- **CI `fixture-smoke-test` job 추가 (`.github/workflows/ci.yml`)** — pnpm workspace + dist-based exports 경로를 upstream PR 단계에서 실측. v2.28.2 / v2.29.1 부류 regression 이 다운스트림에서만 드러나던 blindspot 차단
- **`package.json::files` 누수 가드 영속화 (`test/package-files-no-test-leak.test.js`)** — fixture 의 publish 유출을 유닛 테스트로 차단 (Gemini 교차검증에서 보안 가드로 격상)
- **DX: 루트 `scripts.test:fixture` 추가** — 로컬 fixture 독립 실행

## 내부 변경 요약

**#190 (PR #223)** — upstream self-coverage 확장
- `test/fixtures/pnpm-monorepo/` 13 파일 (lib dist-based exports + app workspace:* 소비)
- `.github/workflows/ci.yml` — `fixture-smoke-test` job + `package_json_file` 명시
- `docs/decisions/20260423-ci-fixture-pnpm-workspace.md` — ADR (축 3개 비교, footnote 포함)
- `docs/harness-update-compat-checklist.md` — 체크리스트 ↔ fixture 양방향 링크
- 유닛 가드 2개 (`test/ci-fixture-smoke-test.test.js` / `test/package-files-no-test-leak.test.js`)
- `scripts.test:fixture` DX

## 검증

- [x] `bash scripts/verify-release-version-bump.sh` → ✅ 3.2.0 정합
- [x] `npm test` → 122/122 pass
- [x] CI `fixture-smoke-test (pnpm-monorepo)` pass 10s
- [x] regression proof PR #224 CLOSED (RED 실측 박제)
- [x] U+FFFD 검증 통과

## 머지 방식 (중요)

**`--merge` (merge commit) 방식으로 머지** — squash 금지. merge commit 이 main tip 에 develop tip 을 직계 조상으로 포함시켜 merge-back 불필요. 머지 직후 `git push origin main:develop` fast-forward.

## 자체 점검 (CRITICAL DIRECTIVES)

- [x] base=main, head=develop (release PR 예외)
- [x] 범위 명시 (#190 단일)
- [x] 파괴적 작업 없음
- [x] U+FFFD 검증 통과

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)