### PR TITLE
[#269] feat(cross-validate)!: gemini-cli → agy (Antigravity) 어댑터 교체 (MAJOR)

### DIFF
--- a/.claude/skills/cross-validate/SKILL.md
+++ b/.claude/skills/cross-validate/SKILL.md
@@ -1,132 +1,34 @@
 ---
 name: cross-validate
 description: |
-  Gemini CLI를 활용하여 코드, 설계, 스킬, 구조를 교차검증하는 스킬.
+  외부 검증 모델 (Antigravity `agy`) 을 활용하여 코드, 설계, 스킬, 구조를 교차검증하는 스킬.
+  Phase 1A (#269, 2026-06-18 Gemini CLI 종료 대응) 부터 gemini-cli → agy 교체.
   TRIGGER when: 교차검증이 필요할 때, "검증해줘", "cross-validate", "교차 리뷰",
-  "gemini로 확인", "다른 시각", "두 번째 의견", 설계 리뷰, PR의 독립적 검토,
+  "agy로 확인", "gemini로 확인" (alias), "다른 시각", "두 번째 의견", 설계 리뷰, PR의 독립적 검토,
   스킬 품질 검증, 프레임워크 구조 점검이 필요할 때.
   ALSO TRIGGER (루틴): 정책·규약·ADR·CRITICAL DIRECTIVE 박제 직후 1회 — 단일 모델 편향 노출 효율이 박제 직후에 가장 높다 (volt #23).
   DO NOT TRIGGER when: 일반 코드 리뷰, 테스트 실행,
-  Gemini와 무관한 작업일 때.
+  외부 검증 모델과 무관한 작업일 때.
 ---
 
 # 교차검증
 
-Gemini CLI를 외부 검증 도구로 활용하여 산출물을 독립적으로 검증한다.
-Claude와 Gemini의 이중 시각으로 단일 모델 편향을 방지한다.
+외부 검증 모델 (Antigravity `agy`) 을 활용하여 산출물을 독립적으로 검증한다.
+Claude 와 외부 모델의 이중 시각으로 단일 모델 편향을 방지한다.
 
 ## 사전 조건
 
 ```bash
-# Gemini CLI 설치 확인
-command -v gemini || echo "gemini CLI 미설치"
+# agy (Antigravity CLI) 설치 확인
+command -v agy || echo "agy 미설치 — https://antigravity.google/docs/cli-overview 참조"
 
-# 인증 확인
-gemini -p "hello" --approval-mode plan 2>&1 | head -3
+# 인증 + 응답성 확인
+agy -p "hello" 2>&1 | head -3
 ```
 
-## 검증 유형
+## 권장 호출 경로 — `cross_validate.sh` (자동 가드)
 
-### 1. 설계 검증 (architecture)
-
-Architect 산출물을 검증한다.
-
-```bash
-# 설계 문서를 Gemini에 전달
-gemini -p "$(cat <<'PROMPT'
-당신은 소프트웨어 아키텍처 리뷰어입니다.
-아래 설계 문서를 검증해주세요.
-
-검증 기준:
-1. 구조적 완성도 — 빠진 컴포넌트가 없는지
-2. 기술 결정 타당성 — 선택의 근거가 합리적인지
-3. 확장성 — 향후 변경에 유연한지
-4. 보안 — 위험한 설계 패턴이 없는지
-5. 누락 요소 — 고려하지 못한 사항이 있는지
-
-한국어로 항목별 평가와 개선 제안을 해주세요.
-PROMPT
-)" --approval-mode plan
-```
-
-### 2. 코드 검증 (code)
-
-PR의 변경 사항을 검증한다.
-
-```bash
-# PR diff를 Gemini에 전달
-DIFF=$(gh pr diff <PR번호>)
-
-gemini -p "$(cat <<PROMPT
-당신은 시니어 코드 리뷰어입니다.
-아래 코드 변경사항을 리뷰해주세요.
-
-검증 기준:
-1. 로직 정확성 — 버그, 오프바이원, 경쟁 조건
-2. 보안 — 인젝션, XSS, 하드코딩된 시크릿
-3. 성능 — 불필요한 루프, 메모리 누수
-4. 엣지 케이스 — 빈 입력, null, 경계값
-5. 설계 준수 — 기존 패턴과 일관성
-
-변경 내용:
-${DIFF}
-
-한국어로 항목별 평가와 구체적 개선 제안을 해주세요.
-PROMPT
-)" --approval-mode plan
-```
-
-### 3. 스킬 검증 (skill)
-
-스킬의 형식과 트리거 정확도를 검증한다.
-
-```bash
-SKILL_CONTENT=$(cat .claude/skills/<스킬명>/SKILL.md)
-
-gemini -p "$(cat <<PROMPT
-당신은 Claude Code 스킬 검증자입니다.
-아래 스킬을 검증해주세요.
-
-검증 기준:
-1. frontmatter 형식 — name(kebab-case), description(트리거 조건 명시)
-2. description 품질 — TRIGGER when/DO NOT TRIGGER when 패턴 사용 여부
-3. 본문 완성도 — 절차, 명령어, 규칙이 실행 가능한지
-4. 트리거 정확도 — description으로 과소/과다 트리거 가능성
-5. 500줄 이하 여부
-
-스킬 내용:
-${SKILL_CONTENT}
-
-한국어로 항목별 평가와 개선 제안을 해주세요.
-PROMPT
-)" --approval-mode plan
-```
-
-### 4. 구조 검증 (structure)
-
-프로젝트 전체 구조를 검증한다.
-
-```bash
-gemini -p "$(cat <<'PROMPT'
-당신은 소프트웨어 아키텍처 리뷰어입니다.
-이 저장소의 전체 구조를 검증해주세요.
-
-검증 기준:
-1. 구조적 완성도 — 에이전트, 스킬, 스크립트가 빠짐없이 연결되어 있는지
-2. 워크플로우 일관성 — 상태 전이, 라벨, 통신 방식에 모순이 없는지
-3. 실행 가능성 — 스크립트가 동작하는지, 빠진 의존성이 없는지
-4. 확장성 — 새 에이전트/스킬 추가 시 구조가 유연한지
-5. 보안/안전성 — 위험한 패턴이 없는지
-6. 누락 요소 — 빠진 것이 있는지
-
-한국어로 답변해주세요.
-PROMPT
-)" --approval-mode plan
-```
-
-## 실행 스크립트
-
-자동화된 검증은 아래 스크립트를 사용한다:
+자동화 검증은 아래 스크립트를 사용한다. 본 스크립트는 **L1 prompt strict prefix** (도구 호출 차단) + **L3 워킹트리 snapshot 가드** (사후 자동 롤백, #479) 를 자동 적용한다.
 
 ```bash
 # 구조 검증
@@ -142,39 +44,161 @@ PROMPT
 .claude/skills/cross-validate/scripts/cross_validate.sh skill <스킬명>
 ```
 
+스크립트는 다음을 자동 처리:
+- L1: prompt 에 strict prefix 자동 prepend (`STRICT INSTRUCTION: Do NOT execute any tool...`)
+- L3: 워킹트리 snapshot pre/post 비교 + 도구 호출로 인한 파일 수정 자동 롤백
+- capacity 폴백 (stderr `^Error: ` 패턴 매칭) + 재시도 + claude-only fallback
+- outcome JSON 자동 생성 (`{LOG_DIR}/cross-validate-<type>-<timestamp>-outcome.json`)
+
+## 검증 유형 (직접 호출 예제 — 디버깅용)
+
+> ⚠ 직접 호출 시 L1/L3 가드가 자동 적용되지 않음. 자동화는 위 `cross_validate.sh` 권장.
+
+### 1. 설계 검증 (architecture)
+
+Architect 산출물을 검증한다.
+
+```bash
+# 직접 호출 — L1 strict prefix 수동 포함 권고
+agy -p "$(cat <<'PROMPT'
+STRICT INSTRUCTION: You are performing read-only code review and analysis. Do NOT execute any shell command or tool. Do NOT modify any file. Respond ONLY with text-based analysis.
+
+---
+
+당신은 소프트웨어 아키텍처 리뷰어입니다.
+아래 설계 문서를 검증해주세요.
+
+검증 기준:
+1. 구조적 완성도 — 빠진 컴포넌트가 없는지
+2. 기술 결정 타당성 — 선택의 근거가 합리적인지
+3. 확장성 — 향후 변경에 유연한지
+4. 보안 — 위험한 설계 패턴이 없는지
+5. 누락 요소 — 고려하지 못한 사항이 있는지
+
+한국어로 항목별 평가와 개선 제안을 해주세요.
+PROMPT
+)"
+```
+
+### 2. 코드 검증 (code)
+
+PR의 변경 사항을 검증한다.
+
+```bash
+DIFF=$(gh pr diff <PR번호>)
+
+agy -p "$(cat <<PROMPT
+STRICT INSTRUCTION: You are performing read-only code review. Do NOT execute any shell command or tool. Do NOT modify any file. Respond ONLY with text-based analysis.
+
+---
+
+당신은 시니어 코드 리뷰어입니다.
+아래 코드 변경사항을 리뷰해주세요.
+
+검증 기준:
+1. 로직 정확성 — 버그, 오프바이원, 경쟁 조건
+2. 보안 — 인젝션, XSS, 하드코딩된 시크릿
+3. 성능 — 불필요한 루프, 메모리 누수
+4. 엣지 케이스 — 빈 입력, null, 경계값
+5. 설계 준수 — 기존 패턴과 일관성
+
+변경 내용:
+${DIFF}
+
+한국어로 항목별 평가와 구체적 개선 제안을 해주세요.
+PROMPT
+)"
+```
+
+### 3. 스킬 검증 (skill)
+
+스킬의 형식과 트리거 정확도를 검증한다.
+
+```bash
+SKILL_CONTENT=$(cat .claude/skills/<스킬명>/SKILL.md)
+
+agy -p "$(cat <<PROMPT
+STRICT INSTRUCTION: Read-only analysis. Do NOT execute any tool. Respond with text only.
+
+---
+
+당신은 Claude Code 스킬 검증자입니다.
+아래 스킬을 검증해주세요.
+
+검증 기준:
+1. frontmatter 형식 — name(kebab-case), description(트리거 조건 명시)
+2. description 품질 — TRIGGER when/DO NOT TRIGGER when 패턴 사용 여부
+3. 본문 완성도 — 절차, 명령어, 규칙이 실행 가능한지
+4. 트리거 정확도 — description으로 과소/과다 트리거 가능성
+5. 500줄 이하 여부
+
+스킬 내용:
+${SKILL_CONTENT}
+
+한국어로 항목별 평가와 개선 제안을 해주세요.
+PROMPT
+)"
+```
+
+### 4. 구조 검증 (structure)
+
+프로젝트 전체 구조를 검증한다.
+
+```bash
+agy -p "$(cat <<'PROMPT'
+STRICT INSTRUCTION: Read-only architecture analysis. Do NOT execute any tool or modify any file. Respond with text only.
+
+---
+
+당신은 소프트웨어 아키텍처 리뷰어입니다.
+이 저장소의 전체 구조를 검증해주세요.
+
+검증 기준:
+1. 구조적 완성도 — 에이전트, 스킬, 스크립트가 빠짐없이 연결되어 있는지
+2. 워크플로우 일관성 — 상태 전이, 라벨, 통신 방식에 모순이 없는지
+3. 실행 가능성 — 스크립트가 동작하는지, 빠진 의존성이 없는지
+4. 확장성 — 새 에이전트/스킬 추가 시 구조가 유연한지
+5. 보안/안전성 — 위험한 패턴이 없는지
+6. 누락 요소 — 빠진 것이 있는지
+
+한국어로 답변해주세요.
+PROMPT
+)"
+```
+
 ## 결과 분석
 
-Gemini 응답을 받은 후 Claude가 수행하는 분석:
+외부 검증 모델 (agy) 응답을 받은 후 Claude 가 수행하는 분석:
 
-0. **(선행) 수용 전 실측 sanity check (volt #66)** — Gemini 가 제안한 **수치 DoD 재정의·물리/환경 제약·완료 기준 강화** 는 ADR/계약 박제 전 1회 실 환경 실행 또는 단위 테스트 snippet 으로 **자가모순 확인** 선행. "이 조건이 정상 동작에서 실현 가능한가?" 를 현존 시스템에서 직접 확인한다. **30분 실측 > 2차 수정 비용**. AI (Gemini + Claude 공유) 는 "엄격한 DoD = 안전" 편향으로 self-contradiction 을 간과하는 경향 — 실측이 유일한 가드.
+0. **(선행) 수용 전 실측 sanity check (volt #66)** — 외부 모델이 제안한 **수치 DoD 재정의·물리/환경 제약·완료 기준 강화** 는 ADR/계약 박제 전 1회 실 환경 실행 또는 단위 테스트 snippet 으로 **자가모순 확인** 선행. "이 조건이 정상 동작에서 실현 가능한가?" 를 현존 시스템에서 직접 확인한다. **30분 실측 > 2차 수정 비용**. AI (Claude + 외부 모델 공유) 는 "엄격한 DoD = 안전" 편향으로 self-contradiction 을 간과하는 경향 — 실측이 유일한 가드.
 1. **합의 항목 식별**: 두 모델이 동의하는 문제 → 높은 신뢰도
 2. **이견 항목 식별**: 두 모델이 다른 의견 → 양쪽 근거 제시
-3. **Gemini 고유 발견**: Claude가 놓친 문제 → 추가 검토
-4. **오탐 필터링**: Gemini의 잘못된 지적 → 근거와 함께 기각
+3. **외부 모델 고유 발견**: Claude 가 놓친 문제 → 추가 검토
+4. **오탐 필터링**: 외부 모델의 잘못된 지적 → 근거와 함께 기각
 
 ## 수용 vs 후속 분리 3단 프로토콜 (volt #29)
 
-고유 발견을 현재 PR 에 즉시 반영할지 후속 이슈로 분리할지의 판단 절차. 스프린트 계약(특히 **비목표**)이 Gemini 제안보다 우선한다.
+고유 발견을 현재 PR 에 즉시 반영할지 후속 이슈로 분리할지의 판단 절차. 스프린트 계약(특히 **비목표**)이 외부 모델 제안보다 우선한다.
 
-1. **합의 선별** — Claude 설계와 일치하는 Gemini 지적은 현재 PR 에 즉시 반영. 이견은 근거 비교 후 취사.
-2. **고유 발견의 범위 체크** — Gemini 만의 제안이면 현재 스프린트 계약의 **비목표** 와 대조:
+1. **합의 선별** — Claude 설계와 일치하는 외부 모델 지적은 현재 PR 에 즉시 반영. 이견은 근거 비교 후 취사.
+2. **고유 발견의 범위 체크** — 외부 모델만의 제안이면 현재 스프린트 계약의 **비목표** 와 대조:
    - 범위 내 → 현재 PR 에 반영
    - 범위 밖 (비목표와 상충) → **후속 이슈로 분리**
    - 판단 질문: "이 변경이 현재 PR 의 `Behavior Changes` 에 원 완료 기준과 직교하는 항목을 추가하는가?"
 3. **분리 시 박제 규칙** — 후속 이슈를 **즉시 생성**해 맥락 유실 방지:
-   - 본문에 Gemini 제안의 설계 스케치 인용
+   - 본문에 외부 모델 제안의 설계 스케치 인용
    - 원 PR 과 링크 (`Builds on: #원PR`)
    - 우선순위 초안 명시 (high / medium / low)
 
 ### 금지
 
-- 스프린트 비목표를 "Gemini 제안이 타당하다" 는 이유만으로 무시 (CRITICAL #6 침범)
+- 스프린트 비목표를 "외부 모델 제안이 타당하다" 는 이유만으로 무시 (CRITICAL #6 침범)
 - 분리 판단 없이 현재 PR 로 수용하여 스코프 팽창
 - 분리 후 이슈 생성을 미루어 맥락 유실
 
 ### 참고 사례
 
-harness #89 (post-apply 게이트) 교차검증에서 Gemini 가 `previousSha256` 매니페스트 스키마 확장을 제안. 비목표 "매니페스트 스키마 변경 없음"과 상충 → 후속 이슈 #92 로 분리 → 3 PR / 3 릴리스로 자연 분할되어 각 단계 위험 독립. 고유 발견 안에서도 비용/범위에 따라 취사한다 (같은 교차검증에서 managed-block 테스트는 범위 내 + 비용 저렴으로 Phase 2 에 즉시 수용).
+harness #89 (post-apply 게이트) 교차검증에서 Gemini (당시 백엔드) 가 `previousSha256` 매니페스트 스키마 확장을 제안. 비목표 "매니페스트 스키마 변경 없음"과 상충 → 후속 이슈 #92 로 분리 → 3 PR / 3 릴리스로 자연 분할되어 각 단계 위험 독립. 고유 발견 안에서도 비용/범위에 따라 취사한다.
 
 ## 결과 보고 형식
 
@@ -185,7 +209,7 @@ harness #89 (post-apply 게이트) 교차검증에서 Gemini 가 `previousSha256
 - 유형: [architecture/code/skill/structure]
 - 대상: [파일 또는 PR 번호]
 
-### Gemini 피드백 요약
+### 외부 모델 (agy) 피드백 요약
 | 항목 | 평가 | 상세 |
 |------|------|------|
 | ... | 양호/주의/위험 | ... |
@@ -206,8 +230,27 @@ harness #89 (post-apply 게이트) 교차검증에서 Gemini 가 `previousSha256
 
 ## 규칙
 
-- Gemini는 항상 `--approval-mode plan` (읽기 전용)으로 실행한다. 코드 변경을 허용하지 않는다.
-- Gemini 출력을 맹목적으로 수용하지 않는다. Claude가 반드시 재분석한다.
-- 검증 결과는 로그 파일에 기록한다.
-- 민감한 정보(시크릿, 인증 토큰)가 포함된 파일은 Gemini에 전달하지 않는다.
+- 외부 검증 모델 (agy) 호출 시 **L1 strict prompt prefix** 자동 prepend (`cross_validate.sh` 경유 시 자동, 직접 호출 시 수동 포함 권고)
+- L3 워킹트리 snapshot 가드 (#479) 가 사후 검증 + 자동 롤백 수행 — 직접 호출 시 워킹트리 변경 가능성 인지
+- 외부 모델 출력을 맹목적으로 수용하지 않는다. Claude 가 반드시 재분석한다.
+- 검증 결과는 로그 파일에 기록한다 (`${LOG_DIR}/cross-validate-<type>-<timestamp>.log`)
+- 민감한 정보(시크릿, 인증 토큰)가 포함된 파일은 외부 모델에 전달하지 않는다 (`is_sensitive()` 자동 필터).
 - 두 모델의 합의된 문제는 우선적으로 해결한다.
+- capacity 실패 시 cross_validate.sh 가 자동 폴백 (재시도 → claude-only fallback exit 77). stderr 패턴: `^Error: (timed out|rate limit|quota|not logged|unauthorized|forbidden)`
+
+## 환경변수 (cross_validate.sh)
+
+| 변수 | 기본 | 설명 |
+|---|---|---|
+| `EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS` | 5 | 재시도 sleep 단위 (테스트는 0) |
+| `EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP` | 300 | sleep 상한 (지수 backoff cap) |
+| `EXTERNAL_VALIDATOR_PRINT_TIMEOUT` | 300s | agy `--print-timeout` 값 |
+| `SKIP_CAPACITY_PROBE` | 0 | 1 이면 capacity probe 생략 (free tier quota 보존) |
+| `LOG_DIR` | `${PROJECT_DIR}/.claude/logs` | 로그 출력 디렉토리 (테스트 격리) |
+| `CROSS_VALIDATE_ANCHOR` | (없음) | 폴백 시 reminder 이슈 생성 트리거 |
+| `REMINDER_ISSUE_DRYRUN` | 1 | 0 이면 실제 reminder 이슈 생성 |
+
+### backward-compat alias (Phase 4 #272 에서 제거 예정)
+- `GEMINI_MODEL` — agy 는 모델 옵션 없음. 설정 시 WARN 만 출력하고 무시
+- `GEMINI_RETRY_SLEEP_SECONDS` → `EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS` alias (silent)
+- `GEMINI_RETRY_SLEEP_CAP` → `EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP` alias (silent)

--- a/.claude/skills/cross-validate/scripts/cross_validate.sh
+++ b/.claude/skills/cross-validate/scripts/cross_validate.sh
@@ -342,24 +342,27 @@ check_external_capacity() {
   local probe_stdout probe_stderr probe_rc
   local probe_stderr_file
   probe_stderr_file=$(mktemp)
+  # agy 권고 제안 1 수용 (PR #275 dogfooding): SIGINT/SIGTERM 또는 set -e 조기 이탈 시 임시 파일 누수 차단
+  # RETURN trap 은 함수 종료 시점에 호출되며 호출자로 전파 안 됨 (bash 기본 INHERITRC 비활성)
+  trap "rm -f '${probe_stderr_file}'" RETURN
   # capacity probe — 빠른 응답 (30s) timeout, 정상 응답은 1~3s 안에 옴
   probe_stdout=$(agy --print-timeout 30s -p "hello" 2>"${probe_stderr_file}") && probe_rc=0 || probe_rc=$?
   probe_stderr=$(cat "${probe_stderr_file}")
-  rm -f "${probe_stderr_file}"
 
   # 정상 응답: 비어있지 않은 stdout + stderr Error 없음 (exit code 무관 — agy 는 항상 0)
-  if [ -n "${probe_stdout}" ] && ! echo "${probe_stderr}" | grep -qE "^Error: "; then
+  # agy 권고 제안 2 수용: echo "${var}" 는 `-e/-n` 시작 문자열에서 옵션 파싱 오동작 가능 → printf '%s\n' 사용
+  if [ -n "${probe_stdout}" ] && ! printf '%s\n' "${probe_stderr}" | grep -qE "^Error: "; then
     return "${CAPACITY_OK}"
   fi
 
   # capacity 실패 패턴 매칭 — PoC T2 발견 + 추정 패턴 (rate limit/quota/not logged)
-  if echo "${probe_stderr}" | grep -qE "^Error: (timed out|rate limit|quota|not logged|unauthorized|forbidden)"; then
-    log "capacity 체크 결과: agy capacity 부족 또는 인증 문제 (code=${CAPACITY_EXHAUSTED}) — $(echo "${probe_stderr}" | head -1)"
+  if printf '%s\n' "${probe_stderr}" | grep -qE "^Error: (timed out|rate limit|quota|not logged|unauthorized|forbidden)"; then
+    log "capacity 체크 결과: agy capacity 부족 또는 인증 문제 (code=${CAPACITY_EXHAUSTED}) — $(printf '%s\n' "${probe_stderr}" | head -1)"
     return "${CAPACITY_EXHAUSTED}"
   fi
 
   # 그 외: 알 수 없는 probe 실패
-  log "capacity 체크 결과: 비-capacity probe 실패 (code=${CAPACITY_OTHER_ERROR}) — stdout=$(echo "${probe_stdout}" | head -1) stderr=$(echo "${probe_stderr}" | head -1)"
+  log "capacity 체크 결과: 비-capacity probe 실패 (code=${CAPACITY_OTHER_ERROR}) — stdout=$(printf '%s\n' "${probe_stdout}" | head -1) stderr=$(printf '%s\n' "${probe_stderr}" | head -1)"
   return "${CAPACITY_OTHER_ERROR}"
 }
 
@@ -440,9 +443,16 @@ run_external_validator() {
   # L1: prompt 에 strict prefix 자동 prepend (호출 측 PROMPT 변경 없이 일괄 적용)
   local guarded_prompt="${EXTERNAL_VALIDATOR_STRICT_PREFIX}${prompt}"
 
+  # agy 권고 제안 1 수용 (PR #275 dogfooding): mktemp 임시 파일 누수 차단 (SIGINT/SIGTERM 또는 set -e 조기 이탈)
+  # 루프 안에서 새 mktemp 가 생성되므로 trap 의 변수 참조는 RETURN 시점의 최종 값을 사용 (마지막 루프 반복의 파일만 cleanup)
+  # 이를 보강하기 위해 루프 안에서 명시적 rm 도 유지 (이중 안전망)
+  local stdout_file=""
+  local stderr_file=""
+  trap "rm -f \"\${stdout_file:-}\" \"\${stderr_file:-}\"" RETURN
+
   while [ "${attempt}" -le "${MAX_EXTERNAL_VALIDATOR_RETRIES}" ]; do
     log "외부 검증 모델 (agy) 실행 중 (시도: ${attempt}/${MAX_EXTERNAL_VALIDATOR_RETRIES}, timeout: ${EXTERNAL_VALIDATOR_PRINT_TIMEOUT})..."
-    local stdout_file stderr_file stdout_content stderr_content
+    local stdout_content stderr_content
     stdout_file=$(mktemp)
     stderr_file=$(mktemp)
     # agy 호출 — stdout/stderr 분리, --print-timeout 으로 wait 한계 설정
@@ -453,8 +463,9 @@ run_external_validator() {
     rm -f "${stdout_file}" "${stderr_file}"
 
     # 정상 응답 판정: 비어있지 않은 stdout + stderr Error 패턴 없음
-    if [ -n "${stdout_content}" ] && ! echo "${stderr_content}" | grep -qE "^Error: "; then
-      echo "${stdout_content}" | tee -a "${LOG_FILE}"
+    # agy 권고 제안 2 수용: echo "${var}" 는 `-e/-n` 시작 문자열에서 옵션 파싱 오동작 가능 → printf '%s\n' 사용
+    if [ -n "${stdout_content}" ] && ! printf '%s\n' "${stderr_content}" | grep -qE "^Error: "; then
+      printf '%s\n' "${stdout_content}" | tee -a "${LOG_FILE}"
       # stderr 가 비어있지 않으면 (정상 경로의 부수 메시지) 로그에만 남김
       if [ -n "${stderr_content}" ]; then
         printf '%s\n' "${stderr_content}" >> "${LOG_FILE}"
@@ -463,8 +474,8 @@ run_external_validator() {
     fi
 
     # capacity 실패 패턴 매칭 — PoC T2 (`Error: timed out`) + 추정 패턴
-    if echo "${stderr_content}" | grep -qE "^Error: (timed out|rate limit|quota|not logged|unauthorized|forbidden)"; then
-      log "경고: agy capacity/인증 실패 (시도 ${attempt}/${MAX_EXTERNAL_VALIDATOR_RETRIES}) — $(echo "${stderr_content}" | head -1)"
+    if printf '%s\n' "${stderr_content}" | grep -qE "^Error: (timed out|rate limit|quota|not logged|unauthorized|forbidden)"; then
+      log "경고: agy capacity/인증 실패 (시도 ${attempt}/${MAX_EXTERNAL_VALIDATOR_RETRIES}) — $(printf '%s\n' "${stderr_content}" | head -1)"
       if [ "${attempt}" -lt "${MAX_EXTERNAL_VALIDATOR_RETRIES}" ]; then
         # 폴백 프로토콜 단계 1: 지연 후 (선택적으로) capacity 체크 + 재시도
         # sleep 공식: MIN(SLEEP_CAP, 2^attempt * BASE) — Phase A 의 지수 공식에
@@ -503,7 +514,8 @@ run_external_validator() {
       fi
       attempt=$((attempt + 1))
     else
-      log "경고: agy 실패 (비-capacity 오류) — stdout=$(echo "${stdout_content}" | head -1) stderr=$(echo "${stderr_content}" | head -1)"
+      # agy 권고 제안 2 수용: printf '%s\n' 사용
+      log "경고: agy 실패 (비-capacity 오류) — stdout=$(printf '%s\n' "${stdout_content}" | head -1) stderr=$(printf '%s\n' "${stderr_content}" | head -1)"
       printf 'stdout:\n%s\nstderr:\n%s\n' "${stdout_content}" "${stderr_content}" >> "${LOG_FILE}"
       fatal=1
       break

--- a/.claude/skills/cross-validate/scripts/cross_validate.sh
+++ b/.claude/skills/cross-validate/scripts/cross_validate.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Gemini CLI를 활용한 교차검증 스크립트
+# 외부 검증 모델 (Antigravity `agy`) 를 활용한 교차검증 스크립트
+# Phase 1A (#269) 부터 gemini-cli → agy 교체. ADR: docs/decisions/20260521-gemini-to-antigravity.md
+# 보호 모델 — L1 (prompt strict prefix) + L3 (snapshot diff + 자동 롤백, #479)
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -27,9 +29,9 @@ usage() {
   exit 1
 }
 
-# Gemini CLI 확인
-if ! command -v gemini &> /dev/null; then
-  echo "에러: gemini CLI가 설치되어 있지 않습니다."
+# 외부 검증 모델 CLI 확인 (Antigravity `agy`)
+if ! command -v agy &> /dev/null; then
+  echo "에러: agy (Antigravity CLI) 가 설치되어 있지 않습니다. https://antigravity.google/docs/cli-overview 참조."
   exit 1
 fi
 
@@ -74,11 +76,12 @@ REMINDER_ISSUE_RESULT="none"
 
 # plan-mode 우회 감지 결과 추적 (#479) — snapshot_pre / snapshot_post_and_rollback 이 저장
 # write_outcome_json 이 소비. 초기값은 호출 전 false / 빈 배열 / false (정상 상태).
-#   PLAN_BYPASS:     Gemini 호출 전후 워킹트리 변경 감지 여부
+#   PLAN_BYPASS:     외부 검증 모델 (agy) 호출 전후 워킹트리 변경 감지 여부
 #   BYPASS_FILES:    감지된 파일 경로 배열 (bash 배열)
 #   ROLLBACK_FAILED: 자동 롤백 시도 중 실패한 파일이 있는지 (CRITICAL — 수동 개입 필요)
-# Gemini Q1 수용: tracked 변경 + untracked 신규 파일 모두 추적
-# Gemini Q2 수용: 롤백 자체 실패 케이스 별도 필드로 분리
+# Phase 1A (#269): agy 는 --print mode 에서 도구 자동 실행 + --approval-mode plan 등가 부재 (PoC).
+#   사후 snapshot diff + 자동 롤백이 L3 핵심 보호. L1 (prompt strict prefix) 과 이중 가드.
+# 과거 (gemini 시점) reviewer 권고 박제: Q1 tracked + untracked 모두 추적, Q2 롤백 실패 케이스 분리
 PLAN_BYPASS=false
 BYPASS_FILES=()
 ROLLBACK_FAILED=false
@@ -114,13 +117,15 @@ json_array_from_bash_array() {
 
 # outcome JSON 파일 출력
 # architect.md step 8 규약: 이 파일을 읽어 extends.cross_validate_outcome 에 매핑
-# outcome 값 규약:
-#   "applied"                  — Gemini 정상 응답 수신 (exit 0)
-#   "429-fallback-claude-only" — 429 최종 실패 폴백 (exit 77)
+# outcome 값 규약 (backward-compat 유지 — 5 agents `parse-cross-validate-outcome.sh` 와 정합성):
+#   "applied"                  — 외부 검증 모델 (agy) 정상 응답 수신 (exit 0)
+#   "429-fallback-claude-only" — capacity 최종 실패 폴백 (exit 77). Phase 1A 부터 agy 의
+#                                timeout / rate limit / quota / not logged 모두 본 sentinel
+#                                로 통합. 명칭 일반화는 별도 PR (sentinel 변경 시 5 agents 동기화 필수)
 #   "fatal-error"              — 비-capacity 치명적 오류 (exit 1)
 #
 # Phase 4 (#479) 확장 — plan-mode 우회 가드 3 필드:
-#   plan_bypass:     boolean — Gemini 호출 전후 워킹트리 변경 감지 여부
+#   plan_bypass:     boolean — 외부 검증 모델 (agy) 호출 전후 워킹트리 변경 감지 여부
 #   bypass_files:    string[] — 감지된 파일 경로 배열
 #   rollback_failed: boolean — 자동 롤백 시도 중 실패가 있었는지 (true 면 수동 개입)
 # backward compat: 기존 8 필드 (outcome / exit_code / anchor / pr_ref / context /
@@ -166,9 +171,10 @@ EOF
 # plan-mode 우회 가드 — 호출 전 워킹트리 snapshot (#479)
 # 결정점 1: D 방식 (porcelain + hash-object 혼합)
 #   - tracked 파일은 hash-object 로 정확 검증 (성능 부담 < 100ms)
-#   - untracked 는 porcelain ?? 프리픽스로 별도 식별 (Gemini Q1 수용)
+#   - untracked 는 porcelain ?? 프리픽스로 별도 식별
 # git 저장소가 아닌 경로에서 호출되면 silent skip (가드 비활성).
 # 비-범위: .gitignore 이용 무시 파일 동시 수정 완전 방어는 후속 분리.
+# Phase 1A (#269): agy 는 --print mode 에서 도구 자동 실행 → L3 (본 가드) 가 최종 안전망.
 snapshot_pre() {
   if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
     log "plan-bypass 가드: git 저장소가 아닌 경로 — 가드 비활성"
@@ -192,8 +198,8 @@ snapshot_pre() {
 # plan-mode 우회 가드 — 호출 후 diff 검증 + 자동 롤백 (#479)
 # 결정점 2: R4 (자동 롤백 + 사용자 사후 알림)
 # 결정점 1: tracked 는 hash-object 비교, untracked 는 신규 라인 비교
-# Gemini Q2 수용: 롤백 실패 케이스를 ROLLBACK_FAILED 로 분리
-# .gitignore 변경 시 CRITICAL 격상 (Gemini Q1 부분 수용)
+# Q2 (과거 gemini 시점 reviewer 권고) 수용: 롤백 실패 케이스를 ROLLBACK_FAILED 로 분리
+# .gitignore 변경 시 CRITICAL 격상
 snapshot_post_and_rollback() {
   # snapshot_pre 가 skip 된 경우 (git 저장소 아님) 본 함수도 skip
   if [ -z "${PRE_TRACKED_HASHES}" ] || [ ! -f "${PRE_TRACKED_HASHES}" ]; then
@@ -263,17 +269,17 @@ snapshot_post_and_rollback() {
   fi
 
   # stderr 경고 (CRITICAL 위반 즉시 차단 시각화)
-  echo "WARN: Gemini plan-mode bypass detected — ${#BYPASS_FILES[@]} files modified, auto-rollback applied" >&2
+  echo "WARN: external validator (agy) plan-mode bypass detected — ${#BYPASS_FILES[@]} files modified, auto-rollback applied" >&2
   # `${ROLLBACK_FAILED:+...}` 는 변수가 비어있지 않으면 (값이 'true' 또는 'false' 어느 쪽이든)
   # 텍스트를 출력하므로 실제 실패 여부와 무관. 명시적 비교로 교체.
   local rollback_status="성공"
   [ "${ROLLBACK_FAILED}" = "true" ] && rollback_status="일부 실패"
   log "plan-bypass 가드: ${#BYPASS_FILES[@]}개 파일 감지 — 자동 롤백 (${rollback_status})"
 
-  # .gitignore 변경은 CRITICAL — 별도 경고 (Gemini Q1 부분 수용)
+  # .gitignore 변경은 CRITICAL — 별도 경고
   # 무시 대상 파일 동시 수정 false negative 위험. 사용자 수동 검증 권고.
   if [ "${gitignore_modified}" = "true" ]; then
-    echo "CRITICAL: .gitignore modified by Gemini — 무시 파일 동시 수정 false negative 위험. 수동 검증 필요." >&2
+    echo "CRITICAL: .gitignore modified by external validator (agy) — 무시 파일 동시 수정 false negative 위험. 수동 검증 필요." >&2
     log "plan-bypass 가드 CRITICAL: .gitignore 변경 감지 — 사용자 수동 검증 의무"
   fi
 
@@ -283,17 +289,35 @@ snapshot_post_and_rollback() {
   fi
 }
 
-# Gemini 모델 설정 — 경량 모델 폴백 없음 (교차검증 품질 보존)
-GEMINI_MODEL="${GEMINI_MODEL:-gemini-2.5-pro}"
-MAX_GEMINI_RETRIES=2
+# 외부 검증 모델 (agy) 설정
+# Phase 1A (#269) 부터: agy 는 모델 선택 옵션 부재 — 백엔드 자동 결정
+# `GEMINI_MODEL` 환경변수는 deprecated, 설정되어 있어도 무시 (사용자 가시성 WARN)
+if [ -n "${GEMINI_MODEL:-}" ]; then
+  echo "WARN: GEMINI_MODEL 환경변수는 Phase 1A 부터 deprecated 입니다 (agy 는 모델 옵션 부재). 무시됩니다. Phase 4 (#272) 에서 제거 예정." >&2
+fi
+
+MAX_EXTERNAL_VALIDATOR_RETRIES=2
 # 재시도 간 sleep 단위 (초). 테스트에서는 0 으로 설정해 실행 시간 단축.
-GEMINI_RETRY_SLEEP_SECONDS="${GEMINI_RETRY_SLEEP_SECONDS:-5}"
+# backward-compat: GEMINI_RETRY_SLEEP_SECONDS alias 인식 (1 릴리스 동안 silent, Phase 4 에서 제거)
+EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS="${EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS:-${GEMINI_RETRY_SLEEP_SECONDS:-5}}"
 # sleep 상한 (초). 지수 backoff 가 MAX_RETRIES 증설 시 폭증하는 것을 방지.
 # reviewer non-blocking (#137, v2.21.0~ #131 Phase B): MIN(cap, 2^attempt * BASE)
-GEMINI_RETRY_SLEEP_CAP="${GEMINI_RETRY_SLEEP_CAP:-300}"
-# capacity probe 옵트아웃. 기본 0 (수행). 권고 4 (#131 Phase B): probe (`gemini -p "hello"`)
-# 자체가 free tier quota 를 소모하므로 429 가 이미 감지된 상황에선 생략이 유리할 수 있다.
+EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP="${EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP:-${GEMINI_RETRY_SLEEP_CAP:-300}}"
+# capacity probe 옵트아웃. 기본 0 (수행). 권고 4 (#131 Phase B): probe (`agy -p "hello"`)
+# 자체가 free tier quota 를 소모하므로 capacity 부족이 이미 감지된 상황에선 생략이 유리할 수 있다.
 SKIP_CAPACITY_PROBE="${SKIP_CAPACITY_PROBE:-0}"
+
+# L1 가드 — agy 가 도구 호출을 수행하지 않도록 prompt 에 자동 prepend (#269 Phase 0 PoC)
+# agy --print mode 는 도구 호출을 silent 자동 승인 → prompt 레벨 차단 필수
+# PoC T10/T11 실측: agy 가 "DO NOT execute" 지시를 순순히 따름 (효과 확인)
+EXTERNAL_VALIDATOR_STRICT_PREFIX="STRICT INSTRUCTION: You are performing read-only code review and analysis. Do NOT execute any shell command or tool. Do NOT modify any file. Respond ONLY with text-based analysis. If you would have used a tool, describe in text what you would have done.
+
+---
+
+"
+
+# agy --print-timeout 기본값 (초). 응답 대기 한계. agy 의 default 는 5m (300s).
+EXTERNAL_VALIDATOR_PRINT_TIMEOUT="${EXTERNAL_VALIDATOR_PRINT_TIMEOUT:-300s}"
 
 # Exit code 규약 (CLAUDE.md API capacity 폴백 프로토콜)
 # 0  = Gemini 정상 응답 수신
@@ -301,7 +325,7 @@ SKIP_CAPACITY_PROBE="${SKIP_CAPACITY_PROBE:-0}"
 # 1  = 그 외 실패 (인자 오류 / 파일 부재 / 민감 파일 등)
 EXIT_CLAUDE_ONLY_FALLBACK=77
 
-# check_gemini_capacity 반환 코드 규약 (reviewer 권고 2, #131 Phase A)
+# check_external_capacity 반환 코드 규약 (reviewer 권고 2, #131 Phase A — gemini 시점부터 유지)
 # 0 = capacity 복구 (probe 성공)
 # 2 = 여전히 429/503/500 — capacity 부족 (재시도 의미 낮음)
 # 1 = 비-429 probe 실패 (네트워크/인증 등 — 기타 오류와 구분)
@@ -310,16 +334,32 @@ CAPACITY_OK=0
 CAPACITY_EXHAUSTED=2
 CAPACITY_OTHER_ERROR=1
 
-# Gemini capacity 체크 — `gemini -p "hello"` 로 빠른 응답성 확인
+# 외부 검증 모델 (agy) capacity 체크 — `agy -p "hello"` 로 빠른 응답성 확인
 # CLAUDE.md `## 교차검증` API capacity 폴백 프로토콜 단계 1
-check_gemini_capacity() {
-  local probe_output
-  probe_output=$(gemini -m "${GEMINI_MODEL}" -p "hello" --approval-mode plan 2>&1) && return "${CAPACITY_OK}"
-  if echo "${probe_output}" | grep -qE "RESOURCE_EXHAUSTED|429|503|500"; then
-    log "capacity 체크 결과: 여전히 용량 부족 (code=${CAPACITY_EXHAUSTED})"
+# Phase 1A (#269): agy 는 timeout/capacity 실패 시에도 exit 0 반환 (PoC T2 실측) —
+# stderr 의 `^Error: ` 패턴 매칭으로 판정. exit code 는 보조 신호.
+check_external_capacity() {
+  local probe_stdout probe_stderr probe_rc
+  local probe_stderr_file
+  probe_stderr_file=$(mktemp)
+  # capacity probe — 빠른 응답 (30s) timeout, 정상 응답은 1~3s 안에 옴
+  probe_stdout=$(agy --print-timeout 30s -p "hello" 2>"${probe_stderr_file}") && probe_rc=0 || probe_rc=$?
+  probe_stderr=$(cat "${probe_stderr_file}")
+  rm -f "${probe_stderr_file}"
+
+  # 정상 응답: 비어있지 않은 stdout + stderr Error 없음 (exit code 무관 — agy 는 항상 0)
+  if [ -n "${probe_stdout}" ] && ! echo "${probe_stderr}" | grep -qE "^Error: "; then
+    return "${CAPACITY_OK}"
+  fi
+
+  # capacity 실패 패턴 매칭 — PoC T2 발견 + 추정 패턴 (rate limit/quota/not logged)
+  if echo "${probe_stderr}" | grep -qE "^Error: (timed out|rate limit|quota|not logged|unauthorized|forbidden)"; then
+    log "capacity 체크 결과: agy capacity 부족 또는 인증 문제 (code=${CAPACITY_EXHAUSTED}) — $(echo "${probe_stderr}" | head -1)"
     return "${CAPACITY_EXHAUSTED}"
   fi
-  log "capacity 체크 결과: 비-capacity probe 실패 (code=${CAPACITY_OTHER_ERROR}) — $(echo "${probe_output}" | head -1)"
+
+  # 그 외: 알 수 없는 probe 실패
+  log "capacity 체크 결과: 비-capacity probe 실패 (code=${CAPACITY_OTHER_ERROR}) — stdout=$(echo "${probe_stdout}" | head -1) stderr=$(echo "${probe_stderr}" | head -1)"
   return "${CAPACITY_OTHER_ERROR}"
 }
 
@@ -335,7 +375,7 @@ create_reminder_issue() {
   body=$(cat <<BODY
 ## 배경
 
-cross-validate 스킬 실행 중 Gemini API capacity 소진으로 **claude-only fallback** 발생. CLAUDE.md \`## 교차검증\` API capacity 폴백 프로토콜 단계 3 (노출 효율 최대 앵커 해당 시 reminder 이슈 박제) 에 따라 API 복구 후 재검증용 이슈 박제.
+cross-validate 스킬 실행 중 외부 검증 모델 (agy) capacity 소진 또는 인증 문제로 **claude-only fallback** 발생. CLAUDE.md \`## 교차검증\` API capacity 폴백 프로토콜 단계 3 (노출 효율 최대 앵커 해당 시 reminder 이슈 박제) 에 따라 복구 후 재검증용 이슈 박제.
 
 ## 맥락
 
@@ -353,13 +393,13 @@ cross-validate 스킬 실행 중 Gemini API capacity 소진으로 **claude-only 
 
 ## 완료 기준
 
-- [ ] Gemini API 복구 확인 (\`gemini -p "hello"\`)
+- [ ] agy 응답성 복구 확인 (\`agy -p "hello"\`)
 - [ ] 원 컨텍스트에 대해 cross-validate 재실행
 - [ ] 결과를 원 PR / ADR / CHANGELOG 해당 위치에 박제
 - [ ] 재시도 성공 시 본 이슈 close
 BODY
 )
-  local title="[cross-validate reminder] ${context} — Gemini capacity 복구 후 재시도 (${anchor})"
+  local title="[cross-validate reminder] ${context} — agy 응답성 복구 후 재시도 (${anchor})"
   if [ "${REMINDER_ISSUE_DRYRUN:-1}" = "0" ]; then
     log "reminder 이슈 생성 (실제)"
     # gh issue create 의 성공/실패를 실측해 REMINDER_ISSUE_RESULT 에 반영 (reviewer 차단 반영)
@@ -379,55 +419,72 @@ BODY
   fi
 }
 
-# Gemini 실행 (읽기 전용)
+# 외부 검증 모델 (agy) 실행 (L1 prompt-level read-only)
 # CLAUDE.md `## 교차검증` API capacity 폴백 프로토콜:
-#   1. 1차 429/timeout → capacity 체크 + 지연 후 1회 재시도
+#   1. 1차 capacity 실패 → capacity 체크 + 지연 후 1회 재시도
 #   2. 2차 실패 → claude-only analysis completed 프리픽스 + exit 77
 #   3. 앵커 해당 시 reminder 이슈 박제
 # 앵커 컨텍스트는 호출 측에서 CROSS_VALIDATE_ANCHOR 환경변수로 전달 가능
-run_gemini() {
+#
+# Phase 1A (#269) 변경:
+#   - L1: prompt 에 EXTERNAL_VALIDATOR_STRICT_PREFIX 자동 prepend (도구 호출 차단)
+#   - capacity 판정: stderr `^Error: ` 패턴 매칭 (agy exit code 는 timeout 도 0 — PoC T2)
+#   - stdout/stderr 분리 처리 (이전: 2>&1 합쳐서 처리)
+run_external_validator() {
   local prompt="$1"
   local attempt=1
   local fatal=0
   # Phase B (reviewer #140 권고 3): 루프 내 사용 변수를 함수 스코프에 local 선언해 전역 유출 방지
   local raw_sleep=0
   local capacity_rc=0
+  # L1: prompt 에 strict prefix 자동 prepend (호출 측 PROMPT 변경 없이 일괄 적용)
+  local guarded_prompt="${EXTERNAL_VALIDATOR_STRICT_PREFIX}${prompt}"
 
-  while [ "${attempt}" -le "${MAX_GEMINI_RETRIES}" ]; do
-    log "Gemini 실행 중 (모델: ${GEMINI_MODEL}, 시도: ${attempt}/${MAX_GEMINI_RETRIES})..."
-    local output
-    output=$(gemini -m "${GEMINI_MODEL}" -p "${prompt}" --approval-mode plan 2>&1) && {
-      echo "${output}" | tee -a "${LOG_FILE}"
+  while [ "${attempt}" -le "${MAX_EXTERNAL_VALIDATOR_RETRIES}" ]; do
+    log "외부 검증 모델 (agy) 실행 중 (시도: ${attempt}/${MAX_EXTERNAL_VALIDATOR_RETRIES}, timeout: ${EXTERNAL_VALIDATOR_PRINT_TIMEOUT})..."
+    local stdout_file stderr_file stdout_content stderr_content
+    stdout_file=$(mktemp)
+    stderr_file=$(mktemp)
+    # agy 호출 — stdout/stderr 분리, --print-timeout 으로 wait 한계 설정
+    # `|| true` 는 set -e 회피 (agy 는 exit code 신뢰 불가 — stderr 패턴으로 판정)
+    agy --print-timeout "${EXTERNAL_VALIDATOR_PRINT_TIMEOUT}" -p "${guarded_prompt}" >"${stdout_file}" 2>"${stderr_file}" || true
+    stdout_content=$(cat "${stdout_file}")
+    stderr_content=$(cat "${stderr_file}")
+    rm -f "${stdout_file}" "${stderr_file}"
+
+    # 정상 응답 판정: 비어있지 않은 stdout + stderr Error 패턴 없음
+    if [ -n "${stdout_content}" ] && ! echo "${stderr_content}" | grep -qE "^Error: "; then
+      echo "${stdout_content}" | tee -a "${LOG_FILE}"
+      # stderr 가 비어있지 않으면 (정상 경로의 부수 메시지) 로그에만 남김
+      if [ -n "${stderr_content}" ]; then
+        printf '%s\n' "${stderr_content}" >> "${LOG_FILE}"
+      fi
       return 0
-    }
+    fi
 
-    if echo "${output}" | grep -qE "RESOURCE_EXHAUSTED|429|503|500"; then
-      log "경고: ${GEMINI_MODEL} 용량 부족 (시도 ${attempt}/${MAX_GEMINI_RETRIES})"
-      if [ "${attempt}" -lt "${MAX_GEMINI_RETRIES}" ]; then
+    # capacity 실패 패턴 매칭 — PoC T2 (`Error: timed out`) + 추정 패턴
+    if echo "${stderr_content}" | grep -qE "^Error: (timed out|rate limit|quota|not logged|unauthorized|forbidden)"; then
+      log "경고: agy capacity/인증 실패 (시도 ${attempt}/${MAX_EXTERNAL_VALIDATOR_RETRIES}) — $(echo "${stderr_content}" | head -1)"
+      if [ "${attempt}" -lt "${MAX_EXTERNAL_VALIDATOR_RETRIES}" ]; then
         # 폴백 프로토콜 단계 1: 지연 후 (선택적으로) capacity 체크 + 재시도
         # sleep 공식: MIN(SLEEP_CAP, 2^attempt * BASE) — Phase A 의 지수 공식에
-        #   Phase B (reviewer non-blocking) 상한 cap 을 추가. MAX_RETRIES=10 이상에서도
-        #   sleep 이 GEMINI_RETRY_SLEEP_CAP (기본 300s) 이하로 보장됨.
-        # 테스트 환경에서는 GEMINI_RETRY_SLEEP_SECONDS=0 으로 sleep 생략
-        if [ "${GEMINI_RETRY_SLEEP_SECONDS}" -gt 0 ]; then
-          raw_sleep=$(( (1 << attempt) * GEMINI_RETRY_SLEEP_SECONDS ))
-          if [ "${raw_sleep}" -gt "${GEMINI_RETRY_SLEEP_CAP}" ]; then
-            log "sleep cap ${GEMINI_RETRY_SLEEP_CAP}s 적용 (원시 ${raw_sleep}s, attempt=${attempt})"
-            raw_sleep="${GEMINI_RETRY_SLEEP_CAP}"
+        #   Phase B (reviewer non-blocking) 상한 cap 을 추가.
+        # 테스트 환경에서는 EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS=0 (또는 GEMINI_RETRY_SLEEP_SECONDS=0 alias) 으로 sleep 생략
+        if [ "${EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS}" -gt 0 ]; then
+          raw_sleep=$(( (1 << attempt) * EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS ))
+          if [ "${raw_sleep}" -gt "${EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP}" ]; then
+            log "sleep cap ${EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP}s 적용 (원시 ${raw_sleep}s, attempt=${attempt})"
+            raw_sleep="${EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP}"
           fi
           sleep "${raw_sleep}"
         fi
         # 권고 4 (#131 Phase B) — probe 옵트아웃
-        # SKIP_CAPACITY_PROBE=1 설정 시 probe 호출 생략 → free tier quota 보존
-        # 호출 측이 "429 이면 재시도도 어차피 429" 를 확신할 때 비용 절약 경로
         if [ "${SKIP_CAPACITY_PROBE}" = "1" ]; then
           log "capacity probe 생략 (SKIP_CAPACITY_PROBE=1) — 바로 재시도"
         else
           # 반환 코드 3값 분기 (reviewer 권고 2, #131 Phase A)
-          # Gemini 교차검증 (#137) 고유 발견 반영: CAPACITY_OTHER_ERROR 케이스 명시 +
-          # `*)` 는 알 수 없는 code 방어용 (향후 반환 코드 추가 시 조용한 오분기 방지)
           capacity_rc=0
-          check_gemini_capacity || capacity_rc=$?
+          check_external_capacity || capacity_rc=$?
           case "${capacity_rc}" in
             "${CAPACITY_OK}")
               log "capacity 복구 감지 — 재시도 진행"
@@ -436,7 +493,7 @@ run_gemini() {
               log "capacity 여전히 부족 — 재시도 진행하되 조기 포기 가능성 높음"
               ;;
             "${CAPACITY_OTHER_ERROR}")
-              log "capacity probe 실패 (비-429) — 재시도는 진행 (probe 자체 이슈일 수 있음)"
+              log "capacity probe 실패 (비-capacity) — 재시도는 진행 (probe 자체 이슈일 수 있음)"
               ;;
             *)
               log "알 수 없는 capacity_rc (${capacity_rc}) — 재시도 진행 (방어적 분기)"
@@ -446,8 +503,8 @@ run_gemini() {
       fi
       attempt=$((attempt + 1))
     else
-      log "경고: ${GEMINI_MODEL} 실패 (비-capacity 오류) — $(echo "${output}" | head -3)"
-      echo "${output}" >> "${LOG_FILE}"
+      log "경고: agy 실패 (비-capacity 오류) — stdout=$(echo "${stdout_content}" | head -1) stderr=$(echo "${stderr_content}" | head -1)"
+      printf 'stdout:\n%s\nstderr:\n%s\n' "${stdout_content}" "${stderr_content}" >> "${LOG_FILE}"
       fatal=1
       break
     fi
@@ -458,12 +515,12 @@ run_gemini() {
   log "${fallback_msg}"
   echo "${fallback_msg}" >&2
   # stdout 헤더 (reviewer 권고 1, #131 Phase A) — 호출 측이 stdout 만으로 fallback 모드 감지 가능
-  # 정상 경로 stdout 에는 Gemini 응답 본문이 출력됨. fallback 경로는 본문이 없으므로 이 프리픽스가 signal.
+  # 정상 경로 stdout 에는 agy 응답 본문이 출력됨. fallback 경로는 본문이 없으므로 이 프리픽스가 signal.
   # NOTE (qa non-blocking, #131 Phase B): fatal 경로 (비-capacity 오류, exit 1) 도 이 헤더를
-  #   동일하게 출력한다. fatal vs 429 정확 구분은 outcome JSON 의 "outcome" 필드를 참조해야 하며
+  #   동일하게 출력한다. fatal vs capacity 정확 구분은 outcome JSON 의 "outcome" 필드를 참조해야 하며
   #   (scripts/parse-cross-validate-outcome.sh 헬퍼 사용 권장), stdout 헤더 단독으로는 구분 불가.
-  echo "[claude-only-fallback] Gemini ${GEMINI_MODEL} 응답 없음 — Claude 단독 분석 (교차검증 미확보)"
-  echo "⚠ 교차검증 불가 — Claude 단독 분석. Gemini ${GEMINI_MODEL} 응답 없음." | tee -a "${LOG_FILE}"
+  echo "[claude-only-fallback] agy (Antigravity CLI) 응답 없음 — Claude 단독 분석 (교차검증 미확보)"
+  echo "⚠ 교차검증 불가 — Claude 단독 분석. agy (Antigravity CLI) 응답 없음." | tee -a "${LOG_FILE}"
 
   # 폴백 프로토콜 단계 3: 앵커 컨텍스트 있으면 reminder 이슈 (dry-run 기본)
   if [ -n "${CROSS_VALIDATE_ANCHOR:-}" ]; then
@@ -491,7 +548,7 @@ is_sensitive() {
 }
 
 # plan-mode 우회 가드 — 호출 전 워킹트리 snapshot (#479)
-# Gemini 호출 (run_gemini) 직전에 실행해 사전 상태를 박제.
+# 외부 검증 모델 호출 (run_external_validator) 직전에 실행해 사전 상태를 박제.
 # 사후 비교는 case 분기 후 snapshot_post_and_rollback 으로 수행.
 snapshot_pre
 
@@ -516,7 +573,7 @@ case "${TYPE}" in
 한국어로 답변해주세요.
 PROMPT_END
 )"
-    run_gemini "${PROMPT}" || RC=$?
+    run_external_validator "${PROMPT}" || RC=$?
     ;;
 
   code)
@@ -571,7 +628,7 @@ ${DIFF}
 한국어로 항목별 평가(양호/주의/위험)와 구체적 개선 제안을 해주세요.
 PROMPT_END
 )"
-    run_gemini "${PROMPT}" || RC=$?
+    run_external_validator "${PROMPT}" || RC=$?
     ;;
 
   architecture)
@@ -613,7 +670,7 @@ ${DOC_CONTENT}
 한국어로 항목별 평가와 개선 제안을 해주세요.
 PROMPT_END
 )"
-    run_gemini "${PROMPT}" || RC=$?
+    run_external_validator "${PROMPT}" || RC=$?
     ;;
 
   skill)
@@ -664,7 +721,7 @@ ${EVALS_INFO}
 한국어로 항목별 평가와 개선 제안을 해주세요.
 PROMPT_END
 )"
-    run_gemini "${PROMPT}" || RC=$?
+    run_external_validator "${PROMPT}" || RC=$?
     ;;
 
   *)
@@ -678,7 +735,7 @@ log "=== 교차검증 완료 ==="
 log "로그: ${LOG_FILE}"
 
 # plan-mode 우회 가드 — 호출 후 diff 검증 + 자동 롤백 (#479)
-# Gemini 호출 직후 워킹트리 변경이 있는지 검증. 변경 발견 시 자동 롤백 + PLAN_BYPASS=true.
+# 외부 검증 모델 호출 직후 워킹트리 변경이 있는지 검증. 변경 발견 시 자동 롤백 + PLAN_BYPASS=true.
 # 결과는 write_outcome_json 이 outcome JSON 의 plan_bypass / bypass_files / rollback_failed 필드에 박제.
 snapshot_post_and_rollback
 
@@ -695,5 +752,5 @@ log "outcome: ${OUTCOME} (exit ${FINAL_RC}) — ${OUTCOME_FILE}"
 # stdout 파싱 편의용 prefix — 호출 측은 grep '^\[outcome-file\] ' 로 추출
 echo "[outcome-file] ${OUTCOME_FILE}"
 
-# run_gemini 가 77 (claude-only fallback) 또는 1 (fatal) 을 반환한 경우 스크립트도 동일 코드로 종료
+# run_external_validator 가 77 (claude-only fallback) 또는 1 (fatal) 을 반환한 경우 스크립트도 동일 코드로 종료
 exit "${FINAL_RC}"

--- a/test/cross-validate-diff-truncation.test.js
+++ b/test/cross-validate-diff-truncation.test.js
@@ -22,9 +22,9 @@ const SCRIPT_PATH = path.join(
   '.claude/skills/cross-validate/scripts/cross_validate.sh'
 );
 
-// mock gh + gemini 바이너리 생성.
+// mock gh + agy 바이너리 생성 (Phase 1A — gemini → agy 어댑터 교체).
 // gh pr diff <N> 는 지정된 라인 수만큼 fake diff 출력,
-// gh pr view ... 는 고정 PR 메타, gemini 는 정상 응답을 낸다.
+// gh pr view ... 는 고정 PR 메타, agy 는 정상 응답을 낸다.
 // 각 라인을 40자 이상으로 채워 총 용량이 64KB 파이프 버퍼를 초과하도록 구성.
 function setupMocks(diffLines) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-cv-diff-'));
@@ -51,14 +51,14 @@ exit 0
 `;
   fs.writeFileSync(ghPath, ghScript, { mode: 0o755 });
 
-  const geminiPath = path.join(tmpDir, 'gemini');
+  const agyPath = path.join(tmpDir, 'agy');
   fs.writeFileSync(
-    geminiPath,
-    `#!/bin/bash\necho "mock gemini review"\nexit 0\n`,
+    agyPath,
+    `#!/bin/bash\necho "mock agy review"\nexit 0\n`,
     { mode: 0o755 }
   );
 
-  return { tmpDir, ghPath, geminiPath };
+  return { tmpDir, ghPath, agyPath };
 }
 
 function setupLogDir() {
@@ -68,7 +68,8 @@ function setupLogDir() {
 function runScript(args, env) {
   return spawnSync('bash', [SCRIPT_PATH, ...args], {
     cwd: PROJECT_DIR,
-    env: { ...process.env, GEMINI_RETRY_SLEEP_SECONDS: '0', ...env },
+    // Phase 1A: 신규 변수 이름. alias (GEMINI_RETRY_SLEEP_SECONDS) backward-compat 는 fallback.test.js 에서 별도 검증
+    env: { ...process.env, EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS: '0', ...env },
     encoding: 'utf8',
     timeout: 60_000,
   });

--- a/test/cross-validate-fallback.test.js
+++ b/test/cross-validate-fallback.test.js
@@ -1,14 +1,21 @@
 // cross_validate.sh 의 API capacity 폴백 프로토콜 스모크 테스트
 // CLAUDE.md `## 교차검증` API capacity 폴백 프로토콜 준수 여부를
-// mock gemini 바이너리로 시뮬레이션해 검증한다.
+// mock agy (Antigravity CLI) 바이너리로 시뮬레이션해 검증한다.
 //
-// 검증 항목:
-// - 429 시뮬레이션 → capacity 체크 실행 + 재시도 + 최종 claude-only fallback
+// Phase 1A (#269) 변경: gemini-cli → agy 어댑터 교체.
+//   - mock 바이너리 이름: gemini → agy
+//   - mock 동작: agy 는 timeout/capacity 실패 시에도 exit 0 + stderr `^Error: ` 패턴 (PoC T2)
+//   - env 변수: GEMINI_RETRY_SLEEP_SECONDS → EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS
+//   - backward-compat: GEMINI_RETRY_SLEEP_SECONDS alias 인식 검증 케이스 별도 유지
+//
+// 검증 항목 (기존 + Phase 1A):
+// - capacity 실패 (stderr `Error: timed out`) 시뮬레이션 → capacity 체크 실행 + 재시도 + 최종 claude-only fallback
 // - exit code 77 (EXIT_CLAUDE_ONLY_FALLBACK) 반환
 // - stderr 에 "claude-only analysis completed" 프리픽스 출력
 // - CROSS_VALIDATE_ANCHOR 환경변수 있을 때 reminder 이슈 dry-run 출력
 // - CROSS_VALIDATE_ANCHOR 없을 때 dry-run 생략
 // - 정상 응답 시 exit 0 + dry-run 출력 없음
+// - outcome JSON sentinel "429-fallback-claude-only" 유지 (5 agents backward-compat, D-8)
 
 const { test } = require('node:test');
 const assert = require('node:assert');
@@ -20,24 +27,29 @@ const os = require('node:os');
 const PROJECT_DIR = path.resolve(__dirname, '..');
 const SCRIPT_PATH = path.join(PROJECT_DIR, '.claude/skills/cross-validate/scripts/cross_validate.sh');
 
-// mock gemini 바이너리 생성 헬퍼
-// mode: '429' | 'ok' | 'fatal' | 'recover-after-1' | '429-counted'
-//   recover-after-1: 1차 호출 429, 2차 이후 정상 — 복구 분기 검증 (reviewer 권고 6, #131 Phase A)
-//   429-counted: 모든 호출 429, 호출 횟수를 counter 파일에 기록 — probe 생략 검증 (권고 4, #131 Phase B)
-function setupMockGemini(mode) {
+// mock agy 바이너리 생성 헬퍼 (Phase 1A — 함수 이름 도구 중립)
+// mode: 'capacity' | 'ok' | 'fatal' | 'recover-after-1' | 'capacity-counted'
+//   capacity:          모든 호출 stderr `Error: timed out`, exit 0 (PoC T2 패턴)
+//   ok:                정상 응답, stdout 응답 + exit 0
+//   fatal:             비-capacity 패턴 stderr (`Error: invalid argument`), exit 2
+//   recover-after-1:   1차 capacity 실패, 2차+ 정상 — 복구 분기 검증 (reviewer 권고 6, #131 Phase A)
+//   capacity-counted:  모든 호출 capacity 실패, 호출 횟수를 counter 파일에 기록 — probe 생략 검증 (권고 4, #131 Phase B)
+function setupMockAgy(mode) {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-cv-mock-'));
-  const mockPath = path.join(tmpDir, 'gemini');
+  const mockPath = path.join(tmpDir, 'agy');
   const counterPath = path.join(tmpDir, 'counter');
   let script;
-  if (mode === '429') {
-    // 모든 호출 실패 (capacity 체크 + 재시도 모두 429)
-    script = `#!/bin/bash\necho "Error: 429 RESOURCE_EXHAUSTED" >&2\nexit 1\n`;
+  if (mode === 'capacity') {
+    // 모든 호출 capacity 실패 (capacity 체크 + 재시도 모두 timeout 패턴)
+    // PoC T2 발견: agy 는 timeout 시에도 exit 0 + stderr `Error: timed out waiting for response`
+    script = `#!/bin/bash\necho "Error: timed out waiting for response" >&2\nexit 0\n`;
   } else if (mode === 'ok') {
-    script = `#!/bin/bash\necho "mock gemini response"\nexit 0\n`;
+    script = `#!/bin/bash\necho "mock agy response"\nexit 0\n`;
   } else if (mode === 'fatal') {
+    // 비-capacity 패턴 (timed out/rate limit/quota/not logged 미포함) → fatal 분기
     script = `#!/bin/bash\necho "Error: invalid argument" >&2\nexit 2\n`;
   } else if (mode === 'recover-after-1') {
-    // 임시 디렉토리 내 counter 파일로 호출 순번 추적 — 1차 429, 2차+ 정상
+    // 임시 디렉토리 내 counter 파일로 호출 순번 추적 — 1차 capacity 실패, 2차+ 정상
     script = `#!/bin/bash
 COUNTER_FILE="${counterPath}"
 count=0
@@ -45,22 +57,22 @@ if [ -f "\${COUNTER_FILE}" ]; then count=$(cat "\${COUNTER_FILE}"); fi
 count=$((count + 1))
 echo "\${count}" > "\${COUNTER_FILE}"
 if [ "\${count}" = "1" ]; then
-  echo "Error: 429 RESOURCE_EXHAUSTED" >&2
-  exit 1
+  echo "Error: timed out waiting for response" >&2
+  exit 0
 fi
-echo "mock gemini recovered response (call \${count})"
+echo "mock agy recovered response (call \${count})"
 exit 0
 `;
-  } else if (mode === '429-counted') {
-    // 모든 호출 429 + 호출 횟수 counter 기록 — SKIP_CAPACITY_PROBE 검증용 (권고 4, #131 Phase B)
+  } else if (mode === 'capacity-counted') {
+    // 모든 호출 capacity 실패 + 호출 횟수 counter 기록 — SKIP_CAPACITY_PROBE 검증용 (권고 4, #131 Phase B)
     script = `#!/bin/bash
 COUNTER_FILE="${counterPath}"
 count=0
 if [ -f "\${COUNTER_FILE}" ]; then count=$(cat "\${COUNTER_FILE}"); fi
 count=$((count + 1))
 echo "\${count}" > "\${COUNTER_FILE}"
-echo "Error: 429 RESOURCE_EXHAUSTED" >&2
-exit 1
+echo "Error: timed out waiting for response" >&2
+exit 0
 `;
   } else {
     throw new Error(`unknown mode: ${mode}`);
@@ -80,7 +92,8 @@ function runScript(args, env) {
     env: {
       ...process.env,
       // 테스트에서는 sleep 생략 — 재시도 로직 자체만 검증
-      GEMINI_RETRY_SLEEP_SECONDS: '0',
+      // Phase 1A: 신규 변수 이름. alias (GEMINI_RETRY_SLEEP_SECONDS) 는 별도 테스트로 검증
+      EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS: '0',
       ...env,
     },
     encoding: 'utf8',
@@ -99,16 +112,16 @@ function readOutcomeFromDir(logDir) {
   return JSON.parse(fs.readFileSync(files[0].full, 'utf8'));
 }
 
-test('cross-validate: 429 응답 → claude-only fallback exit code 77', () => {
-  const { tmpDir, mockPath } = setupMockGemini('429');
+test('cross-validate: capacity 실패 (Error: timed out) → claude-only fallback exit code 77', () => {
+  const { tmpDir, mockPath } = setupMockAgy('capacity');
   try {
-    // MAX_GEMINI_RETRIES 는 스크립트 내부 고정값(2) — 실행 시간 단축 위해 sleep 을 회피하는
-    // 환경변수가 없으므로 짧은 structure 프롬프트로 테스트 (sleep 총 5초 이내)
+    // MAX_EXTERNAL_VALIDATOR_RETRIES 는 스크립트 내부 고정값(2) — 실행 시간 단축 위해 sleep 을 회피하는
+    // 환경변수가 없으므로 짧은 structure 프롬프트로 테스트
     const result = runScript(['structure'], {
       PATH: `${tmpDir}:${process.env.PATH}`,
       REMINDER_ISSUE_DRYRUN: '1',
     });
-    assert.strictEqual(result.status, 77, `exit code 77 기대, 실제: ${result.status}`);
+    assert.strictEqual(result.status, 77, `exit code 77 기대, 실제: ${result.status}, stderr: ${result.stderr}`);
     assert.ok(
       result.stderr.includes('claude-only analysis completed'),
       `stderr 에 claude-only 프리픽스 기대. 실제 stderr: ${result.stderr}`
@@ -119,7 +132,7 @@ test('cross-validate: 429 응답 → claude-only fallback exit code 77', () => {
 });
 
 test('cross-validate: CROSS_VALIDATE_ANCHOR 설정 시 reminder 이슈 dry-run 출력', () => {
-  const { tmpDir } = setupMockGemini('429');
+  const { tmpDir } = setupMockAgy('capacity');
   try {
     const result = runScript(['structure'], {
       PATH: `${tmpDir}:${process.env.PATH}`,
@@ -141,7 +154,7 @@ test('cross-validate: CROSS_VALIDATE_ANCHOR 설정 시 reminder 이슈 dry-run �
 });
 
 test('cross-validate: CROSS_VALIDATE_ANCHOR 미설정 시 dry-run 생략', () => {
-  const { tmpDir } = setupMockGemini('429');
+  const { tmpDir } = setupMockAgy('capacity');
   try {
     const result = runScript(['structure'], {
       PATH: `${tmpDir}:${process.env.PATH}`,
@@ -159,7 +172,7 @@ test('cross-validate: CROSS_VALIDATE_ANCHOR 미설정 시 dry-run 생략', () =>
 });
 
 test('cross-validate: 정상 응답 → exit 0', () => {
-  const { tmpDir } = setupMockGemini('ok');
+  const { tmpDir } = setupMockAgy('ok');
   try {
     const result = runScript(['structure'], {
       PATH: `${tmpDir}:${process.env.PATH}`,
@@ -176,7 +189,7 @@ test('cross-validate: 정상 응답 → exit 0', () => {
 });
 
 test('cross-validate: 비-capacity fatal 오류 → exit 1 (claude-only 시그널 아님)', () => {
-  const { tmpDir } = setupMockGemini('fatal');
+  const { tmpDir } = setupMockAgy('fatal');
   try {
     const result = runScript(['structure'], {
       PATH: `${tmpDir}:${process.env.PATH}`,
@@ -190,9 +203,11 @@ test('cross-validate: 비-capacity fatal 오류 → exit 1 (claude-only 시그�
 
 // Phase 3 (#131) — outcome JSON 파일 출력 + architect 자동 매핑 근거 검증
 // 테스트 격리: 각 테스트가 자체 LOG_DIR 사용 (reviewer 권고 5)
+// Phase 1A (#269) — outcome sentinel "429-fallback-claude-only" 는 backward-compat 위해 유지 (D-8).
+//   agy 의 timeout/capacity 실패도 본 sentinel 로 통합. 명칭 일반화는 별도 PR.
 
-test('cross-validate outcome: 429 응답 → outcome JSON 에 "429-fallback-claude-only" 기록', () => {
-  const { tmpDir } = setupMockGemini('429');
+test('cross-validate outcome: capacity 실패 → outcome JSON 에 "429-fallback-claude-only" 기록 (backward-compat sentinel)', () => {
+  const { tmpDir } = setupMockAgy('capacity');
   const logDir = setupLogDir();
   try {
     const result = runScript(['structure'], {
@@ -222,7 +237,7 @@ test('cross-validate outcome: 429 응답 → outcome JSON 에 "429-fallback-clau
 });
 
 test('cross-validate outcome: 정상 응답 → outcome JSON 에 "applied" 기록', () => {
-  const { tmpDir } = setupMockGemini('ok');
+  const { tmpDir } = setupMockAgy('ok');
   const logDir = setupLogDir();
   try {
     const result = runScript(['structure'], {
@@ -244,7 +259,7 @@ test('cross-validate outcome: 정상 응답 → outcome JSON 에 "applied" 기�
 });
 
 test('cross-validate outcome: fatal 오류 → outcome JSON 에 "fatal-error" 기록', () => {
-  const { tmpDir } = setupMockGemini('fatal');
+  const { tmpDir } = setupMockAgy('fatal');
   const logDir = setupLogDir();
   try {
     const result = runScript(['structure'], {
@@ -267,8 +282,8 @@ test('cross-validate outcome: fatal 오류 → outcome JSON 에 "fatal-error" �
 
 // Phase A (#131) — 권고 1, 6 추가 검증
 
-test('cross-validate: 1차 429 → capacity 복구 → 2차 정상 응답 → exit 0 (복구 분기, 권고 6)', () => {
-  const { tmpDir } = setupMockGemini('recover-after-1');
+test('cross-validate: 1차 capacity 실패 → 복구 → 2차 정상 응답 → exit 0 (복구 분기, 권고 6)', () => {
+  const { tmpDir } = setupMockAgy('recover-after-1');
   const logDir = setupLogDir();
   try {
     const result = runScript(['structure'], {
@@ -276,7 +291,7 @@ test('cross-validate: 1차 429 → capacity 복구 → 2차 정상 응답 → ex
       LOG_DIR: logDir,
       REMINDER_ISSUE_DRYRUN: '1',
     });
-    // 1차 429 → check_gemini_capacity (2차 호출, ok) → run_gemini 재시도 (3차 호출, ok) → exit 0
+    // 1차 capacity 실패 → check_external_capacity (2차 호출, ok) → run_external_validator 재시도 (3차 호출, ok) → exit 0
     assert.strictEqual(result.status, 0, `복구 후 exit 0 기대. 실제: ${result.status}, stderr: ${result.stderr}`);
     // fallback 프리픽스는 없어야 함 (최종적으로 성공)
     assert.ok(
@@ -298,8 +313,8 @@ test('cross-validate: 1차 429 → capacity 복구 → 2차 정상 응답 → ex
   }
 });
 
-test('cross-validate: 429 fallback 시 stdout 에 [claude-only-fallback] 헤더 출력 (권고 1)', () => {
-  const { tmpDir } = setupMockGemini('429');
+test('cross-validate: capacity fallback 시 stdout 에 [claude-only-fallback] 헤더 출력 (권고 1)', () => {
+  const { tmpDir } = setupMockAgy('capacity');
   try {
     const result = runScript(['structure'], {
       PATH: `${tmpDir}:${process.env.PATH}`,
@@ -319,7 +334,7 @@ test('cross-validate: 429 fallback 시 stdout 에 [claude-only-fallback] 헤더 
 // Phase B (#131) — 권고 4 (SKIP_CAPACITY_PROBE) / sleep cap / 헬퍼 스크립트
 
 test('cross-validate: SKIP_CAPACITY_PROBE=1 → probe 호출 생략, mock 호출 횟수 = MAX_RETRIES (권고 4)', () => {
-  const { tmpDir, counterPath } = setupMockGemini('429-counted');
+  const { tmpDir, counterPath } = setupMockAgy('capacity-counted');
   const logDir = setupLogDir();
   try {
     const result = runScript(['structure'], {
@@ -329,7 +344,7 @@ test('cross-validate: SKIP_CAPACITY_PROBE=1 → probe 호출 생략, mock 호출
       SKIP_CAPACITY_PROBE: '1',
     });
     assert.strictEqual(result.status, 77);
-    // probe 생략 시 mock gemini 호출은 run_gemini 의 재시도 루프 횟수만 (= MAX_GEMINI_RETRIES = 2)
+    // probe 생략 시 mock agy 호출은 run_external_validator 의 재시도 루프 횟수만 (= MAX_EXTERNAL_VALIDATOR_RETRIES = 2)
     // probe 가 활성이었다면 3번 호출 (초기 + probe + 재시도)
     const callCount = parseInt(fs.readFileSync(counterPath, 'utf8').trim(), 10);
     assert.strictEqual(callCount, 2, `SKIP_PROBE=1 시 mock 호출 2회 기대. 실제: ${callCount}`);
@@ -344,7 +359,7 @@ test('cross-validate: SKIP_CAPACITY_PROBE=1 → probe 호출 생략, mock 호출
 });
 
 test('cross-validate: SKIP_CAPACITY_PROBE=0 (기본) → probe 호출 수행, mock 호출 횟수 = 3', () => {
-  const { tmpDir, counterPath } = setupMockGemini('429-counted');
+  const { tmpDir, counterPath } = setupMockAgy('capacity-counted');
   const logDir = setupLogDir();
   try {
     const result = runScript(['structure'], {
@@ -353,7 +368,7 @@ test('cross-validate: SKIP_CAPACITY_PROBE=0 (기본) → probe 호출 수행, mo
       REMINDER_ISSUE_DRYRUN: '1',
     });
     assert.strictEqual(result.status, 77);
-    // 기본값: probe 활성 → 3번 호출 (초기 429 + probe 429 + 재시도 429)
+    // 기본값: probe 활성 → 3번 호출 (초기 capacity 실패 + probe capacity 실패 + 재시도 capacity 실패)
     const callCount = parseInt(fs.readFileSync(counterPath, 'utf8').trim(), 10);
     assert.strictEqual(callCount, 3, `기본 probe 활성 시 mock 호출 3회 기대. 실제: ${callCount}`);
   } finally {
@@ -362,8 +377,8 @@ test('cross-validate: SKIP_CAPACITY_PROBE=0 (기본) → probe 호출 수행, mo
   }
 });
 
-test('cross-validate: GEMINI_RETRY_SLEEP_CAP 적용 시 cap 로그 출력', () => {
-  const { tmpDir } = setupMockGemini('429');
+test('cross-validate: EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP 적용 시 cap 로그 출력', () => {
+  const { tmpDir } = setupMockAgy('capacity');
   const logDir = setupLogDir();
   try {
     // sleep cap 로그 검증 — raw=2*100=200s > cap=1s 이므로 cap 적용
@@ -372,8 +387,8 @@ test('cross-validate: GEMINI_RETRY_SLEEP_CAP 적용 시 cap 로그 출력', () =
       PATH: `${tmpDir}:${process.env.PATH}`,
       LOG_DIR: logDir,
       REMINDER_ISSUE_DRYRUN: '1',
-      GEMINI_RETRY_SLEEP_SECONDS: '100',
-      GEMINI_RETRY_SLEEP_CAP: '1',
+      EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS: '100',
+      EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP: '1',
     });
     assert.strictEqual(result.status, 77);
     // 로그 파일에서 cap 적용 메시지 확인
@@ -387,6 +402,48 @@ test('cross-validate: GEMINI_RETRY_SLEEP_CAP 적용 시 cap 로그 출력', () =
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
     fs.rmSync(logDir, { recursive: true, force: true });
+  }
+});
+
+// Phase 1A (#269) — backward-compat alias 검증
+// GEMINI_MODEL / GEMINI_RETRY_SLEEP_SECONDS / GEMINI_RETRY_SLEEP_CAP 는 1 릴리스 동안 alias 인식
+
+test('cross-validate (alias): GEMINI_RETRY_SLEEP_SECONDS alias 인식 — capacity 실패 시나리오 정상 동작', () => {
+  const { tmpDir } = setupMockAgy('capacity');
+  try {
+    const result = runScript(['structure'], {
+      PATH: `${tmpDir}:${process.env.PATH}`,
+      REMINDER_ISSUE_DRYRUN: '1',
+      // EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS 제거 (alias 가 채용되도록)
+      EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS: undefined,
+      GEMINI_RETRY_SLEEP_SECONDS: '0',  // alias
+    });
+    // alias 로도 sleep 회피 + exit 77 정상 (재시도 로직 자체는 동작)
+    assert.strictEqual(result.status, 77, `alias 로도 exit 77 기대. 실제: ${result.status}`);
+    assert.ok(
+      result.stderr.includes('claude-only analysis completed'),
+      `alias 로도 fallback 프리픽스 기대`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('cross-validate (alias): GEMINI_MODEL 설정 시 WARN 출력 (deprecated 안내)', () => {
+  const { tmpDir } = setupMockAgy('ok');
+  try {
+    const result = runScript(['structure'], {
+      PATH: `${tmpDir}:${process.env.PATH}`,
+      REMINDER_ISSUE_DRYRUN: '1',
+      GEMINI_MODEL: 'gemini-2.5-pro',  // deprecated 환경변수
+    });
+    assert.strictEqual(result.status, 0, `WARN 만 출력하고 정상 진행 기대. 실제: ${result.status}`);
+    assert.ok(
+      result.stderr.includes('GEMINI_MODEL') && result.stderr.includes('deprecated'),
+      `GEMINI_MODEL deprecated WARN 기대. 실제 stderr: ${result.stderr}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 });
 
@@ -433,7 +490,7 @@ test('parse-helper: outcome JSON 직접 파싱 → KEY=value 형식 stdout 출�
   }
 });
 
-test('parse-helper: 429 fallback outcome JSON → exit_code=77 + reminder 추출', () => {
+test('parse-helper: capacity fallback outcome JSON → exit_code=77 + reminder 추출', () => {
   const logDir = setupLogDir();
   try {
     const outcomeFile = writeOutcomeJson(logDir, {
@@ -481,7 +538,7 @@ test('parse-helper: --from-stdout 모드 → [outcome-file] 프리픽스 자동 
       timestamp: '2026-04-19T00:00:00Z',
     });
     // cross_validate.sh stdout 모방
-    const fakeStdout = `Some gemini response body\n[outcome-file] ${outcomeFile}\n`;
+    const fakeStdout = `Some agy response body\n[outcome-file] ${outcomeFile}\n`;
     const result = runHelper(['--from-stdout'], fakeStdout);
     assert.strictEqual(result.status, 0);
     assert.match(result.stdout, /CROSS_VALIDATE_OUTCOME="applied"/);
@@ -501,7 +558,7 @@ test('parse-helper: --from-stdout 에서 프리픽스 부재 → OUTCOME="missin
 });
 
 test('parse-helper + cross_validate.sh 통합: 실제 outcome JSON 파싱 (정상 경로)', () => {
-  const { tmpDir } = setupMockGemini('ok');
+  const { tmpDir } = setupMockAgy('ok');
   const logDir = setupLogDir();
   try {
     const result = runScript(['structure'], {

--- a/test/parse-cross-validate-outcome-boundary.test.js
+++ b/test/parse-cross-validate-outcome-boundary.test.js
@@ -29,13 +29,14 @@ const CROSS_VALIDATE_SCRIPT = path.join(
 );
 const PARSE_HELPER = path.join(PROJECT_DIR, 'scripts/parse-cross-validate-outcome.sh');
 
-// mock gemini (ok 모드) 생성 — write 경로까지 정상 도달시키려면 최소 1회 성공 응답 필요
-function setupMockGemini() {
+// mock agy (ok 모드) 생성 — write 경로까지 정상 도달시키려면 최소 1회 성공 응답 필요
+// Phase 1A (#269): gemini-cli → agy 어댑터 교체 반영
+function setupMockAgy() {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-cv-boundary-'));
-  const mockPath = path.join(tmpDir, 'gemini');
+  const mockPath = path.join(tmpDir, 'agy');
   fs.writeFileSync(
     mockPath,
-    `#!/bin/bash\necho "mock gemini boundary-test response"\nexit 0\n`,
+    `#!/bin/bash\necho "mock agy boundary-test response"\nexit 0\n`,
     { mode: 0o755 }
   );
   return { tmpDir, mockPath };
@@ -49,7 +50,8 @@ function runCrossValidate(anchor, logDir, mockDir) {
       PATH: `${mockDir}:${process.env.PATH}`,
       LOG_DIR: logDir,
       CROSS_VALIDATE_ANCHOR: anchor,
-      GEMINI_RETRY_SLEEP_SECONDS: '0',
+      // Phase 1A: 신규 변수 이름
+      EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS: '0',
     },
     encoding: 'utf8',
     timeout: 30_000,
@@ -92,7 +94,7 @@ function runParseHelper(outcomePath) {
 // 검증한다 (완전한 언이스케이프가 아니라 escape 보존을 검증).
 function runBoundaryCase(label, anchorValue, expectedEscapedSubstring) {
   const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-cv-boundary-logs-'));
-  const { tmpDir: mockDir } = setupMockGemini();
+  const { tmpDir: mockDir } = setupMockAgy();
   try {
     const result = runCrossValidate(anchorValue, logDir, mockDir);
     assert.strictEqual(
@@ -164,7 +166,7 @@ test('boundary regression guard: carriage return 포함 anchor round-trip', () =
 test('boundary regression guard: 혼합 경계 문자 (write/parse contract 종합)', () => {
   // 모든 escape 대상이 섞인 anchor 로 파이프라인 전체 계약 종합 검증
   const logDir = fs.mkdtempSync(path.join(os.tmpdir(), 'harness-cv-boundary-logs-'));
-  const { tmpDir: mockDir } = setupMockGemini();
+  const { tmpDir: mockDir } = setupMockAgy();
   try {
     const anchor = 'A\\B"C\tD\nE\rF';
     const result = runCrossValidate(anchor, logDir, mockDir);


### PR DESCRIPTION
## 요약
- Phase 1A — 2026-06-18 Gemini CLI 종료 대응 (#267 트래킹)
- cross_validate.sh: `gemini` → `agy` 어댑터, 함수 이름 도구 중립화, capacity 분기 재설계 (stderr 패턴 매칭)
- L1 strict prompt prefix + L3 snapshot 가드 이중 보호 (PoC #268 결과 반영)
- **MAJOR** — 다운스트림 필수 조치: agy 설치 + OAuth 로그인

## 변경 사항

### 코드 (`.claude/skills/cross-validate/scripts/cross_validate.sh`)
- `run_gemini` → `run_external_validator` (L1 strict prefix 자동 prepend)
- `check_gemini_capacity` → `check_external_capacity` (stderr `^Error: (timed out|rate limit|quota|not logged|unauthorized|forbidden)` 매칭)
- `GEMINI_MODEL` 환경변수 deprecated (WARN + 무시) — agy 는 모델 옵션 부재 (PoC)
- `GEMINI_RETRY_SLEEP_SECONDS/CAP` → `EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS/CAP` (alias 인식, Phase 4 제거 예정)
- 신규 `EXTERNAL_VALIDATOR_PRINT_TIMEOUT` (기본 300s)
- 신규 `EXTERNAL_VALIDATOR_STRICT_PREFIX` 상수 (L1 가드)
- snapshot 가드 (#479) WARN/CRITICAL 메시지 도구 중립화
- reminder 이슈 본문 도구 중립

### 스킬 (`.claude/skills/cross-validate/SKILL.md`)
- frontmatter description 도구 중립 + `agy로 확인` / `gemini로 확인` (alias) 양쪽 TRIGGER
- 사전 조건: `agy -p "hello"`
- 4 검증 유형 호출 예제 모두 L1 strict prefix 포함
- §결과 분석 / §수용 vs 후속 분리 / §규칙 도구 중립화
- 신규 §환경변수 표 + backward-compat alias 안내

### 테스트
- `test/cross-validate-fallback.test.js` (전면 재작성): mock `gemini` → `agy`, mode 이름 변경 (`'429'` → `'capacity'`), mock script: stderr `Error: timed out` + exit 0 (PoC T2)
- `test/cross-validate-diff-truncation.test.js`: mock `gemini` → `agy`, env 변수 신규 이름
- `test/parse-cross-validate-outcome-boundary.test.js`: mock `gemini` → `agy`
- **backward-compat alias 검증 테스트 2건 신설** (GEMINI_RETRY_SLEEP_SECONDS / GEMINI_MODEL WARN)
- 나머지 4 테스트 (sentinels/package-leak/doctor-gitflow/verify-docs-links) 는 역사적 인용 보존

## Behavior Changes (CHANGELOG 박제 예정)
- `cross-validate` 스킬이 `gemini-cli` 대신 `agy` (Antigravity CLI) 호출
- `GEMINI_MODEL` 환경변수 deprecated (WARN + 무시). agy 는 모델 선택 옵션 부재 (백엔드 자동)
- 다운스트림 필수 조치: agy 설치 (https://antigravity.google/docs/cli-overview) + OAuth 로그인. `gemini` 명령은 더 이상 호출되지 않음
- plan-mode 우회 가드 (#479) 동작 모델 변경 — 사전 차단 (`--approval-mode plan`) → L1 (prompt strict prefix) + L3 (사후 snapshot diff) 이중 가드. agy 는 `--approval-mode plan` 등가 옵션 부재
- capacity 분기 판정 변경: exit code → **stderr `^Error: ` 패턴 매칭** (agy 는 timeout 시에도 exit 0)
- outcome sentinel `"429-fallback-claude-only"` 명칭은 backward-compat 유지 (5 agents `parse-cross-validate-outcome.sh` 와 정합성). 명칭 일반화는 별도 PR

## 영향 범위
- harness-setting 자체 cross-validate 스킬 호출 모두 (Architect / Reviewer / QA 페르소나)
- 다운스트림 (`harness update` 적용 시): agy 설치 필요
- CHANGELOG 갱신 + 다음 릴리스 시 MAJOR 분류 (`v3.0.0` 또는 현 흐름의 MAJOR bump)
- 본 PR 의 영향 가드: 단위 137/137 PASS + verify-agent-ssot 45/45 PASS (drift 0)

## 테스트 계획
- [x] `npm test` — 137/137 PASS (cross-validate 28 + alias 검증 2 + boundary 5 등)
- [x] `bash scripts/verify-agent-ssot.sh` — 5 files × 9 fields = 45 checks 통과
- [x] cross_validate.sh bash 문법 검증
- [x] 한글 인코딩 검증 (5 파일 모두 0 U+FFFD)
- [ ] **dogfooding cross-validate** — `bash .claude/skills/cross-validate/scripts/cross_validate.sh skill cross-validate` 1회 (ADR Proposed 박제 직후 루틴, CLAUDE.md §교차검증)
- [ ] reviewer 사전 검토 (sub-agent)
- [ ] **(별도 세션)** 다운스트림 (astro-simulator) `harness update` 적용 + 실측

## 의존성
- **PR #273** (ADR Proposed `20260521-gemini-to-antigravity`) 머지 후 본 PR ADR Accepted 박제 의도. PR #273 결정 변경 시 본 PR 재작업 위험
- **PR #274** (.gitignore `.antigravitycli/`) — 독립, 머지 순서 무관

## 관련 이슈
- Closes #269 (Phase 1A)
- Tracked in #267 (마이그레이션 트래킹)
- 의존: #268 (Phase 0 PoC 결과 반영)
- 후속: #270 (Phase 2 행동 박제) / #271 (Phase 3 문서) / #272 (Phase 4 gemini 제거)
- 영향 받는 가드: #479 (plan-mode 우회 자동 감지)

## 메모 — 잔여 미확인
- agy 의 실제 OAuth 만료 / 429 / quota 실측은 데몬 재시작 필요 (PoC 잔여). Phase 1A 머지 후 실 운영 중 stderr 패턴 발견 시 별도 박제 권고
- `~/.gemini/antigravity-cli/settings.json::trustedWorkspaces` 자동 등록 (PoC 부수 발견) — 별건 모니터링

## 메타 체크리스트
- [x] CRITICAL #1 base=develop 준수
- [x] CRITICAL #4 한글 인코딩 0 U+FFFD (5 파일)
- [x] CRITICAL #6 Sprint Contract — 본 PR DoD 7건 합의 (기획서 §6)
- [x] sub-agent SSoT 9 필드 무결성 (drift 0)
- [ ] reviewer 권고 반영
- [ ] dogfooding cross-validate 결과 본 PR 코멘트 박제
- [ ] **(별도 세션)** 다운스트림 실측