### PR TITLE
chore(release): v4.0.0 — Antigravity 마이그레이션 + 누적 cross-validate 가드 (MAJOR)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,34 @@
 
 ## [Unreleased]
 
+## [4.0.0] — 2026-05-21
+
+v3.7.0 이후 **MAJOR 릴리스** — **Antigravity 마이그레이션** (`gemini-cli` → `agy` 어댑터 교체, 2026-06-18 Gemini CLI 종료 대응) + 누적 cross-validate 가드 (plan-mode 우회 자동 가드, reviewer ADR 호환성 검증, create-pr Strict Assertion, PR 본문 7 체크박스 메타 가드).
+
+MAJOR 분류 사유: **다운스트림 필수 조치 — `agy` (Antigravity CLI) 설치 + OAuth 로그인. `gemini` 명령은 더 이상 호출되지 않음. `GEMINI_MODEL` 환경변수 deprecated (silent 무시 + WARN)**.
+
+**포함 범위** (본 release):
+- Antigravity 마이그레이션 Phase 0~3 + #276 — PR [#273](https://github.com/coseo12/harness-setting/pull/273) (기획/ADR) / [#274](https://github.com/coseo12/harness-setting/pull/274) (.gitignore) / [#275](https://github.com/coseo12/harness-setting/pull/275) (Phase 1A MAJOR) / [#277](https://github.com/coseo12/harness-setting/pull/277) (Phase 2 PATCH) / [#278](https://github.com/coseo12/harness-setting/pull/278) (Phase 3 PATCH) / [#280](https://github.com/coseo12/harness-setting/pull/280) (#276 alias WARN MINOR)
+- cross-validate plan-mode 가드 + reviewer ADR 호환성 + create-pr Strict Assertion + PR 본문 7 체크박스 메타 가드 — PR [#260](https://github.com/coseo12/harness-setting/pull/260) / [#261](https://github.com/coseo12/harness-setting/pull/261) / [#262](https://github.com/coseo12/harness-setting/pull/262) / [#264](https://github.com/coseo12/harness-setting/pull/264)
+- 5 페르소나 create-pr 의무 박제 + 측정 방법 C — PR [#248](https://github.com/coseo12/harness-setting/pull/248) / [#257](https://github.com/coseo12/harness-setting/pull/257)
+- real-lessons 박제 (spawnSync stdin / gitflow base 함정) — PR [#254](https://github.com/coseo12/harness-setting/pull/254)
+- CLAUDE.md 가지치기 (4 블록 lessons 위임) — PR [#263](https://github.com/coseo12/harness-setting/pull/263)
+
+### Behavior Changes (MAJOR — Antigravity 마이그레이션)
+
+- **`cross-validate` 스킬 백엔드 교체: `gemini-cli` → Antigravity `agy`** (이슈 [#267](https://github.com/coseo12/harness-setting/issues/267) 트래킹 / [#269](https://github.com/coseo12/harness-setting/issues/269) Phase 1A / PR [#275](https://github.com/coseo12/harness-setting/pull/275)) — 2026-06-18 Gemini CLI 종료 대응. ADR: [docs/decisions/20260521-gemini-to-antigravity.md](docs/decisions/20260521-gemini-to-antigravity.md). 기획서: [docs/plans/antigravity-migration.md](docs/plans/antigravity-migration.md). 핵심 변경:
+  - `cross_validate.sh` 의 `gemini` 명령 → `agy` 교체. 함수 이름 도구 중립화 (`run_gemini` → `run_external_validator`, `check_gemini_capacity` → `check_external_capacity`)
+  - **capacity 분기 재설계** — agy 는 timeout/error 도 exit 0 반환 (Phase 0 PoC T2 실측) → stderr `^Error: (timed out|rate limit|quota|not logged|unauthorized|forbidden)` 패턴 매칭. exit code 보조 신호
+  - **L1 prompt strict prefix** (`STRICT INSTRUCTION: Do NOT execute any tool...`) 자동 prepend — agy `--print` 모드의 도구 자동 실행 차단 (Phase 0 PoC T10/T11 발견)
+  - **L3 snapshot 가드 (#479) 유지 + 강화** — agy 의 `--approval-mode plan` 등가 옵션 부재로 L1 + L3 이중 보호로 재설계. 동일 보호 효과
+  - `GEMINI_MODEL` 환경변수 **deprecated** — agy 는 모델 선택 옵션 부재 (백엔드 자동). 설정 시 stderr WARN + 무시
+  - `GEMINI_RETRY_SLEEP_SECONDS/CAP` → `EXTERNAL_VALIDATOR_RETRY_SLEEP_SECONDS/CAP` 변수 이름 도구 중립화. **alias 인식 (Phase 4 #272 에서 제거 예정). 사용 시 stderr WARN** (#276 / PR [#280](https://github.com/coseo12/harness-setting/pull/280))
+  - 신규 `EXTERNAL_VALIDATOR_PRINT_TIMEOUT` (기본 300s) — agy `--print-timeout` 값
+  - outcome sentinel `"429-fallback-claude-only"` **유지** (5 agents `parse-cross-validate-outcome.sh` backward-compat. agy 의 timeout/quota 도 본 sentinel 통합)
+  - **다운스트림 필수 조치**: `agy` 설치 (https://antigravity.google/docs/cli-overview) + OAuth 로그인. `gemini` 명령은 더 이상 호출되지 않음
+- **`.claude/agents/architect.md` + `reviewer.md` + `commands/capture-merge.md` cross-validate 호출 안내 도구 중립화** (이슈 [#270](https://github.com/coseo12/harness-setting/issues/270) Phase 2 / PR [#277](https://github.com/coseo12/harness-setting/pull/277)) — "Gemini 1회 교차검증" → "외부 검증 모델 (현재 Antigravity `agy`) 1회 교차검증". 절차 변경 0, 안내 표현만 — 분류 PATCH
+- **6 docs 도구 중립화** (이슈 [#271](https://github.com/coseo12/harness-setting/issues/271) Phase 3 / PR [#278](https://github.com/coseo12/harness-setting/pull/278)) — `CLAUDE.md` §교차검증 + `README.md` + `docs/skills-guide.md` + `docs/security.md` + `docs/deployment-guide.md` + `docs/guides/cross-validate-protocol.md` 현재 안내 본문 도구 중립화. 보존 vs 교체 판정 규칙 적용 — 9 카테고리 (CHANGELOG / ADR / lessons / architecture / knowledge / governance / plan / report-* / scripts) 역사 인용 보존. 분류 PATCH
+
 ### Behavior Changes (MINOR — cross-validate plan-mode 가드 + reviewer ADR 호환성 + create-pr Strict Assertion + PR 본문 7 체크박스 메타 가드 박제)
 
 - **`.claude/skills/cross-validate/scripts/cross_validate.sh` plan-mode 우회 자동 가드** (다운스트림 [astro-simulator#479](https://github.com/coseo12/astro-simulator/issues/479) PR [#482](https://github.com/coseo12/astro-simulator/pull/482) 박제) — Gemini 호출 전/후 워킹트리 snapshot 비교 (porcelain + hash-object 혼합) + 자동 롤백 (tracked = `git checkout --`, untracked = `rm -f`) + outcome JSON 3 신규 필드 (`plan_bypass` / `bypass_files` / `rollback_failed`). `--approval-mode plan` 가드가 무력화돼 Gemini 가 워킹트리에서 무단 파일 수정한 사고 (2026-05-16) 자동 차단

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "3.7.0",
+  "version": "4.0.0",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 요약
- v3.7.0 → **v4.0.0 MAJOR**
- CHANGELOG.md `[Unreleased]` → `[4.0.0] - 2026-05-21` 전환 + Antigravity 마이그레이션 entry 추가
- package.json 3.7.0 → 4.0.0
- release PR 본문은 develop → main 단계에서 추가

## 변경
- CHANGELOG.md: 4.0.0 entry 박제 (Antigravity MAJOR + 누적 MINOR + PATCH)
- package.json: version 4.0.0

## 검증
- [x] verify-release-version-bump: 4.0.0 == 4.0.0
- [x] verify-docs-links / verify-lessons-readme / verify-agent-ssot 통과
- [x] npm test 통과
- [x] 한글 인코딩 0 U+FFFD

## 메타 체크리스트
- [x] CRITICAL #1 base=develop
- [x] CRITICAL #4 한글 인코딩 0
- [x] release 사전 검증 통과