### PR TITLE
docs(harness): volt #95 #98 #102 #103 반영 — verify-*.sh + GitHub Actions YAML 함정 (PATCH)

### DIFF
--- a/docs/lessons/README.md
+++ b/docs/lessons/README.md
@@ -20,7 +20,8 @@ CLAUDE.md `## 실전 교훈` 섹션에서 추출된 상세 문서 디렉토리. 
 | [strict-principle-dynamic-context.md](strict-principle-dynamic-context.md) | 단일 축 엄격 원칙 + 동적 적응 부재는 자동 검증 PASS / 실사용 실패를 생성 (뷰포트·해상도 등 동적 문맥 시뮬레이션 필수) | [#68](https://github.com/coseo12/volt/issues/68) |
 | [sub-agent-multiturn-drift.md](sub-agent-multiturn-drift.md) | sub-agent multi-turn 세션에서 세부 매트릭스가 라운드 간 이탈. SendMessage 로 이전 라운드 매트릭스 재첨부 필수 | [#34](https://github.com/coseo12/volt/issues/34) / [#76](https://github.com/coseo12/volt/issues/76) |
 | [ux-dod-vs-product-behavior.md](ux-dod-vs-product-behavior.md) | 수치 DoD 전부 PASS 여도 사용자가 인지하는 제품은 회귀 가능. 원칙 폐기 ADR 은 downstream UX 계약 재검증 동반 + UX DoD 별도 박제 필수 | [#72](https://github.com/coseo12/volt/issues/72) / [#74](https://github.com/coseo12/volt/issues/74) |
-| [workflow-dispatch-pitfalls.md](workflow-dispatch-pitfalls.md) | `workflow_dispatch` 는 default branch 반영 후에만 discover + PR 자동 생성 권한 기본 OFF 2단계 함정 | [#45](https://github.com/coseo12/volt/issues/45) |
+| [verify-script-authoring.md](verify-script-authoring.md) | `verify-*.sh` 작성 모범 — macOS bash 3.2 호환 (parallel index array + `sort -u`) + 격리 동적 테스트 (mktemp + env override + 4~5 케이스) | [#95](https://github.com/coseo12/volt/issues/95) / [#98](https://github.com/coseo12/volt/issues/98) |
+| [workflow-dispatch-pitfalls.md](workflow-dispatch-pitfalls.md) | GitHub Actions 4 함정 — `workflow_dispatch` default branch 종속 + PR 자동 생성 권한 + YAML 1.1 `on:` boolean coercion + block scalar heredoc indent | [#45](https://github.com/coseo12/volt/issues/45) / [#102](https://github.com/coseo12/volt/issues/102) / [#103](https://github.com/coseo12/volt/issues/103) |
 
 ## 신규 파일 추가 루틴
 

--- a/docs/lessons/verify-script-authoring.md
+++ b/docs/lessons/verify-script-authoring.md
@@ -1,0 +1,145 @@
+# verify-*.sh 작성 모범 — bash 3.2 호환 + 격리 동적 테스트
+
+> **요지**: `verify-*.sh` 류 SSoT/drift 가드 스크립트는 (1) macOS 시스템 bash 3.2 호환 (CI Ubuntu 의 bash 4+ 통과해도 로컬 개발자가 첫 실행에서 차단) + (2) `mktemp` 격리 + env override + 4~5 케이스 매트릭스 동적 테스트가 필수.
+>
+> **근거**: volt [#95](https://github.com/coseo12/volt/issues/95) (bash 3.2) + [#98](https://github.com/coseo12/volt/issues/98) (격리 동적 테스트). harness `scripts/verify-agent-ssot.sh` (#145) / `verify-release-version-bump.sh` 등 이미 본 패턴으로 운영 중 — 신규 verify 스크립트 추가 시 회귀 방지용 박제.
+
+---
+
+## 1. macOS bash 3.2 호환 (#95)
+
+### 배경
+
+macOS 는 Apple 의 GPLv3 회피 정책으로 시스템 `/bin/bash` 가 GNU bash 3.2.57 (2007년) 에 고정. `brew install bash` 로 4+ 설치 가능하지만 별도 경로 (`/usr/local/bin/bash`, `/opt/homebrew/bin/bash`) 라 shebang `#!/usr/bin/env bash` 가 PATH 우선순위에 의존. **CI Ubuntu runner 는 bash 4+ 라 통과하지만 로컬 macOS 개발자가 즉시 차단당함**.
+
+### bash 3.2 미지원 기능 (verify-*.sh 작성 시 자주 쓰이는 것)
+
+- `declare -A` / 모든 associative array (`map[key]=val`) — bash 4.0+
+- `${parameter,,}` / `${parameter^^}` 대소문자 변환 — bash 4.0+
+- `mapfile` / `readarray` — bash 4.0+
+- `coproc` — bash 4.0+
+- `&>>` redirect append — bash 4.0+
+
+### 미지원 패턴 (bash 4+) — 사용 금지
+
+```bash
+declare -A captured_content
+for agent in "${AGENTS[@]}"; do
+  captured_content[$agent]=$(grep ...)
+done
+```
+
+증상:
+```
+scripts/verify-X.sh: line 32: declare: -A: invalid option
+declare: usage: declare [-afFirtx] [-p] [name[=value] ...]
+```
+
+### 호환 패턴 — parallel index array + `sort -u`
+
+```bash
+captured_content=()  # AGENTS[i] 와 1:1 대응 index
+for agent in "${AGENTS[@]}"; do
+  captured_content+=("$(grep ...)")
+done
+
+# 동일성 검증: sort -u 패턴
+unique_count=$(printf '%s\n' "${captured_content[@]}" | sort -u | wc -l | tr -d ' ')
+```
+
+harness 선례: `scripts/verify-agent-ssot.sh` (PR [#145](https://github.com/coseo12/harness-setting/pull/145)) — 5 페르소나 × N 필드 SSoT 검증을 parallel index array 로 작성. AGENT_DIR override 패턴도 동일 PR 에서 도입.
+
+### 예방 박제
+
+- 신규 `verify-*.sh` 첫 줄 주석 박제 의무:
+  ```bash
+  # 호환성 메모: macOS 시스템 bash 3.2 호환 위해 associative array 미사용 — parallel index array + sort -u 로 동일성 검증.
+  ```
+- 로컬 macOS 개발자 실측 의무 — CI 만 믿으면 사용자 첫 실행 차단
+
+---
+
+## 2. 격리 동적 테스트 — `mktemp` + env override (#98)
+
+### 배경
+
+`verify-*.sh` 류 SSoT 가드는 본질적으로 **negative-test 성격** (drift 를 fail 로 분류). 정적 분석 / lint 만으로는 가드 로직 자체 작동 보장 불가. **격리 디렉토리 + 4~5 케이스 매트릭스** 로 가드의 fail 분기까지 입증.
+
+### 스크립트 측 박제 — env override 의무
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+# 테스트 격리용 — 기본 .claude/agents 외 경로 검사 시 AGENT_DIR override
+AGENT_DIR="${AGENT_DIR:-${PROJECT_DIR}/.claude/agents}"
+```
+
+`AGENT_DIR` / `CHECK_DIR` / `BASE_DIR` 등 검사 대상 디렉토리는 env var override 가능하게 설계 (선행 의무). 격리 테스트가 시작점.
+
+### 4~5 케이스 매트릭스
+
+```bash
+set -e
+TMPDIR=$(mktemp -d -t verify-XXXXXX)
+trap "rm -rf $TMPDIR" EXIT
+cp -r .claude/agents "$TMPDIR/agents"
+
+# 케이스 1: 정상 (PASS 기대)
+AGENT_DIR="$TMPDIR/agents" bash scripts/verify-X.sh
+
+# 케이스 2: SSoT 키 라인 제거 (FAIL 기대)
+sed -i.bak '/SSoT 키 패턴/d' "$TMPDIR/agents/pm.md"
+AGENT_DIR="$TMPDIR/agents" bash scripts/verify-X.sh || true
+
+# 케이스 3: SSoT 키 한 글자 변경 (FAIL 기대)
+cp .claude/agents/pm.md "$TMPDIR/agents/pm.md"  # 원본 복구
+sed -i.bak 's/스킬 사용/스킬 호출/' "$TMPDIR/agents/qa.md"
+AGENT_DIR="$TMPDIR/agents" bash scripts/verify-X.sh || true
+
+# 케이스 4: 파일 부재 (FAIL 기대)
+cp .claude/agents/qa.md "$TMPDIR/agents/qa.md"
+rm "$TMPDIR/agents/developer.md"
+AGENT_DIR="$TMPDIR/agents" bash scripts/verify-X.sh || true
+
+# 케이스 5: SSoT 키 유지 + 부수 텍스트 drift (FAIL drift detect 기대)
+cp .claude/agents/developer.md "$TMPDIR/agents/developer.md"
+sed -i.bak 's/(#471)/(#999)/' "$TMPDIR/agents/reviewer.md"
+AGENT_DIR="$TMPDIR/agents" bash scripts/verify-X.sh || true
+```
+
+### 매트릭스 의의
+
+| 케이스 | 검증 대상 |
+|--------|-----------|
+| 1. 정상 | false-positive 부재 (정상을 정상으로 분류) |
+| 2. SSoT 라인 완전 제거 | 누락 감지 분기 |
+| 3. SSoT 키 자체 변형 | 누락 감지 분기 (키 매칭 변형 흡수) |
+| 4. 파일 부재 | 파일 시스템 분기 |
+| 5. SSoT 키 유지 + 부수 텍스트 drift | drift 감지 분기 (동일성 검증) |
+
+### 자명 함정 회피
+
+- **케이스 5 박제 의무** — 케이스 2/3 만 검증하면 "키 변경 = 누락" 분기만 검증되고 "부수 텍스트 drift" 분기 (실제 운영 빈도 1순위) 미검증
+- **`trap EXIT` cleanup 의무** — 케이스 도중 fail 해도 TMPDIR 정리 (`set -e` 와 조합 시 trap 이 안전망)
+- **`set +e` / `|| true` 박제** — fail 기대 케이스에서 종료 코드 활용 + 검증 누락 없이 다음 케이스 진행
+
+### 적용 조건
+
+- 신규 `verify-*.sh` / SSoT 가드 / 보안 가드 / drift 감지 스크립트
+- env var override 가능한 설계 선행
+
+---
+
+## 3. 회귀 가드 시뮬레이션과의 직교성
+
+격리 동적 테스트 (본 문서) 는 **스크립트 로직** 검증. 별도로 **CI 통합 + hashFiles 조건 + 실제 차단** 검증은 [guard-pr-dod.md](guard-pr-dod.md) 의 3중 시뮬레이션 (positive → negative → recovery) 으로 입증. 둘 다 통과해야 가드 작동이 완전 입증된다 (둘 중 하나만 통과 시 어딘가에 함정 잔존).
+
+---
+
+## 근거
+
+- volt [#95](https://github.com/coseo12/volt/issues/95) — astro-simulator PR #496 `scripts/verify-create-pr-ssot.sh` 가 macOS 첫 실행에서 `declare: -A: invalid option` 차단. 호환 패턴 (`scripts/verify-agent-ssot.sh` harness #145) 일관성 유지로 해결
+- volt [#98](https://github.com/coseo12/volt/issues/98) — 동일 PR 에서 격리 동적 테스트 5/5 PASS. AGENT_DIR override + 4~5 케이스 매트릭스 정립
+- harness 선례: `scripts/verify-agent-ssot.sh` (PR [#145](https://github.com/coseo12/harness-setting/pull/145)) / `scripts/verify-release-version-bump.sh` — bash 3.2 호환 작성된 운영 사례
+- GNU bash 4.0 release note (associative array 도입): 2009-02-20
+- Apple bash 3.2 freeze 배경: GPLv3 회피

--- a/docs/lessons/workflow-dispatch-pitfalls.md
+++ b/docs/lessons/workflow-dispatch-pitfalls.md
@@ -1,8 +1,8 @@
-# workflow_dispatch 2단계 함정 (GitHub Actions)
+# GitHub Actions workflow 함정 (workflow_dispatch + YAML)
 
-> **요지**: CLAUDE.md 실전 교훈의 GitHub Actions `workflow_dispatch` 트리거 함정 블록 상세. 본문 요약은 CLAUDE.md `## 실전 교훈` 의 포인터 참조.
+> **요지**: GitHub Actions workflow 도입 시 (1) `workflow_dispatch` 의 default branch 종속 / PR 자동 생성 권한 + (2) YAML 1.1 `on:` boolean coercion + (3) block scalar + bash heredoc indent 의 4가지 silent 함정. **모두 CI statusCheckRollup 은 PASS 로 보이지만 trigger 자체 미발화** — 머지 후에야 발견되는 패턴이 공통.
 >
-> **근거**: harness [#199](https://github.com/coseo12/harness-setting/issues/199) Phase 3-A 에서 추출.
+> **근거**: harness [#199](https://github.com/coseo12/harness-setting/issues/199) Phase 3-A 에서 추출. volt [#45](https://github.com/coseo12/volt/issues/45) / [#102](https://github.com/coseo12/volt/issues/102) / [#103](https://github.com/coseo12/volt/issues/103) 누적.
 
 ---
 
@@ -26,6 +26,81 @@ gh api -X PUT /repos/{OWNER}/{REPO}/actions/permissions/workflow \
 
 변경 후 즉시 효과 (재시작 불필요).
 
+## 함정 3 — YAML 1.1 `on:` → `True` boolean coercion (#102)
+
+YAML 1.1 spec 에서 `on` / `off` / `yes` / `no` 가 boolean 으로 자동 coercion. GitHub Actions workflow 의 `on:` 트리거 키가 일부 parser (Python `yaml.safe_load` 폴백 등) 에서 `True` boolean 키로 해석되어 트리거 인식 실패. **CI statusCheckRollup PASS** (PR CI 와 무관) 라 PR 머지 후에야 발견.
+
+증상:
+
+```yaml
+on:        # ← YAML 1.1 spec 에서 True 로 coercion
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+```
+
+→ `yaml.safe_load` 가 `{True: {schedule: [...], workflow_dispatch: None}}` 로 파싱 → GitHub Actions 가 트리거 key 미인식 → workflow 영구 무효화.
+
+우회 (string 강제 quote):
+
+```yaml
+"on":      # ← 또는 'on':
+  schedule:
+    - cron: '0 0 1 * *'
+  workflow_dispatch:
+```
+
+도구별 처리 차이 (참고):
+
+- Node.js `js-yaml` (1.2 기본): `on` 을 string 유지 ✓
+- Python `yaml.safe_load` (1.1): `on` 을 `True` 로 coercion ✗
+- Go `gopkg.in/yaml.v3` (1.2): `on` 을 string 유지 ✓
+- GitHub Actions runner internal: 1.1 spec (2026-05 기준 — 확인 권장)
+
+### 동일 파일명 stale ID 변형
+
+workflow 파일이 한 번 invalid 상태로 인덱싱되면 GitHub 가 ID 를 frozen 처리. 동일 파일명으로 fix push 해도 stale ID 유지 (404 지속). 우회: 파일명 변경 (`adr-z-pattern-health.yml` → `adr-z-pattern-health-v2.yml`) → 새 ID 발급.
+
+## 함정 4 — YAML block scalar + bash heredoc indent (#103)
+
+`run: |` step 안에 bash heredoc 본문 (`<<HEREEND ... HEREEND`) 을 박을 때, heredoc body 가 column 0 에서 시작하면 YAML block scalar parser 가 step 종료로 오인 → workflow 등록 실패. **silent 함정 — CI 가 workflow 파일 검증을 별도로 안 하면 PR PASS 유지**.
+
+증상:
+
+```yaml
+- name: Create issue
+  run: |
+    gh issue create \
+      --body "$(cat <<HEREEND
+## 배경
+자동 탐지 workflow 발화. 임계값 충족.
+HEREEND
+)"
+```
+
+`run: |` block scalar 인덴트 기준 = 처음 비공백 라인의 column. heredoc body 의 `## 배경` 이 column 0 에서 시작 → block scalar 종료 + step 종료 + 후속 YAML 키 (`## 배경`) 를 next step 으로 해석 시도.
+
+우회 (heredoc body 에 10 space indent prepend):
+
+```yaml
+- name: Create issue
+  run: |
+    gh issue create \
+      --body "$(cat <<HEREEND
+          ## 배경
+          자동 탐지 workflow 발화. 임계값 충족.
+          HEREEND
+    )"
+```
+
+bash heredoc 의 `<<HEREEND` 는 indent 보존 (`<<-HEREEND` 는 leading tab 만 제거). 본문에 10 space 가 그대로 박혀 issue body 로 출력되지만 마크다운 렌더링은 leading whitespace 무시 → **rendered 의도 유지** ✓.
+
+대안 (검토 후 미채택):
+
+- `<<-` + tab indent — tab 만 제거하므로 mixed indent 위험
+- external 파일 (`issue-body.md`) 참조 — workflow 자체 검증 부담 + 동적 변수 보간 어려움
+- one-liner string concat — 가독성 매우 떨어짐
+
 ## 예방 규약
 
 - **workflow_dispatch 도입 PR 의 DoD 에 "default branch 반영 후 실행 검증" 명시** — 설계 PR 만 머지하고 DoD 체크박스 "실행 검증" 을 못 채우는 함정 방지
@@ -36,6 +111,12 @@ gh api -X PUT /repos/{OWNER}/{REPO}/actions/permissions/workflow \
   # 또는: gh api -X PUT /repos/{OWNER}/{REPO}/actions/permissions/workflow -F can_approve_pull_request_reviews=true
   ```
 
+- **`on:` 키는 항상 quote** — `"on":` / `'on':` 둘 다 가능. raw `on:` 금지 (YAML 1.1 boolean coercion 회피)
+- **`run: |` + heredoc body 는 indent 의무** — 10 space 또는 부모 step indent 보존
+- (선택) **`actionlint` / `yamllint` strict mode pre-commit hook** — `on` 키 boolean coercion + block scalar indent 경고
+
 ## 근거
 
 - volt [#45](https://github.com/coseo12/volt/issues/45) — astro-simulator `bench:baseline-remeasure` workflow (PR #238) 도입 후 develop 에서 dispatch 실패 → v0.7.1 release 로 main 반영 → 2차 시도에서 권한 OFF 로 실패 → Settings API 로 플래그 전환 후 성공. 첫 실행 로그: actions/runs/24621714905, 성공 실행: actions/runs/24624988691
+- volt [#102](https://github.com/coseo12/volt/issues/102) — astro-simulator PR #491 hotfix (YAML on quote) + PR #492 hotfix-2 (file rename `-v2.yml`, stale ID 우회). YAML 1.1 spec: https://yaml.org/type/bool.html
+- volt [#103](https://github.com/coseo12/volt/issues/103) — astro-simulator PR #490 (ADR Z 패턴 자동 탐지) qa 차단 → fix `5272f61` (10 space indent prepend)


### PR DESCRIPTION
## [volt #95 #98 #102 #103] verify-*.sh 작성 모범 + GitHub Actions YAML 함정 박제

### 변경 사항
- `docs/lessons/verify-script-authoring.md` 신규 (volt [#95](https://github.com/coseo12/volt/issues/95) + [#98](https://github.com/coseo12/volt/issues/98))
  - macOS 시스템 bash 3.2 호환 — `declare -A` 금지 / parallel index array + `sort -u` 패턴
  - 격리 동적 테스트 — `mktemp` + env override + 4~5 케이스 매트릭스
  - harness 선례: `scripts/verify-agent-ssot.sh` / `verify-release-version-bump.sh` (이미 호환 작성)
- `docs/lessons/workflow-dispatch-pitfalls.md` 보강 (volt [#102](https://github.com/coseo12/volt/issues/102) + [#103](https://github.com/coseo12/volt/issues/103))
  - 함정 3: YAML 1.1 `on:` → `True` boolean coercion + `"on":` quote 우회
  - 함정 4: YAML block scalar + bash heredoc indent + 10 space prepend 우회
  - 동일 파일명 stale ID 변형 (파일명 변경으로 재발급)
- `docs/lessons/README.md` 파일 목록 표 갱신

### 브랜치 / Base 확인 (gitflow)
- [x] **일반 feature/fix**: `base=develop`, `head=feature/*`
- [ ] Release PR
- [ ] Hotfix PR
- [ ] Hotfix merge-back

### 스프린트 계약
- [x] 구현 전 완료 기준 합의 완료 (volt-review 그룹 A + C 채택)
- [x] 모든 완료 기준 충족

### 테스트
- [x] `bash scripts/verify-lessons-readme.sh` PASS
- [x] `bash scripts/verify-docs-links.sh` PASS
- [x] `bash scripts/verify-claudemd-size.sh` PASS (CLAUDE.md 33481/35000 — 본 PR 미변경)
- [x] `grep -rn '�'` 변경 파일 PASS (U+FFFD 없음)

### 영향 범위
- **행위 변화 없음 (PATCH)** — `docs/lessons/` 단순 보강. CLAUDE.md / agents / skills 변경 없음
- harness 행위 자체는 동일. `verify-*.sh` 신규 작성 시 참조 문서가 추가됨

### 관련 volt 이슈
- [#95](https://github.com/coseo12/volt/issues/95) macOS bash 3.2 호환 / [#98](https://github.com/coseo12/volt/issues/98) 격리 동적 테스트
- [#102](https://github.com/coseo12/volt/issues/102) YAML 1.1 on boolean / [#103](https://github.com/coseo12/volt/issues/103) YAML block scalar indent