### PR TITLE
[astro-simulator#854] fix(skills): stage:* 라벨 일원화 skills 계층 전파 — 폐기 status:*/agent:*/size:* 제거

### DIFF
--- a/.claude/commands/capture-merge.md
+++ b/.claude/commands/capture-merge.md
@@ -31,7 +31,7 @@ Gemini의 "마찰 없는 자동화" 통찰을 1단계 적용 (역사적 인용 �
    ```
    결과 있으면 사용자에게 보고 + 새 캡처할지 묻기.
 
-4. **분류 자동 판정** (1차: `type:*` 라벨, 2차: PR 제목 conventional prefix — `feat(`/`fix(`/`docs(`/`chore(`/`refactor(`):
+4. **분류 자동 판정** (1차: `type:*` 라벨, 2차: PR 제목 conventional prefix — `feat`/`fix`/`docs`/`chore`/`refactor`, scope 괄호 유무 무관 `feat:`·`feat(scope):` 모두 매칭):
    - `type:feat` / `enhancement` 라벨 또는 제목 `feat` → report/pattern 또는 knowledge (재사용성 높으면)
    - `bug` 라벨 또는 제목 `fix` → report/troubleshooting
    - `type:docs` / `type:chore` 라벨 또는 제목 `docs`/`chore` → 캡처 가치 낮음, 사용자에게 "스킵 권장" 안내

--- a/.claude/commands/capture-merge.md
+++ b/.claude/commands/capture-merge.md
@@ -31,11 +31,11 @@ Gemini의 "마찰 없는 자동화" 통찰을 1단계 적용 (역사적 인용 �
    ```
    결과 있으면 사용자에게 보고 + 새 캡처할지 묻기.
 
-4. **분류 자동 판정**:
-   - PR 라벨에 `feat:`, `feature` → report/pattern 또는 knowledge (재사용성 높으면)
-   - `fix:`, `bug` → report/troubleshooting
-   - `docs:`, `chore:` → 캡처 가치 낮음, 사용자에게 "스킵 권장" 안내
-   - `refactor:` → 변경량/영향 따라 report/retrospective
+4. **분류 자동 판정** (1차: `type:*` 라벨, 2차: PR 제목 conventional prefix — `feat(`/`fix(`/`docs(`/`chore(`/`refactor(`):
+   - `type:feat` / `enhancement` 라벨 또는 제목 `feat` → report/pattern 또는 knowledge (재사용성 높으면)
+   - `bug` 라벨 또는 제목 `fix` → report/troubleshooting
+   - `type:docs` / `type:chore` 라벨 또는 제목 `docs`/`chore` → 캡처 가치 낮음, 사용자에게 "스킵 권장" 안내
+   - 제목 `refactor` → 변경량/영향 따라 report/retrospective
    - 기본 폴백: report/research
 
 5. **본문 자동 초안 생성** (capture-volt 스킬의 템플릿 사용):

--- a/.claude/skills/browser-test/SKILL.md
+++ b/.claude/skills/browser-test/SKILL.md
@@ -220,7 +220,7 @@ agent-browser get html "#result"
 
 headless 환경(특히 `--use-webgpu-adapter=swiftshader` 류 software adapter)은 3D/WebGPU/카메라 조작 경로에서 **부분 freeze** 가 발생한다. 한 pipeline 은 성공하고 다른 pipeline 은 실패하는 **부분 성공** 케이스를 coarse assertion 만으로 "채택" 판정하면 실 Chrome 에서 렌더 실패가 뒤늦게 드러난다. 아래 체크리스트는 시각 효과(3D/WebGPU/camera/shader-bound) 를 포함하는 작업에 **필수**다.
 
-**체크리스트 (`status:review` 전이 전 모두 통과):**
+**체크리스트 (`stage:review` 전이 전 모두 통과):**
 
 1. **headless 기본 검증** — 비검정 canvas / fps 유지 / WebGPU adapter 초기화 성공 / 콘솔 에러 없음
 2. **도메인 특화 pixel 검증** — 기대되는 시각 요소별 픽셀/색상 존재 assertion
@@ -237,7 +237,7 @@ headless 환경(특히 `--use-webgpu-adapter=swiftshader` 류 software adapter)�
    ```
 4. **실 Chrome GUI 수동 검증 (필수, 최소 1회)** — 위 자동 검증이 전부 PASS 여도 실 Chrome 에서 육안 확인. headless 단독 신뢰 금지
    - 확인 항목: 모든 시각 요소가 의도한 대로 렌더되는지, 카메라 회전/줌/팬 모두 즉시 반응하는지
-   - 누락 시 `status:review` 전이 차단. 문서화: PR 코멘트에 "실 Chrome 검증 완료 (스크린샷)" 명시
+   - 누락 시 `stage:review` 전이 차단. 문서화: PR 코멘트에 "실 Chrome 검증 완료 (스크린샷)" 명시
 5. **부분 성공 보존** — 한 pipeline 만 성공한 경우 `?feature=1` 류 옵트인 경로로 보존하고 ADR 에 "향후 디버깅 자산" 명시. 자동 폐기 금지
 
 **headless "8/8 PASS" false positive 패턴**:

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -56,7 +56,7 @@ gh issue create \
 - 선행: 없음
 EOF
 )" \
-  --label "agent:developer,priority:medium,status:todo,size:m,type:feature"
+  --label "stage:planning,priority:medium,type:feat"
 
 # 의존성 연결
 gh issue comment <이슈번호> --body "의존성: #<선행이슈번호> 완료 후 착수"
@@ -64,18 +64,18 @@ gh issue comment <이슈번호> --body "의존성: #<선행이슈번호> 완료 
 
 ## 라벨 가이드
 
+`stage:*` 일원화 체계 (harness #127). 라벨 목록이 의심되면 `gh label list` 로 실측 후 사용한다.
+
 | 카테고리 | 값 | 설명 |
 |----------|-----|------|
-| **에이전트** | `agent:planner` `agent:pm` `agent:architect` `agent:developer` `agent:frontend-developer` `agent:backend-developer` `agent:reviewer` `agent:qa` `agent:auditor` `agent:integrator` `agent:skill-creator` `agent:cross-validator` `agent:releaser` | 담당 에이전트 |
-| **범위** | `scope:frontend` `scope:backend` `scope:fullstack` | FE/BE 구분 |
-| **우선순위** | `priority:critical` `priority:high` `priority:medium` `priority:low` | 처리 긴급도 |
-| **크기** | `size:s` `size:m` `size:l` `size:xl` | s=1-2h, m=반나절, l=1일, xl=2일+ |
-| **타입** | `type:feature` `type:bug` `type:refactor` `type:infra` | 작업 분류 |
-| **상태** | `status:todo` `status:in-progress` `status:review` `status:audit-passed` `status:qa` `status:qa-passed` `status:done` `status:blocked` | 진행 상태 |
+| **단계** | `stage:planning` `stage:design` `stage:dev` `stage:review` `stage:qa` `stage:done` | 파이프라인 단계 (pm→architect→developer→reviewer→qa→완료). 신규 이슈는 보통 `stage:planning` 또는 무단계 |
+| **우선순위** | `priority:high` `priority:medium` `priority:low` | 처리 긴급도 |
+| **타입** | `type:feat` `type:infra` `type:chore` `type:docs` `type:test` | 작업 분류 (커밋 컨벤션 type 정합. 버그 수정은 `type:feat` 또는 해당 타입 + `bug` 보조 라벨) |
+| **보조** | `bug` `documentation` `enhancement` | GitHub 기본 라벨 — 타입 보강용 |
 
 ## 규칙
 
 - 하나의 이슈는 하나의 책임만 가진다. 너무 크면 분해한다.
-- 모든 이슈에 최소 에이전트, 우선순위, 상태, 타입 라벨을 할당한다.
+- 모든 이슈에 최소 타입 + 우선순위 라벨을 할당한다 (단계 라벨은 파이프라인 진입 시).
 - 의존성이 순환하지 않도록 한다.
 - 완료 조건은 검증 가능한 형태로 작성한다 ("~를 구현한다" X → "~가 동작한다" O).

--- a/.claude/skills/create-issue/SKILL.md
+++ b/.claude/skills/create-issue/SKILL.md
@@ -70,7 +70,7 @@ gh issue comment <이슈번호> --body "의존성: #<선행이슈번호> 완료 
 |----------|-----|------|
 | **단계** | `stage:planning` `stage:design` `stage:dev` `stage:review` `stage:qa` `stage:done` | 파이프라인 단계 (pm→architect→developer→reviewer→qa→완료). 신규 이슈는 보통 `stage:planning` 또는 무단계 |
 | **우선순위** | `priority:high` `priority:medium` `priority:low` | 처리 긴급도 |
-| **타입** | `type:feat` `type:infra` `type:chore` `type:docs` `type:test` | 작업 분류 (커밋 컨벤션 type 정합. 버그 수정은 `type:feat` 또는 해당 타입 + `bug` 보조 라벨) |
+| **타입** | `type:feat` `type:infra` `type:chore` `type:docs` `type:test` | 작업 분류 (커밋 컨벤션 type 정합. 버그 수정 이슈는 해당 작업 타입 라벨에 `bug` 보조 라벨을 병행 부착) |
 | **보조** | `bug` `documentation` `enhancement` | GitHub 기본 라벨 — 타입 보강용 |
 
 ## 규칙

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -73,7 +73,7 @@ gh pr create \
 Closes #이슈번호
 EOF
 )" \
-  --label "status:review"
+  --label "stage:review"
 ```
 
 ## Strict Assertion 동적 읽기 (drift 0 가드)
@@ -133,9 +133,11 @@ gh pr view <PR> --json body --jq .body | grep -c -i "<핵심 키워드>"
 
 ## 라벨 업데이트
 
+**PR 의 `stage:review` 부착 주체는 본 스킬이다** — PR 생성 시 `--label "stage:review"` 를 포함해 reviewer 디스패치 사슬 (reviewer 는 `stage:review` 제거로 시작) 을 연결한다.
+
 ```bash
-# 이슈 상태 전환: in-progress → review
-gh issue edit <이슈번호> --remove-label "status:in-progress" --add-label "status:review"
+# 연결 이슈 단계 전환: dev → review (stage:* 일원화 체계, harness #127)
+gh issue edit <이슈번호> --remove-label "stage:dev" --add-label "stage:review"
 ```
 
 ## Stack PR (base ≠ main/develop) 주의 (volt #17)

--- a/.claude/skills/cross-validate/scripts/cross_validate.sh
+++ b/.claude/skills/cross-validate/scripts/cross_validate.sh
@@ -403,7 +403,7 @@ BODY
   if [ "${REMINDER_ISSUE_DRYRUN:-1}" = "0" ]; then
     log "reminder 이슈 생성 (실제)"
     # gh issue create 의 성공/실패를 실측해 REMINDER_ISSUE_RESULT 에 반영 (reviewer 차단 반영)
-    if gh issue create --title "${title}" --body "${body}" --label "enhancement" 2>&1 | tee -a "${LOG_FILE}"; then
+    if gh issue create --title "${title}" --body "${body}" --label "documentation,priority:high" 2>&1 | tee -a "${LOG_FILE}"; then
       REMINDER_ISSUE_RESULT="created"
     else
       REMINDER_ISSUE_RESULT="create-failed"

--- a/.claude/skills/record-adr/SKILL.md
+++ b/.claude/skills/record-adr/SKILL.md
@@ -187,7 +187,7 @@ ADR §재검토 조건이 발화하면 (자동 탐지 workflow 또는 수동 인
 
 ### Trigger 이슈 표준 구조
 
-이슈 제목 prefix: `[ADR Trigger]`. 라벨: `type:adr-trigger` 또는 `documentation` + `priority:high`.
+이슈 제목 prefix: `[ADR Trigger]`. 라벨: `documentation` + `priority:high` (실측 라벨만 사용 — 의심 시 `gh label list`).
 
 본문 4섹션:
 


### PR DESCRIPTION
## 변경 사항

harness-setting#319 §1 해소 — agents/commands 는 #127 stage:* 일원화가 완료됐으나 **skills 계층만 폐기 라벨 체계 잔존**. 다운스트림 실측 결함 (astro-simulator PR #839 에 `status:review`+`stage:review` 이중 부착) 기반.

- **create-issue**: 라벨 가이드 표 전면 재작성 — `agent:*` 13종/`status:todo~blocked`/`size:*`/`scope:*`/`type:feature` (전부 라벨셋에 미존재) → `stage:*` 6종 + `type:feat/infra/chore/docs/test` + `priority:*` 3종 + 보조(bug/documentation/enhancement) 실측 체계. 규칙 문구 재정의 + "의심 시 gh label list 실측" 가드 추가
- **create-pr**: `status:review` → `stage:review` 2곳 + **stage:review 부착 주체를 본 스킬로 명시** (기존엔 부착 주체가 어느 파일에도 없어 reviewer 디스패치 사슬 단절)
- **browser-test**: 전이 게이트 `status:review` → `stage:review` 2곳
- **record-adr**: 미존재 `type:adr-trigger` 제거
- **cross_validate.sh**: reminder 이슈 라벨 `enhancement` → `documentation,priority:high` (enhancement 미보유 다운스트림에서 실모드 생성 실패 방지)
- **capture-merge**: 분류 판정 키 `feat:`/`fix:` 콜론 접두 유령 라벨 → `type:*` 라벨 1차 + PR 제목 conventional prefix 2차

## Test plan

- [x] 참조 라벨 전수가 stage:* 표준 셋 + GitHub 기본 라벨로만 구성 (다운스트림 astro-simulator 라벨셋 대조 완료)
- [x] 다운스트림 Z 패턴 Phase 1 선반영 (동일 변경 + HARNESS-DRIFT 데코레이터) — drift 가드 11/11 PASS

## 관련

- 결함 보고: #319 §1
- 다운스트림 추적: coseo12/astro-simulator#854 (Phase 1 선반영 PR 후속 생성)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


ADR 20260515 Phase 2 — astro-simulator Z 패턴 upstream 기여 (harness-managed divergent)