### PR TITLE
chore(persona): qa/developer 산출물 처분 의무 박제 — 다운스트림 astro-simulator#793 동기화 (MINOR)

### DIFF
--- a/.claude/agents/developer.md
+++ b/.claude/agents/developer.md
@@ -48,6 +48,7 @@ description: "풀스택 구현 (프론트엔드 + 백엔드)"
     - `auto_close_issue_states` — PR 본문/커밋 메시지의 `Closes #N` 키워드 대상 이슈의 **현재 state** 를 PR 생성 후 (머지 전) `gh issue view <N> --json state` 로 기록. developer 는 머지 주체가 아니므로 보통 `"OPEN"` 이 정상. 실제 close 성공 검증은 메인 오케스트레이터 책임
     - `labels_applied_or_transitioned` — developer 는 보통 빈 배열. 라벨 전이는 reviewer / qa 영역
     - `spawned_bg_pids` / `bg_process_handoff` — 구현 중 dev 서버 / 테스트 러너 / 장시간 빌드를 `run_in_background` 로 띄웠으면 반환 전 **완주/kill 확인 후** `spawned_bg_pids: []` + `bg_process_handoff: "sub-agent-confirmed-done"`. 완주 확인 못 하고 반환하면 살아있는 PID 배열 + `"main-cleanup"` (메인이 `ps`/`lsof` 로 독립 확인). 띄운 적 없으면 `[]` + `"none"`. volt #46/#52 — stale dev 서버 포트 점유 / cargo 좀비 4개 누적 방지
+    - **산출물 처분** (다운스트림 가드 — astro-simulator #793) — 반환 직전 의무: `git status --porcelain` 로 자신이 생성한 untracked 산출물 (verify/debug 스크립트, 스크린샷, 스크래치 로그) 을 확인하고 프로젝트 산출물 수명주기 규약 (있는 경우 — 예: `docs/decisions/` 의 artifact-lifecycle ADR) 에 따라 처분한다: 커밋 대상 (verify 스크립트, 문서 embed 참조 자료) 은 커밋, 나머지는 rm (`_debug-*-tmp.mjs` 는 즉시 rm — volt #67). 처분하지 못한 잔존물은 `non_blocking_suggestions` 에 경로 목록으로 박제해 메인에 인계한다
 
 ### 측정 방법 C (혼합) — DoD #2 가시성 검증
 

--- a/.claude/agents/qa.md
+++ b/.claude/agents/qa.md
@@ -117,6 +117,7 @@ sub-agent 종료 전 반드시 아래 JSON을 반환한다. **공통 코어 필�
 - `commit_sha` — QA 는 커밋 생성하지 않으므로 보통 `null`. qa 가 추가 fix 커밋을 허용받은 경우에만 채움
 - `auto_close_issue_states` — QA 도 머지 주체가 아니므로 기본 `{}`. 단, PR 본문/커밋 메시지의 `Closes #N` **keyword 문법** 을 정적 점검하여 잘못된 문법(`Closes: #A, #B` 콜론 / `Closes #A, #B` 콤마만 / `Closes #A #B` 공백만) 을 발견하면 `non_blocking_suggestions` 에 "closing keyword 문법 오류 — #B 미인식 위험" 경고 추가 (메인 오케스트레이터는 머지 직후 실제 state 를 직접 확인)
 - `spawned_bg_pids` / `bg_process_handoff` — QA 가 dev 서버 / 테스트 러너를 `run_in_background` 로 띄웠으면 반환 전 **완주/kill 확인 후** `spawned_bg_pids: []` + `bg_process_handoff: "sub-agent-confirmed-done"` 로 기록. 완주 확인 못 하고 반환하면 살아있는 PID 배열 + `"main-cleanup"`. dev 서버를 띄우지 않았으면 `[]` + `"none"`. volt #46/#52 — stale 서버 / cargo 좀비 누적 방지
+- **산출물 처분** (다운스트림 가드 — astro-simulator #793) — 반환 직전 의무: `git status --porcelain` 로 자신이 생성한 untracked 산출물 (스크린샷 / 리포트 / 임시 스크립트 / 스크래치 로그) 을 확인하고 프로젝트 산출물 수명주기 규약 (있는 경우 — 예: `docs/decisions/` 의 artifact-lifecycle ADR) 에 따라 처분한다: 커밋 대상 (verify 스크립트, 문서 embed 참조 자료) 은 커밋, 나머지는 rm (`_debug-*-tmp.mjs` 는 즉시 rm — volt #67). 처분하지 못한 잔존물은 `non_blocking_suggestions` 에 경로 목록으로 박제해 메인에 인계한다 — 미인계 잔존물은 세션 경계에서 "커밋 기준 비일관 + untracked 누적" 부채가 된다
 
 ## 자가 점검
 


### PR DESCRIPTION
## 변경 사항

qa.md / developer.md 마무리 체크리스트에 **산출물 처분 (반환 직전 의무)** bullet 을 추가한다 (`spawned_bg_pids` bullet 직후 — 동일한 "반환 직전 의무" 계열):

- `git status --porcelain` 카나리아로 sub-agent 자신이 생성한 untracked 산출물 (verify/debug 스크립트, 스크린샷, 리포트, 스크래치 로그) 확인
- 프로젝트 산출물 수명주기 규약 (있는 경우 — `docs/decisions/` 의 artifact-lifecycle ADR) 에 따라 처분: 커밋 대상 (verify 스크립트 / 문서 embed 참조 자료) 커밋, 나머지 rm, `_debug-*-tmp.mjs` 는 즉시 rm (volt #67)
- 처분 불가 잔존물은 `non_blocking_suggestions` 에 경로 목록으로 박제 → 메인 인계

## 배경 (다운스트림 실측 — Z-패턴 Phase 2)

astro-simulator 2026-07-04 프로젝트 회고에서 qa/dev 산출물 **커밋 기준이 세션마다 상이** (한 세션은 verify 커밋, 다음 세션은 미커밋) 하여 워크스페이스에 **untracked 21건 (~20MB) 누적** + `_debug-*-tmp.mjs` volt #67 규약 위반 잔존이 실측됐다. `spawned_bg_pids` 가 프로세스 리크를 막는 것과 동형으로, 본 bullet 은 **파일 산출물 리크**를 반환 시점에 차단한다.

- 다운스트림 이슈: [astro-simulator#793](https://github.com/coseo12/astro-simulator/issues/793) (처분 규약 ADR + 일괄 정리 + 본 upstream 동기화)
- 다운스트림 선반영 (Z-패턴 Phase 1): astro-simulator feature/793-artifact-lifecycle — 동일 bullet + `HARNESS-DRIFT: Z-PATTERN` 데코레이터 박제

## SemVer

**MINOR** — 에이전트 지시어 행동 변화 (qa/dev 가 반환 직전 산출물 처분을 수행/보고하도록 변경).

## 테스트 계획 (Test plan)

- [x] U+FFFD 인코딩 0건 (신규 삽입 라인)
- [x] 삽입 위치 앵커 검증 — 양 파일 `spawned_bg_pids` bullet 직후, 기존 리스트 구조/들여쓰기 보존 (qa.md top-level `- ` / developer.md nested `    - `)
- [x] 다운스트림 (astro-simulator) 에서 동일 텍스트로 `verify-agent-ssot.sh` 45/45 PASS 확인 (JSON 스키마 무변경 — bullet 설명만 추가)


ADR 20260515 Phase 2 — astro-simulator Z 패턴 upstream 기여 (harness-managed divergent)