### PR TITLE
chore(release): v4.2.1 — pr-conventions 분리 + CLAUDE.md 5차 가지치기 (PATCH)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,33 @@
 
 ## [Unreleased]
 
+## [4.2.1] — 2026-05-22
+
+v4.2.0 이후 **PATCH 릴리스** — pr-conventions.md 단독 분리 (#290 reviewer 권고 3) + CLAUDE.md 5차 가지치기. **행동 변화 0**.
+
+**포함 범위**: PR [#293](https://github.com/coseo12/harness-setting/pull/293)
+
+### Behavior Changes: None — 문서/문구만
+
+### Added (PATCH)
+
+- **`docs/guides/pr-conventions.md` 신설** (#290 reviewer 권고 3) — `docs/guides/branch-strategy-workflow.md` 의 §커밋 컨벤션 + §PR 규칙 단독 분리. 파일명 가시성 문제 해소 (PR/커밋 규칙이 "브랜치 전략" 키워드에 묻히던 검색 효율 개선)
+- **`docs/guides/branch-strategy-workflow.md`**: §커밋/§PR 제거 + 포인터로 갱신
+- **CLAUDE.md 본문 포인터**: `branch-strategy-workflow.md` → `pr-conventions.md` 로 갱신
+
+### Changed (PATCH — CLAUDE.md 5차 가지치기)
+
+- **CLAUDE.md 본문 32,114 → 31,257 chars** (-857 추가, 누적 v4.0.0 49,860 대비 -18,603 = **37.3% 감축**). 30k 목표까지 약 1.3k 추가 가지치기 권고
+- §workflow_dispatch 함정 양면성 (volt #97) inline 압축 — 720 → 250 chars
+- §주석 계약 숨은 상수 변형 (volt #69) inline 압축 — 480 → 180 chars
+- §다운스트림 harness update 체크리스트 inline 압축 — 4 라인 → 1 라인
+
+### Notes
+
+- 이슈 #266 (CLAUDE.md 가지치기) 진행 중 — 본 release 로 누적 37.3%. 30k 목표 (마진 5k 포함 25~30k) 까지 약 1.3k 추가 가지치기 후속 (별도 세션)
+- PR #290 reviewer 권고 3 완료 (pr-conventions.md 단독 분리)
+- PR #293 reviewer 권고 2 (pr-conventions.md:18 공백 1개 drift) 즉시 수용 (commit ce6e8840)
+
 ## [4.2.0] — 2026-05-21
 
 v4.1.1 이후 **MINOR 릴리스** — PR 템플릿에 `ADR 호환성 체크` prefill 신설 (reviewer.md §절차 5 정합) + CLAUDE.md 4차 가지치기 (35,907 → 32,134 chars).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ AI 에이전트 기반 개발 워크플로우 템플릿. 1인 개발자-AI 페�
 - **feature/fix PR 의 `base=main` 금지** — release/hotfix PR 만 main 대상
 
 ## 커밋 컨벤션 + PR 규칙
-형식 `<type>(<scope>): <description>` (type: feat/fix/refactor/test/docs/chore). PR 제목 `[#이슈번호] 설명`. **multi-issue auto-close keyword 함정** (각 이슈 앞 `Closes` 반복 또는 줄 분리 필수, 콜론·콤마 단일 형태는 #B 미인식) + 머지 직후 `gh issue view` 검증 루틴. 상세: [docs/guides/branch-strategy-workflow.md](docs/guides/branch-strategy-workflow.md). 근거: volt [#41](https://github.com/coseo12/volt/issues/41).
+형식 `<type>(<scope>): <description>` (type: feat/fix/refactor/test/docs/chore). PR 제목 `[#이슈번호] 설명`. **multi-issue auto-close keyword 함정** (각 이슈 앞 `Closes` 반복 또는 줄 분리 필수, 콜론·콤마 단일 형태는 #B 미인식) + 머지 직후 `gh issue view` 검증 루틴. 상세: [docs/guides/pr-conventions.md](docs/guides/pr-conventions.md). 근거: volt [#41](https://github.com/coseo12/volt/issues/41).
 
 ---
 
@@ -111,11 +111,7 @@ UI 작업 4축 평가 (Design Quality 30% / Originality 30% / Craft 20% / Functi
 - 상세: [docs/lessons/ci-and-downstream-verification.md](docs/lessons/ci-and-downstream-verification.md)
 
 ### 다운스트림 harness update 부합성 사전 체크리스트
-`harness update` 이후 다운스트림 CI 에서 발생하는 반복 push-fail-fix 루프를 **사전 진단**으로 방지. 4단계 체크 (모노레포 재귀 호출 / 빌드 산출물 exports / 특수 빌드 도구 / 기존 전용 워크플로) + 4개 옵션 비교 (A 제거 / B shim / C divergent / D upstream 확장). 판정 애매 시 A 추천.
-
-- 상세: [docs/harness-update-compat-checklist.md](docs/harness-update-compat-checklist.md)
-- 근거: volt [#62](https://github.com/coseo12/volt/issues/62) — astro-simulator PR #270 6단계 push-fail-fix 실측 (2026-04-20)
-- 관련 실행 이슈: [harness#190](https://github.com/coseo12/harness-setting/issues/190) — upstream CI 에 pnpm workspace + WASM 스모크 fixture 추가 (volt #64)
+`harness update` 후 다운스트림 CI push-fail-fix 루프 **사전 진단** — 4단계 체크 + 4 옵션 (A 제거 / B shim / C divergent / D upstream 확장, 애매 시 A). 상세: [docs/harness-update-compat-checklist.md](docs/harness-update-compat-checklist.md). 근거: volt [#62](https://github.com/coseo12/volt/issues/62) / [harness#190](https://github.com/coseo12/harness-setting/issues/190).
 
 ### 다운스트림 실측이 최종 가드 — upstream 3중 방어 blindspot
 upstream 의 단위 테스트 / reviewer / cross-validate 3중 방어가 통과해도 다운스트림 환경 매트릭스에서만 드러나는 결함 존재. release 를 막는 대신 **역방향 피드백 속도 최대화**. "N 적용 시나리오" 근거는 `[실측]` / `[가정]` 라벨 부착 + 박제 문턱 (실측 ≥ 1 + 가정 ≥ 3 + 공통 조건 매트릭스) 충족 필수 (#195).
@@ -124,7 +120,7 @@ upstream 의 단위 테스트 / reviewer / cross-validate 3중 방어가 통과�
 ### workflow_dispatch 2단계 함정 (GitHub Actions)
 `workflow_dispatch` 트리거는 default branch 반영 후에만 discover 된다 (feature/develop push 로는 실행 불가). 추가로 PR 자동 생성 workflow 는 저장소 Settings `can_approve_pull_request_reviews` 가 기본 OFF 라 거부된다. 도입 PR DoD 에 "default branch 반영 후 실행 검증" 명시.
 - 상세: [docs/lessons/workflow-dispatch-pitfalls.md](docs/lessons/workflow-dispatch-pitfalls.md)
-- **함정의 양면성 — release 가속 트리거 변형 (volt [#97](https://github.com/coseo12/volt/issues/97))**: 본 함정이 검증 차단 효과로 작용해 사용자에게 "지금 release 할지" 결정을 강제 노출시키는 부산물 관찰. develop 누적 ≥ 50 커밋 시 정공법 (release PR) 비용 < 우회법 (cherry-pick) → 결과적으로 자연 release 리듬 정렬. 단, 모든 검증 차단이 release 가속을 정당화하지 않음 — 누적 < 10 커밋이면 옵션 B (대기) / C (cherry-pick) 가 합리적. 가드 도입 PR DoD 에 A/B/C 결정 분기 표 (비용/시점/gitflow 정합성) 명시 의무 추가 권고. release-cadence-check workflow 신설로 함정 의존 제거 가능.
+- **함정의 양면성 — release 가속 트리거 변형 (volt [#97](https://github.com/coseo12/volt/issues/97))**: 검증 차단이 사용자에게 release 결정 강제 노출하는 부산물 + 자연 리듬 정렬 효과. 단 모든 차단이 정당화 아님 — 누적 < 10 커밋이면 옵션 B (대기) / C (cherry-pick) 합리. release-cadence-check workflow 신설로 함정 의존 제거 가능.
 
 ### gh CLI 마크다운 본문 발송 — execSync shell metachar 함정 (volt #114)
 Node.js `execSync('gh pr comment N --body "..."')` 로 백틱/`$`/`!`/`;` 포함 본문 발송 시 shell 이 명령 치환·변수 확장으로 해석 → silent syntax error. **`spawnSync('gh', [...args])` + `--body-file -` + `{ input: body, stdio: ['pipe', 'inherit', 'inherit'] }` 3축 우회** 의무. 상세: [docs/lessons/gh-cli-execsync-pitfall.md](docs/lessons/gh-cli-execsync-pitfall.md).
@@ -132,7 +128,7 @@ Node.js `execSync('gh pr comment N --body "..."')` 로 백틱/`$`/`!`/`;` 포함
 ### 주석 계약 vs 구현 drift — 버그 생성원
 파일 상단 주석 / JSDoc 이 선언한 계약과 구현의 drift 는 **버그 생성원**. default fallback 이 누락을 조용히 흡수해 테스트도 fail 하지 않는다. 주석에 선언된 규칙은 테스트 커버리지 대상이며, enum 분기 fallback 에 경고·assert 추가로 drift 감지.
 - 상세: [docs/lessons/comment-implementation-drift.md](docs/lessons/comment-implementation-drift.md)
-- **숨은 상수 변형 (volt [#69](https://github.com/coseo12/volt/issues/69))**: 모듈 A 에서 상수 폐기 + 동적 함수 교체해도 위성 모듈 B/C/D 의 독립 선언이 잔존하면 상대 비율/단위/스케일 drift 를 조용히 생성. 주 모듈 grep 만으로는 누락 — reviewer 파괴적 리팩토링 체크리스트 (저장소 전체 `grep -rn "<CONST_NAME>"` + 주석 SSoT 참조 dead reference) 로 차단. 원천: `.claude/agents/reviewer.md` §4.
+- **숨은 상수 변형 (volt [#69](https://github.com/coseo12/volt/issues/69))**: 위성 모듈 독립 선언 잔존 → 상대 비율/단위/스케일 drift 조용히 생성. 저장소 전체 `grep -rn "<CONST_NAME>"` + 주석 SSoT 참조 dead reference 차단 의무 (reviewer.md §4).
 
 ### HTTP 200 ≠ 올바른 리소스
 - 이미지 URL이 200을 반환해도 **내용이 의도와 다를 수 있다**

--- a/docs/guides/branch-strategy-workflow.md
+++ b/docs/guides/branch-strategy-workflow.md
@@ -54,28 +54,13 @@ develop   ← 동기화 유지 (누락 시 drift)
   - develop 이 main 의 조상이 아닌 채 `main > develop` — hotfix merge-back 누락 또는 release PR 을 실수로 `--squash` 로 머지한 가능성. `git show main --format=%P | wc -w` 로 merge commit 여부 확인 (2 이면 merge commit, 1 이면 squash)
   - `git rev-list` 실패 (unrelated histories 등) — `git merge-base origin/main origin/develop` 로 공통 조상 확인
 
-## 커밋 컨벤션
+## 커밋 컨벤션 / PR 규칙
 
-```
-<type>(<scope>): <description>
-```
-- type: feat, fix, refactor, test, docs, chore
-- scope: 변경 대상 모듈/컴포넌트
-
-## PR 규칙
-
-- PR 제목에 이슈 번호 포함: `[#이슈번호] 설명`
-- PR 본문에 변경 사항, 테스트 계획, 영향 범위 명시
-- **여러 이슈 auto-close 시 각 이슈마다 keyword 반복 또는 줄 분리** — GitHub 은 각 이슈 바로 앞 단어에 closing keyword (`close[s|d]` / `fix[es|ed]` / `resolve[s|d]`) 가 있어야 인식한다. 잘못된 문법은 **조용히 누락**되어 이슈가 OPEN 으로 잔존.
-  - **단일 원리**: GitHub 은 **각 이슈 번호 직전에 closing keyword 가 토큰으로 인접해야** 인식한다. 콜론/콤마/공백 등으로 keyword 와 번호 사이를 끊거나 두 번째 번호 앞에 keyword 가 없으면 모두 **동일한 결함** (두 번째 이슈 앞 keyword 부재) 으로 수렴해 #B 미인식.
-  - ✅ `Closes #A, closes #B` — 각 이슈에 keyword 반복
-  - ✅ 줄 분리 — `Closes #A\nCloses #B`
-  - ❌ `Closes: #A, #B` / `Closes #A, #B` / `Closes #A #B` — 모두 #B 앞 keyword 부재 (콜론·콤마·공백은 동일 결함의 표면 변형)
-- **머지 직후 auto-close 검증 루틴** — release/feature PR 머지 후 close 대상 이슈 전부에 `gh issue view <n> --json state` 로 실제 close 여부를 확인. default branch (main) 머지가 아닌 경우 (feature PR → develop) 는 릴리스 시점까지 OPEN 유지가 정상
-- 근거: volt [#41](https://github.com/coseo12/volt/issues/41) — harness PR [#108](https://github.com/coseo12/harness-setting/pull/108) (v2.14.0) 커밋 메시지 `Closes: #105, #110` 에서 #105 만 auto-close 되고 #110 은 수동 close 필요했던 실측 사례
+PR #290 reviewer 권고 3 (PR #293) 부터 단독 분리. 상세: [docs/guides/pr-conventions.md](pr-conventions.md).
 
 ## 관련
 
+- [docs/guides/pr-conventions.md](pr-conventions.md) — 커밋 컨벤션 + PR 규칙 (closing keyword 함정 + 머지 후 검증 루틴)
 - [docs/decisions/20260419-gitflow-main-develop.md](../decisions/20260419-gitflow-main-develop.md) — gitflow 복원 ADR (v2.13.0)
 - [docs/decisions/20260419-release-merge-strategy.md](../decisions/20260419-release-merge-strategy.md) — release PR `--merge` 의무 ADR
 - [docs/deployment-patterns.md](../deployment-patterns.md) — PaaS 자동 배포 vs 수동 tag 비교

--- a/docs/guides/pr-conventions.md
+++ b/docs/guides/pr-conventions.md
@@ -1,0 +1,29 @@
+# PR / 커밋 컨벤션
+
+> PR #290 reviewer 권고 3 (PR #293) — `docs/guides/branch-strategy-workflow.md` 의 §커밋 컨벤션 + §PR 규칙 단독 분리 (파일명 중심 검색 시 PR/커밋 규칙이 "브랜치 전략" 키워드에 묻히는 가시성 문제 해소).
+
+## 커밋 컨벤션
+
+```
+<type>(<scope>): <description>
+```
+
+- type: feat, fix, refactor, test, docs, chore
+- scope: 변경 대상 모듈/컴포넌트
+
+## PR 규칙
+
+- PR 제목에 이슈 번호 포함: `[#이슈번호] 설명`
+- PR 본문에 변경 사항, 테스트 계획, 영향 범위 명시
+- **여러 이슈 auto-close 시 각 이슈마다 keyword 반복 또는 줄 분리** — GitHub 은 각 이슈 바로 앞 단어에 closing keyword (`close[s|d]` / `fix[es|ed]` / `resolve[s|d]`) 가 있어야 인식한다. 잘못된 문법은 **조용히 누락**되어 이슈가 OPEN 으로 잔존.
+  - **단일 원리**: GitHub 은 **각 이슈 번호 직전에 closing keyword 가 토큰으로 인접해야** 인식한다. 콜론/콤마/공백 등으로 keyword 와 번호 사이를 끊거나 두 번째 번호 앞에 keyword 가 없으면 모두 **동일한 결함** (두 번째 이슈 앞 keyword 부재) 으로 수렴해 #B 미인식.
+  - ✅ `Closes #A, closes #B` — 각 이슈에 keyword 반복
+  - ✅ 줄 분리 — `Closes #A\nCloses #B`
+  - ❌ `Closes: #A, #B` / `Closes #A, #B` / `Closes #A #B` — 모두 #B 앞 keyword 부재 (콜론·콤마·공백은 동일 결함의 표면 변형)
+- **머지 직후 auto-close 검증 루틴** — release/feature PR 머지 후 close 대상 이슈 전부에 `gh issue view <n> --json state` 로 실제 close 여부를 확인. default branch (main) 머지가 아닌 경우 (feature PR → develop) 는 릴리스 시점까지 OPEN 유지가 정상
+- 근거: volt [#41](https://github.com/coseo12/volt/issues/41) — harness PR [#108](https://github.com/coseo12/harness-setting/pull/108) (v2.14.0) 커밋 메시지 `Closes: #105, #110` 에서 #105 만 auto-close 되고 #110 은 수동 close 필요했던 실측 사례
+
+## 관련
+
+- [docs/guides/branch-strategy-workflow.md](branch-strategy-workflow.md) — gitflow 워크플로 3단계 + drift 감지
+- [.github/PULL_REQUEST_TEMPLATE.md](../../.github/PULL_REQUEST_TEMPLATE.md) — PR 본문 7 체크박스 + ADR 호환성 체크 prefill

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@seo/harness-setting",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "Claude Code 워크플로우 템플릿 — 1인 개발자-AI 페어 프로그래밍 최적화",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## 🚀 Release v4.2.1 — PATCH (행동 변화 0)

v4.2.0 직후 PATCH. pr-conventions.md 단독 분리 (#290 권고 3) + CLAUDE.md 5차 가지치기.

### 포함 (PR #293)
- pr-conventions.md 신설 (branch-strategy-workflow.md 에서 §커밋/§PR 분리)
- CLAUDE.md 32,114 → **31,257 chars** (누적 -18,603 = **37.3% 감축**)

### Behavior Changes: None — 문서/문구만

### 검증
- [x] verify-release-version-bump: 4.2.1 == 4.2.1
- [x] verify-* 4종 통과
- [x] PR #293 reviewer approve

### 머지 절차
- [x] release PR `--merge` (merge commit)
- [ ] `git push origin main:develop` (fast-forward)
- [ ] `git tag v4.2.1` + `gh release create v4.2.1` (이전 v4.2.0 502 학습 — release PR 머지 확실 후만 tag)

### 관련
- Refs #266 (CLAUDE.md 가지치기 누적 37.3%)
- Implements #290 reviewer 권고 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)