### PR TITLE
[#276] feat(cross-validate): GEMINI_RETRY_* alias WARN — Phase 4 사전 deprecation 노출 (MINOR, ex-#279)

### DIFF
--- a/.claude/skills/cross-validate/SKILL.md
+++ b/.claude/skills/cross-validate/SKILL.md
@@ -252,5 +252,5 @@ harness #89 (post-apply 게이트) 교차검증에서 Gemini (당시 백엔드) 
 
 ### backward-compat alias (Phase 4 #272 에서 제거 예정)
 - `GEMINI_MODEL` — agy 는 모델 옵션 없음. 설정 시 WARN 만 출력하고 무시
-- `GEMINI_RETRY_SLEEP_SECONDS` → `EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS` alias (silent)
-- `GEMINI_RETRY_SLEEP_CAP` → `EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP` alias (silent)
+- `GEMINI_RETRY_SLEEP_SECONDS` → `EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS` alias (#276 부터 사용 시 stderr WARN 출력)
+- `GEMINI_RETRY_SLEEP_CAP` → `EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP` alias (#276 부터 사용 시 stderr WARN 출력)

--- a/.claude/skills/cross-validate/scripts/cross_validate.sh
+++ b/.claude/skills/cross-validate/scripts/cross_validate.sh
@@ -298,10 +298,18 @@ fi
 
 MAX_EXTERNAL_VALIDATOR_RETRIES=2
 # 재시도 간 sleep 단위 (초). 테스트에서는 0 으로 설정해 실행 시간 단축.
-# backward-compat: GEMINI_RETRY_SLEEP_SECONDS alias 인식 (1 릴리스 동안 silent, Phase 4 에서 제거)
+# backward-compat: GEMINI_RETRY_SLEEP_SECONDS alias 인식 (1 릴리스 동안 — Phase 4 #272 에서 제거)
+# #276: silent → WARN 으로 전환. 사용자 가시성 강화 (Phase 4 제거 사전 안내)
+if [ -n "${GEMINI_RETRY_SLEEP_SECONDS:-}" ]; then
+  echo "WARN: GEMINI_RETRY_SLEEP_SECONDS 환경변수는 Phase 1A 부터 deprecated 입니다. EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS 를 사용하세요. Phase 4 (#272) 에서 제거 예정." >&2
+fi
 EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS="${EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS:-${GEMINI_RETRY_SLEEP_SECONDS:-5}}"
 # sleep 상한 (초). 지수 backoff 가 MAX_RETRIES 증설 시 폭증하는 것을 방지.
 # reviewer non-blocking (#137, v2.21.0~ #131 Phase B): MIN(cap, 2^attempt * BASE)
+# #276: silent → WARN 으로 전환 (위와 동일 사유)
+if [ -n "${GEMINI_RETRY_SLEEP_CAP:-}" ]; then
+  echo "WARN: GEMINI_RETRY_SLEEP_CAP 환경변수는 Phase 1A 부터 deprecated 입니다. EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP 를 사용하세요. Phase 4 (#272) 에서 제거 예정." >&2
+fi
 EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP="${EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP:-${GEMINI_RETRY_SLEEP_CAP:-300}}"
 # capacity probe 옵트아웃. 기본 0 (수행). 권고 4 (#131 Phase B): probe (`agy -p "hello"`)
 # 자체가 free tier quota 를 소모하므로 capacity 부족이 이미 감지된 상황에선 생략이 유리할 수 있다.

--- a/test/cross-validate-fallback.test.js
+++ b/test/cross-validate-fallback.test.js
@@ -408,7 +408,7 @@ test('cross-validate: EXTERNAL_VALIDATOR_RETRY_SLEEP_CAP 적용 시 cap 로그 �
 // Phase 1A (#269) — backward-compat alias 검증
 // GEMINI_MODEL / GEMINI_RETRY_SLEEP_SECONDS / GEMINI_RETRY_SLEEP_CAP 는 1 릴리스 동안 alias 인식
 
-test('cross-validate (alias): GEMINI_RETRY_SLEEP_SECONDS alias 인식 — capacity 실패 시나리오 정상 동작', () => {
+test('cross-validate (alias #276): GEMINI_RETRY_SLEEP_SECONDS alias 인식 + WARN 출력', () => {
   const { tmpDir } = setupMockAgy('capacity');
   try {
     const result = runScript(['structure'], {
@@ -423,6 +423,29 @@ test('cross-validate (alias): GEMINI_RETRY_SLEEP_SECONDS alias 인식 — capaci
     assert.ok(
       result.stderr.includes('claude-only analysis completed'),
       `alias 로도 fallback 프리픽스 기대`
+    );
+    // #276: alias 사용 시 WARN 출력 (Phase 4 제거 사전 안내)
+    assert.ok(
+      result.stderr.includes('GEMINI_RETRY_SLEEP_SECONDS') && result.stderr.includes('deprecated'),
+      `#276 — GEMINI_RETRY_SLEEP_SECONDS deprecated WARN 기대. 실제 stderr: ${result.stderr}`
+    );
+  } finally {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test('cross-validate (alias #276): GEMINI_RETRY_SLEEP_CAP alias 사용 시 WARN 출력', () => {
+  const { tmpDir } = setupMockAgy('ok');
+  try {
+    const result = runScript(['structure'], {
+      PATH: `${tmpDir}:${process.env.PATH}`,
+      REMINDER_ISSUE_DRYRUN: '1',
+      GEMINI_RETRY_SLEEP_CAP: '100',  // alias (값은 정상 path 라 미사용이지만 WARN 만 트리거)
+    });
+    assert.strictEqual(result.status, 0, `정상 응답 기대. 실제: ${result.status}`);
+    assert.ok(
+      result.stderr.includes('GEMINI_RETRY_SLEEP_CAP') && result.stderr.includes('deprecated'),
+      `#276 — GEMINI_RETRY_SLEEP_CAP deprecated WARN 기대. 실제 stderr: ${result.stderr}`
     );
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/test/cross-validate-fallback.test.js
+++ b/test/cross-validate-fallback.test.js
@@ -440,7 +440,7 @@ test('cross-validate (alias #276): GEMINI_RETRY_SLEEP_CAP alias 사용 시 WARN 
     const result = runScript(['structure'], {
       PATH: `${tmpDir}:${process.env.PATH}`,
       REMINDER_ISSUE_DRYRUN: '1',
-      GEMINI_RETRY_SLEEP_CAP: '100',  // alias (값은 정상 path 라 미사용이지만 WARN 만 트리거)
+      GEMINI_RETRY_SLEEP_CAP: '100',  // alias — 정상 응답 경로라 sleep 호출 자체가 없어 값 결과적 미사용, WARN 만 트리거
     });
     assert.strictEqual(result.status, 0, `정상 응답 기대. 실제: ${result.status}`);
     assert.ok(


### PR DESCRIPTION
## 요약
- PR #279 가 base 브랜치 (feature/269) 자동 삭제로 CLOSED 됨 → cherry-pick + 새 PR (base=develop)
- 변경 내용 동일 (PR #279 의 2 commit cherry-pick): alias WARN + SKILL.md drift fix + 테스트 주석 정정
- PR #279 reviewer approve 이미 완료 (https://github.com/coseo12/harness-setting/pull/279#issuecomment-4506290683)
- **MINOR**

## 변경 사항
- cross_validate.sh: GEMINI_RETRY_SLEEP_SECONDS / CAP alias 사용 시 stderr WARN
- SKILL.md: alias 안내 `(silent)` → `(#276 부터 사용 시 stderr WARN 출력)`
- test/cross-validate-fallback.test.js: alias WARN 검증 2건 추가 + 주석 정정

## Behavior Changes
- `GEMINI_RETRY_SLEEP_SECONDS` / `GEMINI_RETRY_SLEEP_CAP` 환경변수 사용 시 stderr WARN 출력
- 다운스트림 마이그레이션 권고: 1주 이내 `EXTERNAL_VALIDATOR_*` 전환

## 검증
- npm test cross-validate-fallback: 22/22 PASS
- 한글 인코딩 0
- PR #279 reviewer approve 인용

## 관련
- Closes #276 (Phase 4 사전 — alias WARN)
- Tracked in #267 (Antigravity 마이그레이션)
- PR #275 (Phase 1A) cherry-pick base
- 후속: Phase 4 (#272 — alias 자체 제거)

## 메타 체크리스트
- [x] CRITICAL #1 base=develop
- [x] CRITICAL #4 한글 인코딩 0
- [x] CRITICAL #6 Sprint Contract — MINOR 분류 + Behavior Changes 명시
- [x] reviewer approve 인용 (PR #279)