### PR TITLE
chore(release): v3.3.0 — #208 6c 경로 리포팅 자동화 (MINOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@
 > "규약 추가 = MINOR" 선례(v2.5.0~v2.6.0) 폐기. v2.6.3 부터 **에이전트 지시어·스킬 절차의 행동 변화는 MINOR**, **행동 변화 없는 문서/문구/오타는 PATCH** 로 분기한다. MINOR/MAJOR 릴리스는 `### Behavior Changes` 섹션을 필수로 포함한다.
 > 분류 기준 전문: [CLAUDE.md `### 릴리스`](CLAUDE.md#릴리스).
 
-## [Unreleased]
+## [3.3.0] — 2026-04-23
+
+v3.2.0 이후 **단일 PR MINOR 릴리스** — v3.0.0 `.github/workflows/` 책임 분리 마이그레이션의 6c 경로 리포팅 자동화. 사용자 수정 감지로 자동 분리가 스킵된 다운스트림이 환경 메타를 담은 **pre-filled GitHub 이슈 URL** 로 원클릭 리포트할 수 있도록 확장.
+
+**포함 범위**:
+
+- [#208](https://github.com/coseo12/harness-setting/issues/208) — 6c 경로 리포팅 자동화 (pre-filled URL + 마크다운 템플릿, MINOR) — PR [#227](https://github.com/coseo12/harness-setting/pull/227)
 
 ### Behavior Changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "bin": {
     "harness": "./bin/harness.js"


### PR DESCRIPTION
## 요약

v3.2.0 이후 단일 PR MINOR 릴리스 준비.

- `package.json::version` 3.2.0 → 3.3.0 bump
- `CHANGELOG.md` [Unreleased] → [3.3.0] — 2026-04-23 전환

## 포함 범위

- [#208](https://github.com/coseo12/harness-setting/issues/208) (PR [#227](https://github.com/coseo12/harness-setting/pull/227)) — v3.0.0 마이그레이션 6c 경로 리포팅 자동화

## Behavior Changes (MINOR 근거)

- `lib/migrations/2.31.0-to-3.0.0.js` 6c 분기 stderr 포맷 확장 (`[ACTION REQUIRED]` 헤더 + pre-filled GitHub 이슈 URL) → 다운스트림 관찰값 변화
- `.github/ISSUE_TEMPLATE/6c-migration-report.md` 신규 (환경 메타 자동 수집)
- `docs/harness-ci-migration.md` §"6c 감지 시 리포팅" 섹션 신규

## 검증

- `bash scripts/verify-release-version-bump.sh` — package.json 3.3.0 == CHANGELOG 3.3.0 정합
- `npm test` — 132 pass
- 5 가드 green (release bump / lessons / claudemd / docs links / agent ssot)
- U+FFFD 없음

## 다음 단계

1. 본 PR squash 머지 → develop 반영
2. develop → main release PR (merge commit 방식)
3. `git push origin main:develop` (fast-forward)
4. `git tag v3.3.0` + `gh release create v3.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)